### PR TITLE
Festo update.

### DIFF
--- a/database-seeds/collections/charts-jubeat.json
+++ b/database-seeds/collections/charts-jubeat.json
@@ -101654,7 +101654,8 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101672,7 +101673,8 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101690,7 +101692,8 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101708,7 +101711,8 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101726,7 +101730,8 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101744,7 +101749,8 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101762,7 +101768,8 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101780,7 +101787,8 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101798,7 +101806,8 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101816,7 +101825,8 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101834,7 +101844,8 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101852,7 +101863,8 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101870,7 +101882,8 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101888,7 +101901,8 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101906,7 +101920,8 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101924,7 +101939,8 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101942,7 +101958,8 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101960,7 +101977,8 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101978,7 +101996,8 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -101996,7 +102015,8 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102014,7 +102034,8 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102032,7 +102053,8 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102050,7 +102072,8 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102068,7 +102091,8 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102086,7 +102110,8 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102104,7 +102129,8 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102122,7 +102148,8 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102140,7 +102167,8 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102158,7 +102186,8 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102176,7 +102205,8 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102194,7 +102224,8 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102212,7 +102243,8 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102230,7 +102262,8 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102248,7 +102281,8 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102266,7 +102300,8 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102284,7 +102319,8 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102302,7 +102338,8 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102320,7 +102357,8 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102338,7 +102376,8 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102356,7 +102395,8 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102374,7 +102414,8 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102392,7 +102433,8 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102410,7 +102452,8 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102428,7 +102471,8 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102446,7 +102490,8 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102464,7 +102509,8 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102482,7 +102528,8 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102500,7 +102547,8 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102734,7 +102782,8 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102752,7 +102801,8 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102770,7 +102820,8 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102788,7 +102839,8 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102806,7 +102858,8 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102824,7 +102877,8 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102842,7 +102896,8 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102860,7 +102915,8 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102878,7 +102934,8 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102896,7 +102953,8 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102914,7 +102972,8 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102932,7 +102991,8 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102950,7 +103010,8 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102968,7 +103029,8 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -102986,7 +103048,8 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103004,7 +103067,8 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103022,7 +103086,8 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103040,7 +103105,8 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103058,7 +103124,8 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103076,7 +103143,8 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103094,7 +103162,8 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103112,7 +103181,8 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103130,7 +103200,8 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103148,7 +103219,8 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103166,7 +103238,8 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103184,7 +103257,8 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103202,7 +103276,8 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103220,7 +103295,8 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103238,7 +103314,8 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103256,7 +103333,8 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103274,7 +103352,8 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103292,7 +103371,8 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103310,7 +103390,8 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103328,7 +103409,8 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103346,7 +103428,8 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103364,7 +103447,8 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103382,7 +103466,8 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103400,7 +103485,8 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103418,7 +103504,8 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103436,7 +103523,8 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103454,7 +103542,8 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103472,7 +103561,8 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103490,7 +103580,8 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103508,7 +103599,8 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103526,7 +103618,8 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103544,7 +103637,8 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103562,7 +103656,8 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103580,7 +103675,8 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103598,7 +103694,8 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103616,7 +103713,8 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103634,7 +103732,8 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103652,7 +103751,8 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103670,7 +103770,8 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103688,7 +103789,8 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103706,7 +103808,8 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103724,7 +103827,8 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103742,7 +103846,8 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103760,7 +103865,8 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103778,7 +103884,8 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103796,7 +103903,8 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103814,7 +103922,8 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103832,7 +103941,8 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103850,7 +103960,8 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103868,7 +103979,8 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103886,7 +103998,8 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103904,7 +104017,8 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103922,7 +104036,8 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103940,7 +104055,8 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103958,7 +104074,8 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103976,7 +104093,8 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -103994,7 +104112,8 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104012,7 +104131,8 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104030,7 +104150,8 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104048,7 +104169,8 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104066,7 +104188,8 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104084,7 +104207,8 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104102,7 +104226,8 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104120,7 +104245,8 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104138,7 +104264,8 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104156,7 +104283,8 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104174,7 +104302,8 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104192,7 +104321,8 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104210,7 +104340,8 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104228,7 +104359,8 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104246,7 +104378,8 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104264,7 +104397,8 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104282,7 +104416,8 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104300,7 +104435,8 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104318,7 +104454,8 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104336,7 +104473,8 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104354,7 +104492,8 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104372,7 +104511,8 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104390,7 +104530,8 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104408,7 +104549,8 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104426,7 +104568,8 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104444,7 +104587,8 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104462,7 +104606,8 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104480,7 +104625,8 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104498,7 +104644,8 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104516,7 +104663,8 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104534,7 +104682,8 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104552,7 +104701,8 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104570,7 +104720,8 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104588,7 +104739,8 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104606,7 +104758,8 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104624,7 +104777,8 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104642,7 +104796,8 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104660,7 +104815,8 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104678,7 +104834,8 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104696,7 +104853,8 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104714,7 +104872,8 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104732,7 +104891,8 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104750,7 +104910,8 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104768,7 +104929,8 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104786,7 +104948,8 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104804,7 +104967,8 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104822,7 +104986,8 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104840,7 +105005,8 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104858,7 +105024,8 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104876,7 +105043,8 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104894,7 +105062,8 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104912,7 +105081,8 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104930,7 +105100,8 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104948,7 +105119,8 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104966,7 +105138,8 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -104984,7 +105157,8 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105002,7 +105176,8 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105020,7 +105195,8 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105038,7 +105214,8 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105056,7 +105233,8 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105074,7 +105252,8 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105092,7 +105271,8 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105110,7 +105290,8 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105128,7 +105309,8 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105146,7 +105328,8 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105164,7 +105347,8 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105182,7 +105366,8 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105200,7 +105385,8 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105218,7 +105404,8 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105236,7 +105423,8 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105254,7 +105442,8 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105272,7 +105461,8 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105290,7 +105480,8 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105308,7 +105499,8 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105326,7 +105518,8 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105344,7 +105537,8 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105362,7 +105556,8 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105380,7 +105575,8 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105398,7 +105594,8 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105416,7 +105613,8 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105434,7 +105632,8 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105452,7 +105651,8 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105470,7 +105670,8 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105488,7 +105689,8 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105506,7 +105708,8 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -105524,7 +105727,8 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106514,7 +106718,8 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106532,7 +106737,8 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106550,7 +106756,8 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106568,7 +106775,8 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106586,7 +106794,8 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106604,7 +106813,8 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106622,7 +106832,8 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106640,7 +106851,8 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106658,7 +106870,8 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106676,7 +106889,8 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106694,7 +106908,8 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106712,7 +106927,8 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106730,7 +106946,8 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106748,7 +106965,8 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106766,7 +106984,8 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106784,7 +107003,8 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106802,7 +107022,8 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106820,7 +107041,8 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106838,7 +107060,8 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106856,7 +107079,8 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106874,7 +107098,8 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106892,7 +107117,8 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106910,7 +107136,8 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106928,7 +107155,8 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106946,7 +107174,8 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106964,7 +107193,8 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -106982,7 +107212,8 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107000,7 +107231,8 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107018,7 +107250,8 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107036,7 +107269,8 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107054,7 +107288,8 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107072,7 +107307,8 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107090,7 +107326,8 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107108,7 +107345,8 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107126,7 +107364,8 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107144,7 +107383,8 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107162,7 +107402,8 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107180,7 +107421,8 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107198,7 +107440,8 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107216,7 +107459,8 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107234,7 +107478,8 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107252,7 +107497,8 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107270,7 +107516,8 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107288,7 +107535,8 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107306,7 +107554,8 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107324,7 +107573,8 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107342,7 +107592,8 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107360,7 +107611,8 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107378,7 +107630,8 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107396,7 +107649,8 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107414,7 +107668,8 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107432,7 +107687,8 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107450,7 +107706,8 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107468,7 +107725,8 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107486,7 +107744,8 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107504,7 +107763,8 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107522,7 +107782,8 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107540,7 +107801,8 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107558,7 +107820,8 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107576,7 +107839,8 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107594,7 +107858,8 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107612,7 +107877,8 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107630,7 +107896,8 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107648,7 +107915,8 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107666,7 +107934,8 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107684,7 +107953,8 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107702,7 +107972,8 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107720,7 +107991,8 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107738,7 +108010,8 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107756,7 +108029,8 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107774,7 +108048,8 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107792,7 +108067,8 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107810,7 +108086,8 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107828,7 +108105,8 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107846,7 +108124,8 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107864,7 +108143,8 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107882,7 +108162,8 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107900,7 +108181,8 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107918,7 +108200,8 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107936,7 +108219,8 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107954,7 +108238,8 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107972,7 +108257,8 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -107990,7 +108276,8 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108008,7 +108295,8 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108026,7 +108314,8 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108044,7 +108333,8 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108062,7 +108352,8 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108080,7 +108371,8 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108098,7 +108390,8 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108116,7 +108409,8 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108134,7 +108428,8 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108152,7 +108447,8 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108170,7 +108466,8 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108188,7 +108485,8 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108206,7 +108504,8 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108224,7 +108523,8 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108242,7 +108542,8 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108260,7 +108561,8 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108278,7 +108580,8 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108296,7 +108599,8 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108314,7 +108618,8 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108332,7 +108637,8 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108350,7 +108656,8 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108368,7 +108675,8 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108386,7 +108694,8 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108404,7 +108713,8 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108422,7 +108732,8 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108440,7 +108751,8 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108458,7 +108770,8 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108476,7 +108789,8 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108494,7 +108808,8 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108512,7 +108827,8 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108530,7 +108846,8 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108548,7 +108865,8 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108566,7 +108884,8 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108584,7 +108903,8 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108602,7 +108922,8 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108620,7 +108941,8 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108638,7 +108960,8 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108656,7 +108979,8 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108674,7 +108998,8 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108692,7 +109017,8 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108710,7 +109036,8 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108728,7 +109055,8 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108746,7 +109074,8 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108764,7 +109093,8 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108782,7 +109112,8 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108800,7 +109131,8 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108818,7 +109150,8 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108836,7 +109169,8 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108854,7 +109188,8 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108872,7 +109207,8 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108890,7 +109226,8 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108908,7 +109245,8 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108926,7 +109264,8 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108944,7 +109283,8 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108962,7 +109302,8 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108980,7 +109321,8 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -108998,7 +109340,8 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109016,7 +109359,8 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109034,7 +109378,8 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109052,7 +109397,8 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109070,7 +109416,8 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109088,7 +109435,8 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109106,7 +109454,8 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109124,7 +109473,8 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109142,7 +109492,8 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109160,7 +109511,8 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109178,7 +109530,8 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109196,7 +109549,8 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109214,7 +109568,8 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109232,7 +109587,8 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109250,7 +109606,8 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109268,7 +109625,8 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109286,7 +109644,8 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109304,7 +109663,8 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109322,7 +109682,8 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109340,7 +109701,8 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109358,7 +109720,8 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109376,7 +109739,8 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109394,7 +109758,8 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109412,7 +109777,8 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109430,7 +109796,8 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109448,7 +109815,8 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109466,7 +109834,8 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109484,7 +109853,8 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109502,7 +109872,8 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109520,7 +109891,8 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109538,7 +109910,8 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109556,7 +109929,8 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109574,7 +109948,8 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109592,7 +109967,8 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109610,7 +109986,8 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109628,7 +110005,8 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109646,7 +110024,8 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109664,7 +110043,8 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109682,7 +110062,8 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109700,7 +110081,8 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109718,7 +110100,8 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109736,7 +110119,8 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109754,7 +110138,8 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109772,7 +110157,8 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109790,7 +110176,8 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109808,7 +110195,8 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109826,7 +110214,8 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109844,7 +110233,8 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109862,7 +110252,8 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109880,7 +110271,8 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109898,7 +110290,8 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109916,7 +110309,8 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109934,7 +110328,8 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109952,7 +110347,8 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109970,7 +110366,8 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -109988,7 +110385,8 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110006,7 +110404,8 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110024,7 +110423,8 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110042,7 +110442,8 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110060,7 +110461,8 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110078,7 +110480,8 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110096,7 +110499,8 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110114,7 +110518,8 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110132,7 +110537,8 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110150,7 +110556,8 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110168,7 +110575,8 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110186,7 +110594,8 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110204,7 +110613,8 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110222,7 +110632,8 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110240,7 +110651,8 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110258,7 +110670,8 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110276,7 +110689,8 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110294,7 +110708,8 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110312,7 +110727,8 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110330,7 +110746,8 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110348,7 +110765,8 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110366,7 +110784,8 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110384,7 +110803,8 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110402,7 +110822,8 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110420,7 +110841,8 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110438,7 +110860,8 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110456,7 +110879,8 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110474,7 +110898,8 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110492,7 +110917,8 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110510,7 +110936,8 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110528,7 +110955,8 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110546,7 +110974,8 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110564,7 +110993,8 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110582,7 +111012,8 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110600,7 +111031,8 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110618,7 +111050,8 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110636,7 +111069,8 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110654,7 +111088,8 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110672,7 +111107,8 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110690,7 +111126,8 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110708,7 +111145,8 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110726,7 +111164,8 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110744,7 +111183,8 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110762,7 +111202,8 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110780,7 +111221,8 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110798,7 +111240,8 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110816,7 +111259,8 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110834,7 +111278,8 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110852,7 +111297,8 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110870,7 +111316,8 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110888,7 +111335,8 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110906,7 +111354,8 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110924,7 +111373,8 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110942,7 +111392,8 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110960,7 +111411,8 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110978,7 +111430,8 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -110996,7 +111449,8 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111014,7 +111468,8 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111032,7 +111487,8 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111050,7 +111506,8 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111068,7 +111525,8 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111086,7 +111544,8 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111104,7 +111563,8 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111122,7 +111582,8 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111140,7 +111601,8 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111158,7 +111620,8 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111176,7 +111639,8 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111194,7 +111658,8 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111212,7 +111677,8 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111230,7 +111696,8 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111248,7 +111715,8 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111266,7 +111734,8 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111284,7 +111753,8 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111302,7 +111772,8 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111320,7 +111791,8 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111338,7 +111810,8 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111356,7 +111829,8 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111374,7 +111848,8 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111392,7 +111867,8 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111410,7 +111886,8 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111428,7 +111905,8 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111446,7 +111924,8 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111464,7 +111943,8 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111482,7 +111962,8 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111500,7 +111981,8 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111518,7 +112000,8 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111536,7 +112019,8 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111554,7 +112038,8 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111572,7 +112057,8 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111590,7 +112076,8 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111608,7 +112095,8 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111626,7 +112114,8 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111644,7 +112133,8 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111662,7 +112152,8 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111680,7 +112171,8 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111698,7 +112190,8 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111716,7 +112209,8 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111734,7 +112228,8 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111752,7 +112247,8 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111770,7 +112266,8 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111788,7 +112285,8 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111806,7 +112304,8 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111824,7 +112323,8 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111842,7 +112342,8 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111860,7 +112361,8 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111878,7 +112380,8 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111896,7 +112399,8 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111914,7 +112418,8 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111932,7 +112437,8 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111950,7 +112456,8 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111968,7 +112475,8 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -111986,7 +112494,8 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112004,7 +112513,8 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112022,7 +112532,8 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112040,7 +112551,8 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112058,7 +112570,8 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112076,7 +112589,8 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112094,7 +112608,8 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112112,7 +112627,8 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112130,7 +112646,8 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112148,7 +112665,8 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112166,7 +112684,8 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112184,7 +112703,8 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112202,7 +112722,8 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112220,7 +112741,8 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112238,7 +112760,8 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112256,7 +112779,8 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112274,7 +112798,8 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112292,7 +112817,8 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112310,7 +112836,8 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112328,7 +112855,8 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112346,7 +112874,8 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112364,7 +112893,8 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112382,7 +112912,8 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112400,7 +112931,8 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112418,7 +112950,8 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112436,7 +112969,8 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112454,7 +112988,8 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112472,7 +113007,8 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112490,7 +113026,8 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112508,7 +113045,8 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112526,7 +113064,8 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112544,7 +113083,8 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112562,7 +113102,8 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112580,7 +113121,8 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112598,7 +113140,8 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112616,7 +113159,8 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112634,7 +113178,8 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112652,7 +113197,8 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112670,7 +113216,8 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112688,7 +113235,8 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112706,7 +113254,8 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112724,7 +113273,8 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112742,7 +113292,8 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112760,7 +113311,8 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112778,7 +113330,8 @@
 		"songID": 1004,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112796,7 +113349,8 @@
 		"songID": 1004,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112814,7 +113368,8 @@
 		"songID": 1004,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112832,7 +113387,8 @@
 		"songID": 1004,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112850,7 +113406,8 @@
 		"songID": 1004,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112868,7 +113425,8 @@
 		"songID": 1004,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112886,7 +113444,8 @@
 		"songID": 1005,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112904,7 +113463,8 @@
 		"songID": 1005,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112922,7 +113482,8 @@
 		"songID": 1005,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112940,7 +113501,8 @@
 		"songID": 1005,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112958,7 +113520,8 @@
 		"songID": 1005,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112976,7 +113539,8 @@
 		"songID": 1005,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -112994,7 +113558,8 @@
 		"songID": 1006,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113012,7 +113577,8 @@
 		"songID": 1006,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113030,7 +113596,8 @@
 		"songID": 1006,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113048,7 +113615,8 @@
 		"songID": 1006,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113066,7 +113634,8 @@
 		"songID": 1006,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113084,7 +113653,8 @@
 		"songID": 1006,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113102,7 +113672,8 @@
 		"songID": 1007,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113120,7 +113691,8 @@
 		"songID": 1007,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113138,7 +113710,8 @@
 		"songID": 1007,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113156,7 +113729,8 @@
 		"songID": 1007,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113174,7 +113748,8 @@
 		"songID": 1007,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113192,7 +113767,8 @@
 		"songID": 1007,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113210,7 +113786,8 @@
 		"songID": 1008,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113228,7 +113805,8 @@
 		"songID": 1008,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113246,7 +113824,8 @@
 		"songID": 1008,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113264,7 +113843,8 @@
 		"songID": 1008,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113282,7 +113862,8 @@
 		"songID": 1008,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113300,7 +113881,8 @@
 		"songID": 1008,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113318,7 +113900,8 @@
 		"songID": 1009,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113336,7 +113919,8 @@
 		"songID": 1009,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113354,7 +113938,8 @@
 		"songID": 1009,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113372,7 +113957,8 @@
 		"songID": 1009,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113390,7 +113976,8 @@
 		"songID": 1009,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113408,7 +113995,8 @@
 		"songID": 1009,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113426,7 +114014,8 @@
 		"songID": 1010,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113444,7 +114033,8 @@
 		"songID": 1010,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113462,7 +114052,8 @@
 		"songID": 1010,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113480,7 +114071,8 @@
 		"songID": 1010,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113498,7 +114090,8 @@
 		"songID": 1010,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113516,7 +114109,8 @@
 		"songID": 1010,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113534,7 +114128,8 @@
 		"songID": 1011,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113552,7 +114147,8 @@
 		"songID": 1011,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113570,7 +114166,8 @@
 		"songID": 1011,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113588,7 +114185,8 @@
 		"songID": 1011,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113606,7 +114204,8 @@
 		"songID": 1011,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113624,7 +114223,8 @@
 		"songID": 1011,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113642,7 +114242,8 @@
 		"songID": 1012,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113660,7 +114261,8 @@
 		"songID": 1012,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113678,7 +114280,8 @@
 		"songID": 1012,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113696,7 +114299,8 @@
 		"songID": 1012,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113714,7 +114318,8 @@
 		"songID": 1012,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113732,7 +114337,8 @@
 		"songID": 1012,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113750,7 +114356,8 @@
 		"songID": 1013,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113768,7 +114375,8 @@
 		"songID": 1013,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113786,7 +114394,8 @@
 		"songID": 1013,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113804,7 +114413,8 @@
 		"songID": 1013,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113822,7 +114432,8 @@
 		"songID": 1013,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113840,7 +114451,8 @@
 		"songID": 1013,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113858,7 +114470,8 @@
 		"songID": 1014,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113876,7 +114489,8 @@
 		"songID": 1014,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113894,7 +114508,8 @@
 		"songID": 1014,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113912,7 +114527,8 @@
 		"songID": 1014,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113930,7 +114546,8 @@
 		"songID": 1014,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113948,7 +114565,8 @@
 		"songID": 1014,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113966,7 +114584,8 @@
 		"songID": 1015,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -113984,7 +114603,8 @@
 		"songID": 1015,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114002,7 +114622,8 @@
 		"songID": 1015,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114020,7 +114641,8 @@
 		"songID": 1015,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114038,7 +114660,8 @@
 		"songID": 1015,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114056,7 +114679,8 @@
 		"songID": 1015,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114074,7 +114698,8 @@
 		"songID": 1016,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114092,7 +114717,8 @@
 		"songID": 1016,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114110,7 +114736,8 @@
 		"songID": 1016,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114128,7 +114755,8 @@
 		"songID": 1016,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114146,7 +114774,8 @@
 		"songID": 1016,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114164,7 +114793,8 @@
 		"songID": 1016,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114182,7 +114812,8 @@
 		"songID": 1017,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114200,7 +114831,8 @@
 		"songID": 1017,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114218,7 +114850,8 @@
 		"songID": 1017,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114236,7 +114869,8 @@
 		"songID": 1017,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114254,7 +114888,8 @@
 		"songID": 1017,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114272,7 +114907,8 @@
 		"songID": 1017,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114290,7 +114926,8 @@
 		"songID": 1018,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114308,7 +114945,8 @@
 		"songID": 1018,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114326,7 +114964,8 @@
 		"songID": 1018,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114344,7 +114983,8 @@
 		"songID": 1018,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114362,7 +115002,8 @@
 		"songID": 1018,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114380,7 +115021,8 @@
 		"songID": 1018,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114398,7 +115040,8 @@
 		"songID": 1019,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114416,7 +115059,8 @@
 		"songID": 1019,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114434,7 +115078,8 @@
 		"songID": 1019,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114452,7 +115097,8 @@
 		"songID": 1019,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114470,7 +115116,8 @@
 		"songID": 1019,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114488,7 +115135,8 @@
 		"songID": 1019,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114506,7 +115154,8 @@
 		"songID": 1020,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114524,7 +115173,8 @@
 		"songID": 1020,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114542,7 +115192,8 @@
 		"songID": 1020,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114560,7 +115211,8 @@
 		"songID": 1020,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114578,7 +115230,8 @@
 		"songID": 1020,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114596,7 +115249,8 @@
 		"songID": 1020,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114614,7 +115268,8 @@
 		"songID": 1021,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114632,7 +115287,8 @@
 		"songID": 1021,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114650,7 +115306,8 @@
 		"songID": 1021,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114668,7 +115325,8 @@
 		"songID": 1021,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114686,7 +115344,8 @@
 		"songID": 1021,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114704,7 +115363,8 @@
 		"songID": 1021,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114722,7 +115382,8 @@
 		"songID": 1022,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114740,7 +115401,8 @@
 		"songID": 1022,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114758,7 +115420,8 @@
 		"songID": 1022,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114776,7 +115439,8 @@
 		"songID": 1022,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114794,7 +115458,8 @@
 		"songID": 1022,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114812,7 +115477,8 @@
 		"songID": 1022,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114830,7 +115496,8 @@
 		"songID": 1023,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114848,7 +115515,8 @@
 		"songID": 1023,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114866,7 +115534,8 @@
 		"songID": 1023,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114884,7 +115553,8 @@
 		"songID": 1023,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114902,7 +115572,8 @@
 		"songID": 1023,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114920,7 +115591,8 @@
 		"songID": 1023,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114938,7 +115610,8 @@
 		"songID": 1024,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114956,7 +115629,8 @@
 		"songID": 1024,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114974,7 +115648,8 @@
 		"songID": 1024,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -114992,7 +115667,8 @@
 		"songID": 1024,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115010,7 +115686,8 @@
 		"songID": 1024,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115028,7 +115705,8 @@
 		"songID": 1024,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115046,7 +115724,8 @@
 		"songID": 1025,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115064,7 +115743,8 @@
 		"songID": 1025,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115082,7 +115762,8 @@
 		"songID": 1025,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115100,7 +115781,8 @@
 		"songID": 1025,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115118,7 +115800,8 @@
 		"songID": 1025,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115136,7 +115819,8 @@
 		"songID": 1025,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115154,7 +115838,8 @@
 		"songID": 1026,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115172,7 +115857,8 @@
 		"songID": 1026,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115190,7 +115876,8 @@
 		"songID": 1026,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115208,7 +115895,8 @@
 		"songID": 1026,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115226,7 +115914,8 @@
 		"songID": 1026,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115244,7 +115933,8 @@
 		"songID": 1026,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115262,7 +115952,8 @@
 		"songID": 1027,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115280,7 +115971,8 @@
 		"songID": 1027,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115298,7 +115990,8 @@
 		"songID": 1027,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115316,7 +116009,8 @@
 		"songID": 1027,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115334,7 +116028,8 @@
 		"songID": 1027,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115352,7 +116047,8 @@
 		"songID": 1027,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115370,7 +116066,8 @@
 		"songID": 1028,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115388,7 +116085,8 @@
 		"songID": 1028,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115406,7 +116104,8 @@
 		"songID": 1028,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115424,7 +116123,8 @@
 		"songID": 1028,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115442,7 +116142,8 @@
 		"songID": 1028,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115460,7 +116161,8 @@
 		"songID": 1028,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115478,7 +116180,8 @@
 		"songID": 1029,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115496,7 +116199,8 @@
 		"songID": 1029,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115514,7 +116218,8 @@
 		"songID": 1029,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115532,7 +116237,8 @@
 		"songID": 1029,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115550,7 +116256,8 @@
 		"songID": 1029,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115568,7 +116275,8 @@
 		"songID": 1029,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115586,7 +116294,8 @@
 		"songID": 1030,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115604,7 +116313,8 @@
 		"songID": 1030,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115622,7 +116332,8 @@
 		"songID": 1030,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115640,7 +116351,8 @@
 		"songID": 1030,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115658,7 +116370,8 @@
 		"songID": 1030,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115676,7 +116389,8 @@
 		"songID": 1030,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115694,7 +116408,8 @@
 		"songID": 1031,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115712,7 +116427,8 @@
 		"songID": 1031,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115730,7 +116446,8 @@
 		"songID": 1031,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115748,7 +116465,8 @@
 		"songID": 1031,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115766,7 +116484,8 @@
 		"songID": 1031,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115784,7 +116503,8 @@
 		"songID": 1031,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115802,7 +116522,8 @@
 		"songID": 1032,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115820,7 +116541,8 @@
 		"songID": 1032,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115838,7 +116560,8 @@
 		"songID": 1032,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115856,7 +116579,8 @@
 		"songID": 1032,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115874,7 +116598,8 @@
 		"songID": 1032,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115892,7 +116617,8 @@
 		"songID": 1032,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115910,7 +116636,8 @@
 		"songID": 1033,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115928,7 +116655,8 @@
 		"songID": 1033,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115946,7 +116674,8 @@
 		"songID": 1033,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115964,7 +116693,8 @@
 		"songID": 1033,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -115982,7 +116712,8 @@
 		"songID": 1033,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116000,7 +116731,8 @@
 		"songID": 1033,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116018,7 +116750,8 @@
 		"songID": 1034,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116036,7 +116769,8 @@
 		"songID": 1034,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116054,7 +116788,8 @@
 		"songID": 1034,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116072,7 +116807,8 @@
 		"songID": 1034,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116090,7 +116826,8 @@
 		"songID": 1034,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116108,7 +116845,8 @@
 		"songID": 1034,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116126,7 +116864,8 @@
 		"songID": 1035,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116144,7 +116883,8 @@
 		"songID": 1035,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116162,7 +116902,8 @@
 		"songID": 1035,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116180,7 +116921,8 @@
 		"songID": 1035,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116198,7 +116940,8 @@
 		"songID": 1035,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116216,7 +116959,8 @@
 		"songID": 1035,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116234,7 +116978,8 @@
 		"songID": 1036,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116252,7 +116997,8 @@
 		"songID": 1036,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116270,7 +117016,8 @@
 		"songID": 1036,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116288,7 +117035,8 @@
 		"songID": 1036,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116306,7 +117054,8 @@
 		"songID": 1036,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116324,7 +117073,8 @@
 		"songID": 1036,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116342,7 +117092,8 @@
 		"songID": 1037,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116360,7 +117111,8 @@
 		"songID": 1037,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116378,7 +117130,8 @@
 		"songID": 1037,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116396,7 +117149,8 @@
 		"songID": 1037,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116414,7 +117168,8 @@
 		"songID": 1037,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116432,7 +117187,8 @@
 		"songID": 1037,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116450,7 +117206,8 @@
 		"songID": 1038,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116468,7 +117225,8 @@
 		"songID": 1038,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116486,7 +117244,8 @@
 		"songID": 1038,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116504,7 +117263,8 @@
 		"songID": 1038,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116522,7 +117282,8 @@
 		"songID": 1038,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116540,7 +117301,8 @@
 		"songID": 1038,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116558,7 +117320,8 @@
 		"songID": 1039,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116576,7 +117339,8 @@
 		"songID": 1039,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116594,7 +117358,8 @@
 		"songID": 1039,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116612,7 +117377,8 @@
 		"songID": 1039,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116630,7 +117396,8 @@
 		"songID": 1039,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116648,7 +117415,8 @@
 		"songID": 1039,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116666,7 +117434,8 @@
 		"songID": 1040,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116684,7 +117453,8 @@
 		"songID": 1040,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116702,7 +117472,8 @@
 		"songID": 1040,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116720,7 +117491,8 @@
 		"songID": 1040,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116738,7 +117510,8 @@
 		"songID": 1040,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116756,7 +117529,8 @@
 		"songID": 1040,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116774,7 +117548,8 @@
 		"songID": 1041,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116792,7 +117567,8 @@
 		"songID": 1041,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116810,7 +117586,8 @@
 		"songID": 1041,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116828,7 +117605,8 @@
 		"songID": 1041,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116846,7 +117624,8 @@
 		"songID": 1041,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116864,7 +117643,8 @@
 		"songID": 1041,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116882,7 +117662,8 @@
 		"songID": 1042,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116900,7 +117681,8 @@
 		"songID": 1042,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116918,7 +117700,8 @@
 		"songID": 1042,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116936,7 +117719,8 @@
 		"songID": 1042,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116954,7 +117738,8 @@
 		"songID": 1042,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116972,7 +117757,8 @@
 		"songID": 1042,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -116990,7 +117776,8 @@
 		"songID": 1043,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117008,7 +117795,8 @@
 		"songID": 1043,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117026,7 +117814,8 @@
 		"songID": 1043,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117044,7 +117833,8 @@
 		"songID": 1043,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117062,7 +117852,8 @@
 		"songID": 1043,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117080,7 +117871,8 @@
 		"songID": 1043,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117098,7 +117890,8 @@
 		"songID": 1044,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117116,7 +117909,8 @@
 		"songID": 1044,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117134,7 +117928,8 @@
 		"songID": 1044,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117152,7 +117947,8 @@
 		"songID": 1044,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117170,7 +117966,8 @@
 		"songID": 1044,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117188,7 +117985,8 @@
 		"songID": 1044,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117206,7 +118004,8 @@
 		"songID": 1045,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117224,7 +118023,8 @@
 		"songID": 1045,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117242,7 +118042,8 @@
 		"songID": 1045,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117260,7 +118061,8 @@
 		"songID": 1045,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117278,7 +118080,8 @@
 		"songID": 1045,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117296,7 +118099,8 @@
 		"songID": 1045,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117314,7 +118118,8 @@
 		"songID": 1046,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117332,7 +118137,8 @@
 		"songID": 1046,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117350,7 +118156,8 @@
 		"songID": 1046,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117368,7 +118175,8 @@
 		"songID": 1046,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117386,7 +118194,8 @@
 		"songID": 1046,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117404,7 +118213,8 @@
 		"songID": 1046,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117422,7 +118232,8 @@
 		"songID": 1047,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117440,7 +118251,8 @@
 		"songID": 1047,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117458,7 +118270,8 @@
 		"songID": 1047,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117476,7 +118289,8 @@
 		"songID": 1047,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117494,7 +118308,8 @@
 		"songID": 1047,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117512,7 +118327,8 @@
 		"songID": 1047,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117530,7 +118346,8 @@
 		"songID": 1048,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117548,7 +118365,8 @@
 		"songID": 1048,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117566,7 +118384,8 @@
 		"songID": 1048,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117584,7 +118403,8 @@
 		"songID": 1048,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117602,7 +118422,8 @@
 		"songID": 1048,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117620,7 +118441,8 @@
 		"songID": 1048,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117638,7 +118460,8 @@
 		"songID": 1049,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117656,7 +118479,8 @@
 		"songID": 1049,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117674,7 +118498,8 @@
 		"songID": 1049,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117692,7 +118517,8 @@
 		"songID": 1049,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117710,7 +118536,8 @@
 		"songID": 1049,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117728,7 +118555,8 @@
 		"songID": 1049,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117746,7 +118574,8 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117764,7 +118593,8 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117782,7 +118612,8 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117800,7 +118631,8 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117818,7 +118650,8 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
 		]
 	},
 	{
@@ -117836,7 +118669,3140 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan"
+			"clan",
+			"festo"
+		]
+	},
+	{
+		"chartID": "36844dfc1080269679f18cca04d8a5b61485f6eb",
+		"data": {
+			"inGameID": 70000124,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1051,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "0e89a84a8628856db1a9fa157e5a8e0b1b8862e3",
+		"data": {
+			"inGameID": 70000124,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1051,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "73dc2eb5eea8457e453a49f0ff145c2e16accfd8",
+		"data": {
+			"inGameID": 70000124,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1051,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f4267c5eeb4d3d47f1beb0f262007043527413e3",
+		"data": {
+			"inGameID": 70000124,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1051,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "aa859c5319997f80a032d96845d2b14eb42ef6b5",
+		"data": {
+			"inGameID": 70000124,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1051,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "0e8ab89c7b0d7c5550667a61d4d00b94feb2e897",
+		"data": {
+			"inGameID": 70000124,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1051,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "7fe0efc554ec4944e5a37d520d76057ea61ed9ab",
+		"data": {
+			"inGameID": 90000038,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1052,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "96c9fedad7da54406ba829cc1c6a8193dc5f7574",
+		"data": {
+			"inGameID": 90000038,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1052,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "655246f86632bdc0c10d4b41f63e50553de15c72",
+		"data": {
+			"inGameID": 90000038,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1052,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "49d65c12dbcd8346a219d610a65b168a6dbb080a",
+		"data": {
+			"inGameID": 90000038,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1052,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f6e3df28672cc430e656a64790530fb150da5e16",
+		"data": {
+			"inGameID": 90000038,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1052,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "39d3ee0ece5f5187da458fd79395ef05bf785064",
+		"data": {
+			"inGameID": 90000038,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1052,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "b3a53428ed44c203182c64a4c96e1966319214b5",
+		"data": {
+			"inGameID": 90000099,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1053,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "37c61677bcbdbd234e44b207ae673b2a35568221",
+		"data": {
+			"inGameID": 90000099,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1053,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "385bd5c4e7f72ccb9b59ed38a10b8169cc24b05d",
+		"data": {
+			"inGameID": 90000099,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1053,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "b62d45a3dc26318a2d4fc5000a6bf1c5520bc761",
+		"data": {
+			"inGameID": 90000099,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1053,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "16ad1d55a1376fc15330f37a808f2a1de8e05e73",
+		"data": {
+			"inGameID": 90000099,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1053,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "80645198e3d24eb85cdae98c61ff125b4608cf3a",
+		"data": {
+			"inGameID": 90000099,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1053,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "733ae51785199c377e293de4b01189033dc6dfcc",
+		"data": {
+			"inGameID": 90000117,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1054,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "246124d1c48900ea8aa3bc6326caf9f407cf132d",
+		"data": {
+			"inGameID": 90000117,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1054,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "85ed86e72d387740a39b6c6d2e7ada439ece2151",
+		"data": {
+			"inGameID": 90000117,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1054,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f11b4552af5cd45584ce1df582fb7012250815d2",
+		"data": {
+			"inGameID": 90000117,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1054,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "38e1cec47501bac30c72d667eb99981a073a7090",
+		"data": {
+			"inGameID": 90000117,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1054,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "6e82d25665141a4abc4676ba216176a3a090b59b",
+		"data": {
+			"inGameID": 90000117,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1054,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "516b22aaf0cd98168a7496987d70eeeefcdc2ccc",
+		"data": {
+			"inGameID": 90000119,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1055,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "dde71aa9055794b7e25c5c11fff2bd2c19538ac0",
+		"data": {
+			"inGameID": 90000119,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1055,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "35f97497d27b3c938502b1a332683229211a47f1",
+		"data": {
+			"inGameID": 90000119,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1055,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "904c7630287368c51e4cd97c9ca5a41b4558abf0",
+		"data": {
+			"inGameID": 90000119,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1055,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "1887a5fd5d8a3aa86705fb97b8959097d062fddd",
+		"data": {
+			"inGameID": 90000119,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1055,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "564b1e8a4198695d4165fa5c71fa11d3cead1774",
+		"data": {
+			"inGameID": 90000119,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1055,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "cedb0ccf668d26016227479efbc4d604b83959c9",
+		"data": {
+			"inGameID": 90000121,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1056,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "e6abb8d7cbdf88b1a868ddb3c9869757cb56d126",
+		"data": {
+			"inGameID": 90000121,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1056,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "d601362ea36b7912f8d890aa2ad979bd8c29ab8f",
+		"data": {
+			"inGameID": 90000121,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1056,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "40610905f42a4dad88922934610f1b048748182f",
+		"data": {
+			"inGameID": 90000121,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1056,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "ed8bf27d39d7f8e0a28b7972d496264a5cb8700e",
+		"data": {
+			"inGameID": 90000121,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1056,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "af78b7237cd90377adbb4a35c743196253dd3f56",
+		"data": {
+			"inGameID": 90000121,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1056,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "a403d8b7a7909f942a4ae7a896cc7298a977db23",
+		"data": {
+			"inGameID": 90000124,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1057,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f5feda13be5ef3e16107374e295ba08c411a6d79",
+		"data": {
+			"inGameID": 90000124,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1057,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "016ec19cb08fce4d0f6cd987ec03139fcbaf4f71",
+		"data": {
+			"inGameID": 90000124,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1057,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "7c757bf5263c7936e388d593d69ef749769bec1b",
+		"data": {
+			"inGameID": 90000124,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1057,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "6697442259bf0e318b5bc6eef2615a5a2cdd6896",
+		"data": {
+			"inGameID": 90000124,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1057,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "3acf53a8b54292d43a5a9144562d71ac264edee1",
+		"data": {
+			"inGameID": 90000124,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1057,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "c3611681ad246520b5c915e03a9f631bc4f11066",
+		"data": {
+			"inGameID": 90000132,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1058,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "a9c45ec9a4df315034f89e0dafe9014cc17bef85",
+		"data": {
+			"inGameID": 90000132,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1058,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "bfb95e5cdd914b9dc38ad4cdec6e86aa98f8ca78",
+		"data": {
+			"inGameID": 90000132,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1058,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "7786199c4a452c0c78bdee76204972d74a18ff0d",
+		"data": {
+			"inGameID": 90000132,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1058,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "4340267c7c013a3be54477a07fc8331f63074aa2",
+		"data": {
+			"inGameID": 90000132,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1058,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "c5d4a3d9d75fc6326ca454fd54ef286490bd037b",
+		"data": {
+			"inGameID": 90000132,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1058,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "975ebd57a1982f21f2e8c75f9452a8ea16f79671",
+		"data": {
+			"inGameID": 90000133,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1059,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "aafcaf65563a59b65d9108d9be2449b19bc90366",
+		"data": {
+			"inGameID": 90000133,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1059,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "fcb279ea1003942e0934403e0df5595573dfd782",
+		"data": {
+			"inGameID": 90000133,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1059,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "2f29f321819a5e328fc26e7ce34a3526f199037b",
+		"data": {
+			"inGameID": 90000133,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1059,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f026db17f8e99afcff125344951318de9ba5825e",
+		"data": {
+			"inGameID": 90000133,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1059,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "e4f499774c6795e3cf2c4702f63dad75f4c5090b",
+		"data": {
+			"inGameID": 90000133,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1059,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "87400fb36fcef33d8862ab301365a07164909145",
+		"data": {
+			"inGameID": 90000135,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1060,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "72a79d91de4c323efe1b385353f48ff38ab7f335",
+		"data": {
+			"inGameID": 90000135,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1060,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "1e08637c0f5644803510de2a9168775828ccd3bd",
+		"data": {
+			"inGameID": 90000135,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1060,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "e5b91aa801d80d6ceb0d7d9f67b08b74197f8857",
+		"data": {
+			"inGameID": 90000135,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1060,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "3128a0b363cfbab2bbf9dee0525aa2538ad81792",
+		"data": {
+			"inGameID": 90000135,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1060,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "103357b6d5dd5f547449ceb6d40a71d376d1ef1e",
+		"data": {
+			"inGameID": 90000135,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1060,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "efc92ceb5898765bade481f420663be5a574d8a9",
+		"data": {
+			"inGameID": 90000139,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1061,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "9cb9ec03912cd581df06bec763ee10c0d8666bfa",
+		"data": {
+			"inGameID": 90000139,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1061,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f773c6ee691c8e207002ed52db951800a7e35073",
+		"data": {
+			"inGameID": 90000139,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1061,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f25eb1556b4ffb6e7320f3ca288ada9a2e6fefe8",
+		"data": {
+			"inGameID": 90000139,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1061,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "d3a280197e19100699b513afd29b0022b27f2b35",
+		"data": {
+			"inGameID": 90000139,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1061,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "d0d50a1c9d60eb8c7705c91cd6337d1b89ad1a4b",
+		"data": {
+			"inGameID": 90000139,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1061,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "2e56ce23cf1326c9a989e54496342826a6bb1710",
+		"data": {
+			"inGameID": 90000140,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1062,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "0641402f5e8caee23699e3b2c535c257651bd205",
+		"data": {
+			"inGameID": 90000140,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1062,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "891295c9d5ce85d5b0a85590366ac871aa66400d",
+		"data": {
+			"inGameID": 90000140,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1062,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "5d28b1f568bcd9e7be2c123c8e3caf6a9b183730",
+		"data": {
+			"inGameID": 90000140,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1062,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "30d311ec066d3fdc5d3733c4e101ec99cd650c98",
+		"data": {
+			"inGameID": 90000140,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1062,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "c3f79ab73235ef66e4a4c4e380cf875efb0ec6c3",
+		"data": {
+			"inGameID": 90000140,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1062,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "6d0211f3c38fe86c936c888f706ee3355a987363",
+		"data": {
+			"inGameID": 90000141,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1063,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "27dc18813322c50a961e9e128fe0540956be7541",
+		"data": {
+			"inGameID": 90000141,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1063,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "d4d007dfe31d5a7399cf1083f813b097049d6019",
+		"data": {
+			"inGameID": 90000141,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1063,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "486c583dd5065d1d996ad5a5c0fdd7dd055f3a5b",
+		"data": {
+			"inGameID": 90000141,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1063,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "c1e09ebc81733913eb7b82b576d4ce11cdae7f5e",
+		"data": {
+			"inGameID": 90000141,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1063,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f2a52a6abe98d4890f6ec4bc2c8bb78c3bcbc07b",
+		"data": {
+			"inGameID": 90000141,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1063,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "d122d606ef95b2a723a93bb2be4142b7e00c94bb",
+		"data": {
+			"inGameID": 90000151,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1064,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "34439d0881e90e2dd91c91d842b35f7b04965560",
+		"data": {
+			"inGameID": 90000151,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1064,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "08857fed2c9d63b139c1522abcb38ec6355a59f3",
+		"data": {
+			"inGameID": 90000151,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1064,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "96beab0b07426a34cb5fc6ab4c6a276d67016a7a",
+		"data": {
+			"inGameID": 90000151,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1064,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "a13d82b34a443163b3b8fa9435da78df941433d4",
+		"data": {
+			"inGameID": 90000151,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1064,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "e0ba1ee46d2933703c91c6e8fea672b76c1135de",
+		"data": {
+			"inGameID": 90000151,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1064,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "fce1498faf97c0c0cb923aede01249d467e4485f",
+		"data": {
+			"inGameID": 90000152,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1065,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "53b762873b271296ea0bf3039639f67e41a7f3f8",
+		"data": {
+			"inGameID": 90000152,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1065,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "999fad3a3a73920edfd156d77b7bbf17218111da",
+		"data": {
+			"inGameID": 90000152,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1065,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "1570fe697692455dd5d0a54b9c225d15d01d7213",
+		"data": {
+			"inGameID": 90000152,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1065,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "d1abd2e94ebebbb2c559e9f2e2f79babb63d93fd",
+		"data": {
+			"inGameID": 90000152,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1065,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "cefb59553b5a0296d55ffd64f41d156ffe5ec0d2",
+		"data": {
+			"inGameID": 90000152,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1065,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "fe31665300fcf0ace6d13730ab485f57f2d0a3e0",
+		"data": {
+			"inGameID": 90000157,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1066,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "0113dcdacd3d9bb2a55e8aa0529b067a97d14aeb",
+		"data": {
+			"inGameID": 90000157,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1066,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "e574bab074b826ea43fe53f9e4e95adb34d71ecb",
+		"data": {
+			"inGameID": 90000157,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1066,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "7c22a24da3a232fb12d51e515c283fed5757b7a8",
+		"data": {
+			"inGameID": 90000157,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1066,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "7dd0ebde1eb52e7bf4262147279f6f63eb8000af",
+		"data": {
+			"inGameID": 90000157,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1066,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "a60f474d73f1f27f6c2e7ff126f0fcd23f620122",
+		"data": {
+			"inGameID": 90000157,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1066,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f2147f222cfccee33617f852df8be2297ba0d445",
+		"data": {
+			"inGameID": 90000158,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1067,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "b98eaa88e6e93211d3a43f3028deea8d906f026d",
+		"data": {
+			"inGameID": 90000158,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1067,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "1faee041c467970c1c2c284f139f914850801016",
+		"data": {
+			"inGameID": 90000158,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1067,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "c22ba75e9102181bc5cc3552f99a1dac0bd97e93",
+		"data": {
+			"inGameID": 90000158,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1067,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "43a2bbe14eb509528aca34cfb6037e25c40b648d",
+		"data": {
+			"inGameID": 90000158,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1067,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "318a96700f7d5b77a02f1dbb274c2b86699a673f",
+		"data": {
+			"inGameID": 90000158,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1067,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "124cb707c6b367b6827dcafbfa90c1f38c6dec8b",
+		"data": {
+			"inGameID": 90000163,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1068,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "3cdcdd9502d320f8798d7920b96c432cb42c10de",
+		"data": {
+			"inGameID": 90000163,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1068,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "4503a7c7e7099aa0cb103d06300abb544e050e31",
+		"data": {
+			"inGameID": 90000163,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1068,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "cbc1cdaabc5f4a42df34f40fe0d4ef2bc9dc63b2",
+		"data": {
+			"inGameID": 90000163,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1068,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "a3d04b5ddbd451fab27d6472e69032cf25403378",
+		"data": {
+			"inGameID": 90000163,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1068,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "53853b95f05abed2005e5f57c90fcce95f0fb768",
+		"data": {
+			"inGameID": 90000163,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1068,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "680b82f317118e0a0b72b67c55041f6d0c7337dc",
+		"data": {
+			"inGameID": 90000165,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1069,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "61c2dac2f2a99a45db1aafc6a54db267e02b7ced",
+		"data": {
+			"inGameID": 90000165,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1069,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "255df34158a01b9765910ac9480981f2665e36fe",
+		"data": {
+			"inGameID": 90000165,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1069,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "cb6b2f19ccac8cef53fa6277b7e781a66f93bb48",
+		"data": {
+			"inGameID": 90000165,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1069,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "141052af90933048f7daf10a79a2aae18e7f8bdc",
+		"data": {
+			"inGameID": 90000165,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1069,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "aa5d858c429fa386fae0d1474538e011552894b0",
+		"data": {
+			"inGameID": 90000165,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1069,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "43c73c6b5ea5a911a5e6f5c64c66413fb7cbb421",
+		"data": {
+			"inGameID": 90000170,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1070,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "925de72667fc1130ab3648e68e1ee38e2e5c194f",
+		"data": {
+			"inGameID": 90000170,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1070,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "c7fa5ed02cc22bde056a7388a5814fcecc154a91",
+		"data": {
+			"inGameID": 90000170,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1070,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "3a2073e522817a021534164c6fcd86d53df5a148",
+		"data": {
+			"inGameID": 90000170,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1070,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "a8f6e0446b24ccecf3e4f663a3bcca292840572a",
+		"data": {
+			"inGameID": 90000170,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1070,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "2cbc8a0630eac38c40b60cc498be968e473778d5",
+		"data": {
+			"inGameID": 90000170,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1070,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "b5aa22b6dafe4d7dfc287818b7eb1839cb53ad4d",
+		"data": {
+			"inGameID": 90000171,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1071,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "d0d8ea6ec0167f3fd16d4dd57f478dc02f8e5d84",
+		"data": {
+			"inGameID": 90000171,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1071,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "73d9fc82c7241314539359bc2d74d22da5d8231e",
+		"data": {
+			"inGameID": 90000171,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1071,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "aab3b2a8f94f1bc5d54bd1167be1ba3a4975ae1c",
+		"data": {
+			"inGameID": 90000171,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1071,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "33c89c05dd3429d0213ef4be5d560e5ae60d0d9d",
+		"data": {
+			"inGameID": 90000171,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1071,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f0b8912b5c3ad85e3148848211a9742979fc22f0",
+		"data": {
+			"inGameID": 90000171,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1071,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "b932df5f225e40efbe72e519fb9c65eac3e67bfd",
+		"data": {
+			"inGameID": 90000172,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1072,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "833d0bd66ed2dd5bd87fbf63c6229e2f88dad4c3",
+		"data": {
+			"inGameID": 90000172,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1072,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "88dbe1fcb9e652b59f858e456c5d0e0c9a114dd4",
+		"data": {
+			"inGameID": 90000172,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1072,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "7460195f586dc83c39ca35e448f4e674b9914e1b",
+		"data": {
+			"inGameID": 90000172,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1072,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "4bee78412ced9f87488f82db63359c55650c3d4f",
+		"data": {
+			"inGameID": 90000172,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1072,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "e6ee5960f6b80ac4768cd95f2b53652a02b77299",
+		"data": {
+			"inGameID": 90000172,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1072,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "e35d883744fc56f4468bcdca5c712afea7e2fbfe",
+		"data": {
+			"inGameID": 90000173,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1073,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "edc8654ba82f3e8a88f74e6a671cdc035540ee99",
+		"data": {
+			"inGameID": 90000173,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1073,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "3e585b6e6e98eac601333ee06f5bede3db80a921",
+		"data": {
+			"inGameID": 90000173,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1073,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "52601eb5e4a61ff6f38559a8ed5b5b0c244fae87",
+		"data": {
+			"inGameID": 90000173,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1073,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "e4dbd812b73c6c8f438df85eebb880878a86b5f2",
+		"data": {
+			"inGameID": 90000173,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1073,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "bf3a1df69ae6460c6cd648a9548ea0393faa2bd2",
+		"data": {
+			"inGameID": 90000173,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1073,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "4a6d18676410f94a141e5bdaef6f5abe82c1d289",
+		"data": {
+			"inGameID": 90000174,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1074,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "bc58aa899705f66cfb78865f74c2415318df497a",
+		"data": {
+			"inGameID": 90000174,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1074,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f5111cbdd7e81bdadd101b8f8aca810bcfa76a5d",
+		"data": {
+			"inGameID": 90000174,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1074,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "3cb2d99823963a991b169fdf87a2bde79bac791d",
+		"data": {
+			"inGameID": 90000174,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1074,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "fc32af109afef33d033e9cb9f953ff5159cab22e",
+		"data": {
+			"inGameID": 90000174,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1074,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "45ac6ce7f0dda1e757e6174d4a4c000a7d5acc98",
+		"data": {
+			"inGameID": 90000174,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1074,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "6a56783026317d27729685bb7f7306f2d8683cad",
+		"data": {
+			"inGameID": 90000175,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1075,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "dc5acbb5e808780ee79591f39c0240f1b6aa5d26",
+		"data": {
+			"inGameID": 90000175,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1075,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "c8c74fc00847734aba2af0925d71753afc7af4dd",
+		"data": {
+			"inGameID": 90000175,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1075,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "29f7fe984c0b0aab364a3f10b8fceea54acd78ca",
+		"data": {
+			"inGameID": 90000175,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1075,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "84269b4d326dd1a0c9f195cbecd4b673dbfa6f4b",
+		"data": {
+			"inGameID": 90000175,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1075,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "9da1a26e2e075063799dbec8c17dedc5b935dae9",
+		"data": {
+			"inGameID": 90000175,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1075,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "ee05964382f9cf84de7d217bf27649eba76706eb",
+		"data": {
+			"inGameID": 90000176,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1076,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "36df13d9f491ef98602d91253e9b716a966391f6",
+		"data": {
+			"inGameID": 90000176,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1076,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "b737b279f844559da63b08458b51f186a25615e8",
+		"data": {
+			"inGameID": 90000176,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1076,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "df208eedea4cd7b1a56f58cfcb08c8c10a01d2e5",
+		"data": {
+			"inGameID": 90000176,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1076,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "17515690e5b1f7faa379bf00dd0fbc29d6627e12",
+		"data": {
+			"inGameID": 90000176,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1076,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "584ab219249be12e8aa98d7d6175b63947ab4352",
+		"data": {
+			"inGameID": 90000176,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1076,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "1ae34bbc1ad0df974ff1c7bbd04f82d90d961e5f",
+		"data": {
+			"inGameID": 90000177,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1077,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "2c5c716a963f73e5f608d9601d5827af6082cbb1",
+		"data": {
+			"inGameID": 90000177,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1077,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f4d3ccc238a24e8c4fcae2dec94c4b72b9ed5cbd",
+		"data": {
+			"inGameID": 90000177,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1077,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "08c660d8238fa6a503732270f8bcdf3cce0fd7ee",
+		"data": {
+			"inGameID": 90000177,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1077,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "64c9837e78c75821017825adebde68a025bcb364",
+		"data": {
+			"inGameID": 90000177,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1077,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "6c3315206fb6a9068390af22706093955cc9d6f9",
+		"data": {
+			"inGameID": 90000177,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1077,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "cae3237c50329822efa51fe2c1e8a62416a67f4d",
+		"data": {
+			"inGameID": 90000178,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1078,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "63bca4045f0904ad2a07bc426d9c72d6a2dcd0af",
+		"data": {
+			"inGameID": 90000178,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1078,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "3fb9a454566b77a8a7fac7b9a58c1a7aac449bd6",
+		"data": {
+			"inGameID": 90000178,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1078,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "eea102c62df155815d8ee57daf6829fa6754cc3b",
+		"data": {
+			"inGameID": 90000178,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1078,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "aa7a59d7c91700086d18953e60e78f91dee94626",
+		"data": {
+			"inGameID": 90000178,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1078,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "6d3980fdaef392bc52385a7ebd57dd54fc80886f",
+		"data": {
+			"inGameID": 90000178,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1078,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "ac702aefc9f2669078391c8e36b8453f4d70c298",
+		"data": {
+			"inGameID": 90000179,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1079,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "e32add8a14742b032b83cab07ed51320e0bde6fe",
+		"data": {
+			"inGameID": 90000179,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1079,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "7c75f371bc00ebf847ed821008348a207235deaa",
+		"data": {
+			"inGameID": 90000179,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1079,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "1a007836170c7c72bd464d8a53fea2dbec84c843",
+		"data": {
+			"inGameID": 90000179,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1079,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "965f6e1f4449ef4afda7607fb1ab34c0f411101a",
+		"data": {
+			"inGameID": 90000179,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1079,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
+		]
+	},
+	{
+		"chartID": "f1947378a8803f95f52bb303b19efdcb65b6eceb",
+		"data": {
+			"inGameID": 90000179,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1079,
+		"tierlistInfo": {},
+		"versions": [
+			"festo"
 		]
 	}
 ]

--- a/database-seeds/collections/songs-jubeat.json
+++ b/database-seeds/collections/songs-jubeat.json
@@ -10498,5 +10498,295 @@
 		"id": 1050,
 		"searchTerms": [],
 		"title": "君の知らない物語 [ 2 ]"
+	},
+	{
+		"altTitles": [],
+		"artist": "ピコ太郎",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 1051,
+		"searchTerms": [],
+		"title": "ペンパイナッポーアッポーペン"
+	},
+	{
+		"altTitles": [],
+		"artist": "オーイシマサヨシ",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1052,
+		"searchTerms": [],
+		"title": "オトモダチフィルム"
+	},
+	{
+		"altTitles": [],
+		"artist": "Hommarju",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1053,
+		"searchTerms": [],
+		"title": "Midsummer Madness"
+	},
+	{
+		"altTitles": [],
+		"artist": "駄々子",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1054,
+		"searchTerms": [],
+		"title": "封隠文様"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"TAG\"",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1055,
+		"searchTerms": [],
+		"title": "StaRgAZER"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Sota Fujimori\"",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1056,
+		"searchTerms": [],
+		"title": "Life Without You"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Power Of Nature\"",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1057,
+		"searchTerms": [],
+		"title": "Hades Doll"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Expander\"",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1058,
+		"searchTerms": [],
+		"title": "Neuron"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"サイバー劇レコ\"",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1059,
+		"searchTerms": [],
+		"title": "SPACE INASAKU"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"TATSUYA\"",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1060,
+		"searchTerms": [],
+		"title": "Spica"
+	},
+	{
+		"altTitles": [],
+		"artist": "Official髭男dism",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1061,
+		"searchTerms": [],
+		"title": "Pretender"
+	},
+	{
+		"altTitles": [],
+		"artist": "あいみょん",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1062,
+		"searchTerms": [],
+		"title": "マリーゴールド"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1063,
+		"searchTerms": [],
+		"title": "令和"
+	},
+	{
+		"altTitles": [],
+		"artist": "RoughSketch",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1064,
+		"searchTerms": [],
+		"title": "ラプンツェル"
+	},
+	{
+		"altTitles": [],
+		"artist": "コバヤシユウヤ(IOSYS) feat. miko",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1065,
+		"searchTerms": [],
+		"title": "ピザが食べたくてしょうがない皆さんの気持ちを代弁しました"
+	},
+	{
+		"altTitles": [],
+		"artist": "nora2r",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1066,
+		"searchTerms": [],
+		"title": "No Rule Adventure"
+	},
+	{
+		"altTitles": [],
+		"artist": "MARON (IOSYS)",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1067,
+		"searchTerms": [],
+		"title": "Toy Robot Factory"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"HuΣeR Vs. SYUNN\" feat.いちか",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1068,
+		"searchTerms": [],
+		"title": "狂水一華"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"dj TAKA\" feat.のの",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1069,
+		"searchTerms": [],
+		"title": "Jetcoaster Windy"
+	},
+	{
+		"altTitles": [],
+		"artist": "SIRUP",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1070,
+		"searchTerms": [],
+		"title": "Do Well"
+	},
+	{
+		"altTitles": [],
+		"artist": "須田景凪",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1071,
+		"searchTerms": [],
+		"title": "Alba"
+	},
+	{
+		"altTitles": [],
+		"artist": "anime",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1072,
+		"searchTerms": [],
+		"title": "紅蓮華"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Trance Liquid\"",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1073,
+		"searchTerms": [],
+		"title": "X-ray binary"
+	},
+	{
+		"altTitles": [],
+		"artist": "かめりあ",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1074,
+		"searchTerms": [],
+		"title": "世界の果てに約束の凱歌を -jubeat edition-"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"あさき隊\"",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1075,
+		"searchTerms": [],
+		"title": "ここからよろしく大作戦143"
+	},
+	{
+		"altTitles": [],
+		"artist": "ヨルシカ",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1076,
+		"searchTerms": [],
+		"title": "思想犯"
+	},
+	{
+		"altTitles": [],
+		"artist": "柊キライ",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1077,
+		"searchTerms": [],
+		"title": "ボッカデラベリタ"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"S-C-U & TATSUYA\"",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1078,
+		"searchTerms": [],
+		"title": "turn into white"
+	},
+	{
+		"altTitles": [],
+		"artist": "PSYQUI",
+		"data": {
+			"displayVersion": "festo"
+		},
+		"id": 1079,
+		"searchTerms": [],
+		"title": "Still Lonesome"
 	}
 ]

--- a/database-seeds/scripts/package.json
+++ b/database-seeds/scripts/package.json
@@ -6,10 +6,6 @@
 	"scripts": {
 		"test": "./run-tests.sh"
 	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/TeamNewGuys/tachi-database-seeds.git"
-	},
 	"keywords": [
 		"Kamaitachi",
 		"Bokutachi",
@@ -18,10 +14,6 @@
 	],
 	"author": "zkldi",
 	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/TeamNewGuys/tachi-database-seeds/issues"
-	},
-	"homepage": "https://github.com/TeamNewGuys/tachi-database-seeds#readme",
 	"dependencies": {
 		"@types/lodash.get": "^4.4.7",
 		"better-sqlite3": "^7.5.0",


### PR DESCRIPTION
A script was written to add charts and songs to the corresponsing json collections for Jubeat. Song titles and artists were manually fetched. The `chartID` strings were generated using `secrets.token_hex(20)`, and were not checked for duplicates. New additions were appended to the end of the array, with `songID` starting from `1051`. The 6 charts per song were added in difficulty order `ADV`, `BSC`, `EXT`, `HARD ADV`, `HARD BSC`, `HARD EXT`, per song. The `displayVersion` strings are derived from the first digit in the `id`. The `versions` list contains `festo` for every chart which has appeared in Jubeat Festo before December 2020; it does not assume current state. Charts removed during the running of Festo have still received the `festo` tag.