### PR TITLE
Jubeat Qubell update.

### DIFF
--- a/common/src/config/config.ts
+++ b/common/src/config/config.ts
@@ -2063,7 +2063,7 @@ const GAME_PT_CONFIGS: GamePTConfigs = {
 
 		scoreBucket: "grade",
 
-		supportedVersions: ["clan", "festo"],
+		supportedVersions: ["qubell", "clan", "festo"],
 
 		tierlists: [],
 		tierlistDescriptions: {},

--- a/common/src/config/static-config.ts
+++ b/common/src/config/static-config.ts
@@ -167,6 +167,7 @@ export const PrettyVersions: Versions = {
 	"jubeat:Single": {
 		festo: "festo",
 		clan: "clan",
+		qubell: "qubell",
 	},
 	"pms:Controller": {},
 	"pms:Keyboard": {},

--- a/common/src/lib/schemas.ts
+++ b/common/src/lib/schemas.ts
@@ -312,7 +312,7 @@ function GetChartDataForGPT(idString: IDStrings): PrudenceSchema {
 				notecount: p.isPositiveNonZeroInteger,
 				hashSHA256: "?string",
 				hashMD5: "?string",
-				aiLevel: "?number",
+				aiLevel: "?string",
 				tableFolders: [
 					{
 						table: "string",

--- a/common/src/lib/schemas.ts
+++ b/common/src/lib/schemas.ts
@@ -412,6 +412,9 @@ function GetChartDataForGPT(idString: IDStrings): PrudenceSchema {
 				length: p.isPositive,
 				charter: "string",
 				displayBPM: p.isPositive,
+
+				// todo, maybe constrain this a bit?
+				difficultyTag: "string",
 			};
 		case "gitadora:Dora":
 		case "gitadora:Gita":
@@ -448,7 +451,7 @@ const PR_CHART_DOCUMENT = (game: Game) => (self: unknown) => {
 		level: "string",
 		levelNum: "number",
 		isPrimary: "boolean",
-		difficulty: p.isIn(gptConfig.difficulties),
+		difficulty: game === "itg" ? "string" : p.isIn(gptConfig.difficulties),
 		playtype: p.is(playtype),
 		data,
 		tierlistInfo: Object.fromEntries(
@@ -517,7 +520,7 @@ const PRE_SCHEMAS = {
 
 			return true;
 		},
-		set: p.isIn("genocideDan", "stslDan"),
+		set: p.isIn("genocideDan", "stslDan", "lnDan", "scratchDan"),
 		playtype: p.isIn("7K", "14K"),
 		value: p.isInteger,
 	}),

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -768,7 +768,7 @@ export interface GPTSupportedVersions {
 	"ddr:SP": "a20";
 	"ddr:DP": "a20";
 	"maimai:Single": "finale";
-	"jubeat:Single": "clan" | "festo";
+	"jubeat:Single": "clan" | "festo" | "qubell";
 	"museca:Single": "1.5-b" | "1.5";
 	"bms:7K": never;
 	"bms:14K": never;

--- a/database-seeds/collections/charts-jubeat.json
+++ b/database-seeds/collections/charts-jubeat.json
@@ -14,6 +14,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33,6 +34,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52,6 +54,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -71,6 +74,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -90,6 +94,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109,6 +114,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -128,6 +134,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -147,6 +154,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -166,6 +174,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -185,6 +194,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -204,6 +214,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -223,6 +234,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -242,6 +254,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -261,6 +274,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -280,6 +294,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -299,6 +314,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -318,6 +334,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -337,6 +354,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -356,6 +374,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -375,6 +394,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -394,6 +414,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -413,6 +434,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -432,6 +454,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -451,6 +474,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -470,6 +494,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -489,6 +514,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -508,6 +534,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -527,6 +554,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -546,6 +574,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -565,6 +594,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -584,6 +614,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -603,6 +634,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -622,6 +654,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -641,6 +674,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -660,6 +694,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -679,6 +714,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -698,6 +734,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -717,6 +754,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -736,6 +774,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -755,6 +794,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -774,6 +814,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -793,6 +834,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -812,6 +854,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -831,6 +874,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -850,6 +894,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -869,6 +914,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -888,6 +934,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -907,6 +954,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -926,6 +974,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -945,6 +994,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -964,6 +1014,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -983,6 +1034,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1002,6 +1054,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1021,6 +1074,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1040,6 +1094,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1059,6 +1114,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1078,6 +1134,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1097,6 +1154,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1116,6 +1174,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1135,6 +1194,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1154,6 +1214,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1173,6 +1234,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1192,6 +1254,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1211,6 +1274,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1230,6 +1294,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1249,6 +1314,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1268,6 +1334,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1287,6 +1354,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1306,6 +1374,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1325,6 +1394,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1344,6 +1414,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1363,6 +1434,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1382,6 +1454,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1401,6 +1474,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1420,6 +1494,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1439,6 +1514,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1458,6 +1534,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1477,6 +1554,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1496,6 +1574,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1515,6 +1594,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1534,6 +1614,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1553,6 +1634,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1572,6 +1654,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1591,6 +1674,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1610,6 +1694,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1629,6 +1714,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1648,6 +1734,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1667,6 +1754,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1686,6 +1774,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1705,6 +1794,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1724,6 +1814,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1743,6 +1834,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1762,6 +1854,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1781,6 +1874,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1800,6 +1894,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1819,6 +1914,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1838,6 +1934,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1857,6 +1954,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1876,6 +1974,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1895,6 +1994,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1914,6 +2014,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1933,6 +2034,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1952,6 +2054,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1971,6 +2074,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -1990,6 +2094,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2009,6 +2114,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2028,6 +2134,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2047,6 +2154,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2066,6 +2174,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2085,6 +2194,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2104,6 +2214,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2123,6 +2234,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2142,6 +2254,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2161,6 +2274,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2180,6 +2294,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2199,6 +2314,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2218,6 +2334,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2237,6 +2354,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2256,6 +2374,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2275,6 +2394,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2294,6 +2414,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2313,6 +2434,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2332,6 +2454,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2351,6 +2474,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2370,6 +2494,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2389,6 +2514,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2408,6 +2534,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2427,6 +2554,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2446,6 +2574,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2465,6 +2594,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2484,6 +2614,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2503,6 +2634,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2522,6 +2654,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2541,6 +2674,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2560,6 +2694,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2579,6 +2714,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2598,6 +2734,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2617,6 +2754,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2636,6 +2774,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2655,6 +2794,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2674,6 +2814,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2693,6 +2834,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2712,6 +2854,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2731,6 +2874,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2750,6 +2894,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2769,6 +2914,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2788,6 +2934,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2807,6 +2954,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2826,6 +2974,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2845,6 +2994,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2864,6 +3014,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2883,6 +3034,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2902,6 +3054,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2921,6 +3074,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2940,6 +3094,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2959,6 +3114,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2978,6 +3134,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -2997,6 +3154,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3016,6 +3174,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3035,6 +3194,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3054,6 +3214,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3073,6 +3234,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3092,6 +3254,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3111,6 +3274,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3130,6 +3294,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3149,6 +3314,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3168,6 +3334,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3187,6 +3354,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3206,6 +3374,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3225,6 +3394,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3244,6 +3414,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3263,6 +3434,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3282,6 +3454,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3301,6 +3474,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3320,6 +3494,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3339,6 +3514,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3358,6 +3534,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3377,6 +3554,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3396,6 +3574,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3415,6 +3594,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3434,6 +3614,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3453,6 +3634,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3472,6 +3654,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3491,6 +3674,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3510,6 +3694,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3529,6 +3714,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3548,6 +3734,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3567,6 +3754,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3586,6 +3774,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3605,6 +3794,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3624,6 +3814,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3643,6 +3834,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3662,6 +3854,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3681,6 +3874,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3700,6 +3894,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3719,6 +3914,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3738,6 +3934,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3757,6 +3954,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3776,6 +3974,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3795,6 +3994,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3814,6 +4014,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3833,6 +4034,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3852,6 +4054,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3871,6 +4074,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3890,6 +4094,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3909,6 +4114,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3928,6 +4134,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3947,6 +4154,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3966,6 +4174,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -3985,6 +4194,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4004,6 +4214,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4023,6 +4234,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4042,6 +4254,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4061,6 +4274,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4080,6 +4294,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4099,6 +4314,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4118,6 +4334,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4137,6 +4354,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4156,6 +4374,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4175,6 +4394,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4194,6 +4414,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4213,6 +4434,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4232,6 +4454,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4251,6 +4474,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4270,6 +4494,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4289,6 +4514,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4308,6 +4534,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4327,6 +4554,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4346,6 +4574,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4365,6 +4594,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4384,6 +4614,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4403,6 +4634,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4422,6 +4654,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4441,6 +4674,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4460,6 +4694,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4479,6 +4714,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4498,6 +4734,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4517,6 +4754,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4536,6 +4774,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4555,6 +4794,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4574,6 +4814,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4593,6 +4834,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4612,6 +4854,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4631,6 +4874,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4650,6 +4894,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4669,6 +4914,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4688,6 +4934,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4707,6 +4954,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4726,6 +4974,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4745,6 +4994,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4764,6 +5014,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4783,6 +5034,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4802,6 +5054,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4821,6 +5074,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4840,6 +5094,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4859,6 +5114,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4878,6 +5134,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4897,6 +5154,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4916,6 +5174,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4935,6 +5194,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4954,6 +5214,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4973,6 +5234,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -4992,6 +5254,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5011,6 +5274,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5030,6 +5294,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5049,6 +5314,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5068,6 +5334,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5087,6 +5354,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5106,6 +5374,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5125,6 +5394,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5144,6 +5414,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5163,6 +5434,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5182,6 +5454,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5201,6 +5474,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5220,6 +5494,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5239,6 +5514,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5258,6 +5534,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5277,6 +5554,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5296,6 +5574,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5315,6 +5594,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5334,6 +5614,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5353,6 +5634,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5372,6 +5654,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5391,6 +5674,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5410,6 +5694,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5429,6 +5714,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5448,6 +5734,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5467,6 +5754,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5486,6 +5774,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5505,6 +5794,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5524,6 +5814,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5543,6 +5834,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5562,6 +5854,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5581,6 +5874,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5600,6 +5894,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5619,6 +5914,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5638,6 +5934,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5657,6 +5954,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5676,6 +5974,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5695,6 +5994,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5714,6 +6014,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5733,6 +6034,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5752,6 +6054,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5771,6 +6074,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5790,6 +6094,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5809,6 +6114,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5828,6 +6134,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5847,6 +6154,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5866,6 +6174,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5885,6 +6194,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5904,6 +6214,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5923,6 +6234,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5942,6 +6254,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5961,6 +6274,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5980,6 +6294,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -5999,6 +6314,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6018,6 +6334,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6037,6 +6354,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6056,6 +6374,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6075,6 +6394,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6094,6 +6414,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6113,6 +6434,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6132,6 +6454,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6151,6 +6474,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6170,6 +6494,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6189,6 +6514,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6208,6 +6534,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6227,6 +6554,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6246,6 +6574,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6265,6 +6594,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6284,6 +6614,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6303,6 +6634,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6322,6 +6654,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6341,6 +6674,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6360,6 +6694,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6379,6 +6714,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6398,6 +6734,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6417,6 +6754,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6436,6 +6774,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6455,6 +6794,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6474,6 +6814,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6493,6 +6834,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6512,6 +6854,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6531,6 +6874,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6550,6 +6894,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6569,6 +6914,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6588,6 +6934,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6607,6 +6954,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6626,6 +6974,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6645,6 +6994,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6664,6 +7014,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6683,6 +7034,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6702,6 +7054,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6721,6 +7074,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6740,6 +7094,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6759,6 +7114,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6778,6 +7134,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6797,6 +7154,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6816,6 +7174,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6835,6 +7194,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6854,6 +7214,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6873,6 +7234,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6892,6 +7254,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6911,6 +7274,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6930,6 +7294,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6949,6 +7314,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6968,6 +7334,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -6987,6 +7354,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7006,6 +7374,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7025,6 +7394,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7044,6 +7414,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7063,6 +7434,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7082,6 +7454,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7101,6 +7474,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7120,6 +7494,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7139,6 +7514,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7158,6 +7534,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7177,6 +7554,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7196,6 +7574,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7215,6 +7594,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7234,6 +7614,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7253,6 +7634,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7272,6 +7654,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7291,6 +7674,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7310,6 +7694,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7329,6 +7714,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7348,6 +7734,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7367,6 +7754,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7386,6 +7774,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7405,6 +7794,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7424,6 +7814,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7443,6 +7834,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7462,6 +7854,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7481,6 +7874,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7500,6 +7894,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7519,6 +7914,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7538,6 +7934,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7557,6 +7954,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7576,6 +7974,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7595,6 +7994,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7614,6 +8014,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7633,6 +8034,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7652,6 +8054,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7671,6 +8074,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7690,6 +8094,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7709,6 +8114,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7728,6 +8134,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7747,6 +8154,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7766,6 +8174,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7785,6 +8194,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7804,6 +8214,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7823,6 +8234,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7842,6 +8254,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7861,6 +8274,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7880,6 +8294,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7899,6 +8314,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7918,6 +8334,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7937,6 +8354,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7956,6 +8374,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7975,6 +8394,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -7994,6 +8414,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8013,6 +8434,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8032,6 +8454,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8051,6 +8474,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8070,6 +8494,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8089,6 +8514,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8108,6 +8534,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8127,6 +8554,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8146,6 +8574,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8165,6 +8594,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8184,6 +8614,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8203,6 +8634,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8222,6 +8654,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8241,6 +8674,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8260,6 +8694,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8279,6 +8714,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8298,6 +8734,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8317,6 +8754,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8336,6 +8774,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8355,6 +8794,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8374,6 +8814,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8393,6 +8834,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8412,6 +8854,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8431,6 +8874,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8450,6 +8894,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8469,6 +8914,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8488,6 +8934,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8507,6 +8954,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8526,6 +8974,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8545,6 +8994,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8564,6 +9014,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8583,6 +9034,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8602,6 +9054,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8621,6 +9074,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8640,6 +9094,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8659,6 +9114,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8678,6 +9134,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8697,6 +9154,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8716,6 +9174,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8735,6 +9194,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8754,6 +9214,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8773,6 +9234,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8792,6 +9254,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8811,6 +9274,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8830,6 +9294,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8849,6 +9314,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8868,6 +9334,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8887,6 +9354,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8906,6 +9374,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8925,6 +9394,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8944,6 +9414,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8963,6 +9434,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -8982,6 +9454,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9001,6 +9474,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9020,6 +9494,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9039,6 +9514,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9058,6 +9534,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9077,6 +9554,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9096,6 +9574,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9115,6 +9594,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9134,6 +9614,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9153,6 +9634,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9172,6 +9654,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9191,6 +9674,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9210,6 +9694,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9229,6 +9714,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9248,6 +9734,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9267,6 +9754,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9286,6 +9774,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9305,6 +9794,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9324,6 +9814,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9343,6 +9834,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9362,6 +9854,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9381,6 +9874,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9400,6 +9894,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9419,6 +9914,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9438,6 +9934,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9457,6 +9954,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9476,6 +9974,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9495,6 +9994,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9514,6 +10014,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9533,6 +10034,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9552,6 +10054,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9571,6 +10074,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9590,6 +10094,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9609,6 +10114,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9628,6 +10134,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9647,6 +10154,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9666,6 +10174,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9685,6 +10194,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9704,6 +10214,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9723,6 +10234,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9742,6 +10254,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9761,6 +10274,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9780,6 +10294,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9799,6 +10314,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9818,6 +10334,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9837,6 +10354,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9856,6 +10374,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9875,6 +10394,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9894,6 +10414,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9913,6 +10434,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9932,6 +10454,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9951,6 +10474,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9970,6 +10494,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -9989,6 +10514,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10008,6 +10534,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10027,6 +10554,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10046,6 +10574,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10065,6 +10594,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10084,6 +10614,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10103,6 +10634,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10122,6 +10654,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10141,6 +10674,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10160,6 +10694,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10179,6 +10714,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10198,6 +10734,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10217,6 +10754,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10236,6 +10774,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10255,6 +10794,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10274,6 +10814,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10293,6 +10834,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10312,6 +10854,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10331,6 +10874,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10350,6 +10894,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10369,6 +10914,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10388,6 +10934,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10407,6 +10954,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10426,6 +10974,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10445,6 +10994,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10464,6 +11014,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10483,6 +11034,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10502,6 +11054,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10521,6 +11074,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10540,6 +11094,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10559,6 +11114,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10578,6 +11134,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10597,6 +11154,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10616,6 +11174,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10635,6 +11194,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10654,6 +11214,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10673,6 +11234,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10692,6 +11254,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10711,6 +11274,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10730,6 +11294,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10749,6 +11314,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10768,6 +11334,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10787,6 +11354,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10806,6 +11374,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10825,6 +11394,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10844,6 +11414,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10863,6 +11434,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10882,6 +11454,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10901,6 +11474,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10920,6 +11494,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10939,6 +11514,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10958,6 +11534,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10977,6 +11554,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -10996,6 +11574,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11015,6 +11594,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11034,6 +11614,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11053,6 +11634,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11072,6 +11654,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11091,6 +11674,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11110,6 +11694,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11129,6 +11714,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11148,6 +11734,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11167,6 +11754,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11186,6 +11774,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11205,6 +11794,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11224,6 +11814,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11243,6 +11834,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11262,6 +11854,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11281,6 +11874,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11300,6 +11894,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11319,6 +11914,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11338,6 +11934,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11357,6 +11954,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11376,6 +11974,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11395,6 +11994,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11414,6 +12014,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11433,6 +12034,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11452,6 +12054,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11471,6 +12074,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11490,6 +12094,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11509,6 +12114,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11528,6 +12134,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11547,6 +12154,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11566,6 +12174,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11585,6 +12194,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11604,6 +12214,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11623,6 +12234,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11642,6 +12254,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11661,6 +12274,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11680,6 +12294,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11699,6 +12314,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11718,6 +12334,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11737,6 +12354,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11756,6 +12374,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11775,6 +12394,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11794,6 +12414,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11813,6 +12434,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11832,6 +12454,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11851,6 +12474,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11870,6 +12494,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11889,6 +12514,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11908,6 +12534,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11927,6 +12554,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11946,6 +12574,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11965,6 +12594,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -11984,6 +12614,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12003,6 +12634,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12022,6 +12654,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12041,6 +12674,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12060,6 +12694,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12079,6 +12714,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12098,6 +12734,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12117,6 +12754,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12136,6 +12774,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12155,6 +12794,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12174,6 +12814,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12193,6 +12834,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12212,6 +12854,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12231,6 +12874,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12250,6 +12894,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12269,6 +12914,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12288,6 +12934,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12307,6 +12954,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12326,6 +12974,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12345,6 +12994,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12364,6 +13014,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12383,6 +13034,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12402,6 +13054,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12421,6 +13074,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12440,6 +13094,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12459,6 +13114,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12478,6 +13134,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12497,6 +13154,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12516,6 +13174,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12535,6 +13194,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12554,6 +13214,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12573,6 +13234,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12592,6 +13254,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12611,6 +13274,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12630,6 +13294,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12649,6 +13314,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12668,6 +13334,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12687,6 +13354,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12706,6 +13374,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12725,6 +13394,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12744,6 +13414,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12763,6 +13434,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12782,6 +13454,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12801,6 +13474,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12820,6 +13494,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12839,6 +13514,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12858,6 +13534,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12877,6 +13554,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12896,6 +13574,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12915,6 +13594,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12934,6 +13614,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12953,6 +13634,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12972,6 +13654,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -12991,6 +13674,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13010,6 +13694,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13029,6 +13714,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13048,6 +13734,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13067,6 +13754,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13086,6 +13774,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13105,6 +13794,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13124,6 +13814,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13143,6 +13834,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13162,6 +13854,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13181,6 +13874,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13200,6 +13894,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13219,6 +13914,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13238,6 +13934,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13257,6 +13954,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13276,6 +13974,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13295,6 +13994,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13314,6 +14014,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13333,6 +14034,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13352,6 +14054,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13371,6 +14074,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13390,6 +14094,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13409,6 +14114,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13428,6 +14134,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13447,6 +14154,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13466,6 +14174,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13485,6 +14194,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13504,6 +14214,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13523,6 +14234,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13542,6 +14254,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13561,6 +14274,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13580,6 +14294,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13599,6 +14314,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13618,6 +14334,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13637,6 +14354,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13656,6 +14374,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13675,6 +14394,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13694,6 +14414,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13713,6 +14434,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13732,6 +14454,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13751,6 +14474,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13770,6 +14494,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13789,6 +14514,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13808,6 +14534,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13827,6 +14554,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13846,6 +14574,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13865,6 +14594,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13884,6 +14614,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13903,6 +14634,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13922,6 +14654,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13941,6 +14674,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13960,6 +14694,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13979,6 +14714,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -13998,6 +14734,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14017,6 +14754,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14036,6 +14774,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14055,6 +14794,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14074,6 +14814,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14093,6 +14834,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14112,6 +14854,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14131,6 +14874,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14150,6 +14894,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14169,6 +14914,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14188,6 +14934,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14207,6 +14954,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14226,6 +14974,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14245,6 +14994,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14264,6 +15014,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14283,6 +15034,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14302,6 +15054,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14321,6 +15074,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14340,6 +15094,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14359,6 +15114,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14378,6 +15134,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14397,6 +15154,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14416,6 +15174,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14435,6 +15194,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14454,6 +15214,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14473,6 +15234,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14492,6 +15254,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14511,6 +15274,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14530,6 +15294,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14549,6 +15314,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14568,6 +15334,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14587,6 +15354,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14606,6 +15374,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14625,6 +15394,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14644,6 +15414,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14663,6 +15434,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14682,6 +15454,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14701,6 +15474,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14720,6 +15494,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14739,6 +15514,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14758,6 +15534,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14777,6 +15554,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14796,6 +15574,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14815,6 +15594,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14834,6 +15614,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14853,6 +15634,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14872,6 +15654,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14891,6 +15674,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14910,6 +15694,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14929,6 +15714,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14948,6 +15734,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14967,6 +15754,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -14986,6 +15774,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15005,6 +15794,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15024,6 +15814,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15043,6 +15834,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15062,6 +15854,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15081,6 +15874,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15100,6 +15894,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15119,6 +15914,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15138,6 +15934,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15157,6 +15954,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15176,6 +15974,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15195,6 +15994,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15214,6 +16014,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15233,6 +16034,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15252,6 +16054,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15271,6 +16074,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15290,6 +16094,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15309,6 +16114,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15328,6 +16134,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15347,6 +16154,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15366,6 +16174,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15385,6 +16194,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15404,6 +16214,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15423,6 +16234,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15442,6 +16254,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15461,6 +16274,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15480,6 +16294,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15499,6 +16314,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15518,6 +16334,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15537,6 +16354,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15556,6 +16374,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15575,6 +16394,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15594,6 +16414,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15613,6 +16434,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15632,6 +16454,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15651,6 +16474,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15670,6 +16494,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15689,6 +16514,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15708,6 +16534,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15727,6 +16554,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15746,6 +16574,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15765,6 +16594,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15784,6 +16614,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15803,6 +16634,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15822,6 +16654,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15841,6 +16674,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15860,6 +16694,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15879,6 +16714,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15898,6 +16734,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15917,6 +16754,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15936,6 +16774,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15955,6 +16794,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15974,6 +16814,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -15993,6 +16834,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16012,6 +16854,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16031,6 +16874,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16050,6 +16894,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16069,6 +16914,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16088,6 +16934,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16107,6 +16954,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16126,6 +16974,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16145,6 +16994,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16164,6 +17014,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16183,6 +17034,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16202,6 +17054,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16221,6 +17074,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16240,6 +17094,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16259,6 +17114,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16278,6 +17134,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16297,6 +17154,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16316,6 +17174,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16335,6 +17194,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16354,6 +17214,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16373,6 +17234,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16392,6 +17254,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16411,6 +17274,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16430,6 +17294,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16449,6 +17314,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16468,6 +17334,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16487,6 +17354,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16506,6 +17374,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16525,6 +17394,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16544,6 +17414,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16563,6 +17434,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16582,6 +17454,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16601,6 +17474,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16620,6 +17494,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16639,6 +17514,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16658,6 +17534,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16677,6 +17554,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16696,6 +17574,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16715,6 +17594,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16734,6 +17614,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16753,6 +17634,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16772,6 +17654,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16791,6 +17674,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16810,6 +17694,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16829,6 +17714,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16848,6 +17734,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16867,6 +17754,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16886,6 +17774,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16905,6 +17794,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16924,6 +17814,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16943,6 +17834,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16962,6 +17854,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -16981,6 +17874,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17000,6 +17894,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17019,6 +17914,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17038,6 +17934,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17057,6 +17954,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17076,6 +17974,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17095,6 +17994,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17114,6 +18014,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17133,6 +18034,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17152,6 +18054,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17171,6 +18074,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17190,6 +18094,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17209,6 +18114,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17228,6 +18134,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17247,6 +18154,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17266,6 +18174,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17285,6 +18194,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17304,6 +18214,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17323,6 +18234,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17342,6 +18254,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17361,6 +18274,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17380,6 +18294,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17399,6 +18314,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17418,6 +18334,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17437,6 +18354,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17456,6 +18374,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17475,6 +18394,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17494,6 +18414,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17513,6 +18434,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17532,6 +18454,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17551,6 +18474,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17570,6 +18494,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17589,6 +18514,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17608,6 +18534,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17627,6 +18554,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17646,6 +18574,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17665,6 +18594,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17684,6 +18614,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17703,6 +18634,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17722,6 +18654,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17741,6 +18674,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17760,6 +18694,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17779,6 +18714,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17798,6 +18734,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17817,6 +18754,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17836,6 +18774,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17855,6 +18794,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17874,6 +18814,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17893,6 +18834,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17912,6 +18854,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17931,6 +18874,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17950,6 +18894,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17969,6 +18914,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -17988,6 +18934,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18007,6 +18954,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18026,6 +18974,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18045,6 +18994,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18064,6 +19014,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18083,6 +19034,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18102,6 +19054,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18121,6 +19074,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18140,6 +19094,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18159,6 +19114,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18178,6 +19134,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18197,6 +19154,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18216,6 +19174,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18235,6 +19194,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18254,6 +19214,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18273,6 +19234,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18292,6 +19254,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18311,6 +19274,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18330,6 +19294,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18349,6 +19314,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18368,6 +19334,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18387,6 +19354,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18406,6 +19374,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18425,6 +19394,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18444,6 +19414,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18463,6 +19434,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18482,6 +19454,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18501,6 +19474,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18520,6 +19494,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18539,6 +19514,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18558,6 +19534,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18577,6 +19554,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18596,6 +19574,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18615,6 +19594,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18634,6 +19614,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18653,6 +19634,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18672,6 +19654,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18691,6 +19674,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18710,6 +19694,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18729,6 +19714,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18748,6 +19734,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18767,6 +19754,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18786,6 +19774,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18805,6 +19794,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18824,6 +19814,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18843,6 +19834,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18862,6 +19854,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18881,6 +19874,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18900,6 +19894,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18919,6 +19914,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18938,6 +19934,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18957,6 +19954,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18976,6 +19974,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -18995,6 +19994,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19014,6 +20014,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19033,6 +20034,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19052,6 +20054,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19071,6 +20074,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19090,6 +20094,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19109,6 +20114,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19128,6 +20134,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19147,6 +20154,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19166,6 +20174,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19185,6 +20194,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19204,6 +20214,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19223,6 +20234,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19242,6 +20254,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19261,6 +20274,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19280,6 +20294,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19299,6 +20314,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19318,6 +20334,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19337,6 +20354,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19356,6 +20374,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19375,6 +20394,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19394,6 +20414,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19413,6 +20434,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19432,6 +20454,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19451,6 +20474,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19470,6 +20494,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19489,6 +20514,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19508,6 +20534,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19527,6 +20554,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19546,6 +20574,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19565,6 +20594,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19584,6 +20614,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19603,6 +20634,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19622,6 +20654,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19641,6 +20674,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19660,6 +20694,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19679,6 +20714,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19698,6 +20734,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19717,6 +20754,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19736,6 +20774,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19755,6 +20794,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19774,6 +20814,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19793,6 +20834,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19812,6 +20854,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19831,6 +20874,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19850,6 +20894,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19869,6 +20914,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19888,6 +20934,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19907,6 +20954,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19926,6 +20974,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19945,6 +20994,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19964,6 +21014,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -19983,6 +21034,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20002,6 +21054,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20021,6 +21074,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20040,6 +21094,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20059,6 +21114,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20078,6 +21134,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20097,6 +21154,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20116,6 +21174,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20135,6 +21194,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20154,6 +21214,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20173,6 +21234,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20192,6 +21254,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20211,6 +21274,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20230,6 +21294,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20249,6 +21314,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20268,6 +21334,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20287,6 +21354,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20306,6 +21374,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20325,6 +21394,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20344,6 +21414,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20363,6 +21434,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20382,6 +21454,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20401,6 +21474,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20420,6 +21494,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20439,6 +21514,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20458,6 +21534,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20477,6 +21554,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20496,6 +21574,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20515,6 +21594,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20534,6 +21614,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20553,6 +21634,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20572,6 +21654,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20591,6 +21674,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20610,6 +21694,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20629,6 +21714,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20648,6 +21734,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20667,6 +21754,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20686,6 +21774,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20705,6 +21794,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20724,6 +21814,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20743,6 +21834,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20762,6 +21854,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20781,6 +21874,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20800,6 +21894,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20819,6 +21914,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20838,6 +21934,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20857,6 +21954,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20876,6 +21974,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20895,6 +21994,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20914,6 +22014,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20933,6 +22034,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20952,6 +22054,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20971,6 +22074,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -20990,6 +22094,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21009,6 +22114,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21028,6 +22134,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21047,6 +22154,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21066,6 +22174,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21085,6 +22194,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21104,6 +22214,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21123,6 +22234,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21142,6 +22254,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21161,6 +22274,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21180,6 +22294,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21199,6 +22314,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21218,6 +22334,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21237,6 +22354,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21256,6 +22374,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21275,6 +22394,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21294,6 +22414,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21313,6 +22434,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21332,6 +22454,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21351,6 +22474,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21370,6 +22494,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21389,6 +22514,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21408,6 +22534,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21427,6 +22554,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21446,6 +22574,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21465,6 +22594,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21484,6 +22614,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21503,6 +22634,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21522,6 +22654,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21541,6 +22674,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21560,6 +22694,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21579,6 +22714,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21598,6 +22734,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21617,6 +22754,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21636,6 +22774,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21655,6 +22794,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21674,6 +22814,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21693,6 +22834,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21712,6 +22854,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21731,6 +22874,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21750,6 +22894,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21769,6 +22914,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21788,6 +22934,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21807,6 +22954,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21826,6 +22974,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21845,6 +22994,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21864,6 +23014,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21883,6 +23034,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21902,6 +23054,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21921,6 +23074,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21940,6 +23094,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21959,6 +23114,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21978,6 +23134,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -21997,6 +23154,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22016,6 +23174,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22035,6 +23194,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22054,6 +23214,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22073,6 +23234,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22092,6 +23254,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22111,6 +23274,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22130,6 +23294,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22149,6 +23314,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22168,6 +23334,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22187,6 +23354,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22206,6 +23374,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22225,6 +23394,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22244,6 +23414,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22263,6 +23434,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22282,6 +23454,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22301,6 +23474,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22320,6 +23494,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22339,6 +23514,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22358,6 +23534,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22377,6 +23554,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22396,6 +23574,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22415,6 +23594,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22434,6 +23614,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22453,6 +23634,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22472,6 +23654,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22491,6 +23674,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22510,6 +23694,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22529,6 +23714,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22548,6 +23734,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22567,6 +23754,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22586,6 +23774,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22605,6 +23794,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22624,6 +23814,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22643,6 +23834,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22662,6 +23854,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22681,6 +23874,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22700,6 +23894,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22719,6 +23914,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22738,6 +23934,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22757,6 +23954,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22776,6 +23974,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22795,6 +23994,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22814,6 +24014,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22833,6 +24034,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22852,6 +24054,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22871,6 +24074,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22890,6 +24094,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22909,6 +24114,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22928,6 +24134,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22947,6 +24154,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22966,6 +24174,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -22985,6 +24194,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23004,6 +24214,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23023,6 +24234,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23042,6 +24254,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23061,6 +24274,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23080,6 +24294,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23099,6 +24314,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23118,6 +24334,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23137,6 +24354,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23156,6 +24374,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23175,6 +24394,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23194,6 +24414,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23213,6 +24434,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23232,6 +24454,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23251,6 +24474,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23270,6 +24494,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23289,6 +24514,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23308,6 +24534,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23327,6 +24554,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23346,6 +24574,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23365,6 +24594,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23384,6 +24614,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23403,6 +24634,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23422,6 +24654,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23441,6 +24674,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23460,6 +24694,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23479,6 +24714,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23498,6 +24734,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23517,6 +24754,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23536,6 +24774,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23555,6 +24794,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23574,6 +24814,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23593,6 +24834,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23612,6 +24854,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23631,6 +24874,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23650,6 +24894,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23669,6 +24914,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23688,6 +24934,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23707,6 +24954,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23726,6 +24974,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23745,6 +24994,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23764,6 +25014,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23783,6 +25034,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23802,6 +25054,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23821,6 +25074,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23840,6 +25094,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23859,6 +25114,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23878,6 +25134,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23897,6 +25154,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23916,6 +25174,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23935,6 +25194,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23954,6 +25214,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23973,6 +25234,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -23992,6 +25254,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24011,6 +25274,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24030,6 +25294,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24049,6 +25314,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24068,6 +25334,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24087,6 +25354,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24106,6 +25374,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24125,6 +25394,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24144,6 +25414,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24163,6 +25434,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24182,6 +25454,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24201,6 +25474,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24220,6 +25494,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24239,6 +25514,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24258,6 +25534,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24277,6 +25554,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24296,6 +25574,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24315,6 +25594,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24334,6 +25614,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24353,6 +25634,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24372,6 +25654,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24391,6 +25674,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24410,6 +25694,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24429,6 +25714,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24448,6 +25734,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24467,6 +25754,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24486,6 +25774,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24505,6 +25794,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24524,6 +25814,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24543,6 +25834,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24562,6 +25854,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24581,6 +25874,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24600,6 +25894,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24619,6 +25914,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24638,6 +25934,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24657,6 +25954,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24676,6 +25974,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24695,6 +25994,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24714,6 +26014,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24733,6 +26034,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24752,6 +26054,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24771,6 +26074,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24790,6 +26094,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24809,6 +26114,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24828,6 +26134,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24847,6 +26154,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24866,6 +26174,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24885,6 +26194,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24904,6 +26214,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24923,6 +26234,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24942,6 +26254,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24961,6 +26274,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24980,6 +26294,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -24999,6 +26314,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25018,6 +26334,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25037,6 +26354,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25056,6 +26374,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25075,6 +26394,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25094,6 +26414,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25113,6 +26434,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25132,6 +26454,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25151,6 +26474,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25170,6 +26494,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25189,6 +26514,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25208,6 +26534,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25227,6 +26554,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25246,6 +26574,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25265,6 +26594,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25284,6 +26614,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25303,6 +26634,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25322,6 +26654,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25341,6 +26674,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25360,6 +26694,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25379,6 +26714,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25398,6 +26734,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25417,6 +26754,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25436,6 +26774,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25455,6 +26794,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25474,6 +26814,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25493,6 +26834,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25512,6 +26854,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25531,6 +26874,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25550,6 +26894,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25569,6 +26914,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25588,6 +26934,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25607,6 +26954,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25626,6 +26974,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25645,6 +26994,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25664,6 +27014,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25683,6 +27034,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25702,6 +27054,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25721,6 +27074,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25740,6 +27094,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25759,6 +27114,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25778,6 +27134,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25797,6 +27154,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25816,6 +27174,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25835,6 +27194,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25854,6 +27214,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25873,6 +27234,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25892,6 +27254,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25911,6 +27274,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25930,6 +27294,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25949,6 +27314,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25968,6 +27334,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -25987,6 +27354,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26006,6 +27374,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26025,6 +27394,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26044,6 +27414,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26063,6 +27434,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26082,6 +27454,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26101,6 +27474,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26120,6 +27494,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26139,6 +27514,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26158,6 +27534,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26177,6 +27554,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26196,6 +27574,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26215,6 +27594,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26234,6 +27614,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26253,6 +27634,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26272,6 +27654,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26291,6 +27674,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26310,6 +27694,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26329,6 +27714,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26348,6 +27734,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26367,6 +27754,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26386,6 +27774,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26405,6 +27794,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26424,6 +27814,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26443,6 +27834,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26462,6 +27854,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26481,6 +27874,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26500,6 +27894,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26519,6 +27914,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26538,6 +27934,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26557,6 +27954,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26576,6 +27974,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26595,6 +27994,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26614,6 +28014,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26633,6 +28034,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26652,6 +28054,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26671,6 +28074,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26690,6 +28094,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26709,6 +28114,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26728,6 +28134,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26747,6 +28154,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26766,6 +28174,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26785,6 +28194,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26804,6 +28214,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26823,6 +28234,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26842,6 +28254,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26861,6 +28274,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26880,6 +28294,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26899,6 +28314,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26918,6 +28334,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26937,6 +28354,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26956,6 +28374,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26975,6 +28394,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -26994,6 +28414,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27013,6 +28434,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27032,6 +28454,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27051,6 +28474,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27070,6 +28494,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27089,6 +28514,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27108,6 +28534,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27127,6 +28554,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27146,6 +28574,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27165,6 +28594,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27184,6 +28614,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27203,6 +28634,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27222,6 +28654,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27241,6 +28674,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27260,6 +28694,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27279,6 +28714,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27298,6 +28734,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27317,6 +28754,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27336,6 +28774,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27355,6 +28794,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27374,6 +28814,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27393,6 +28834,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27412,6 +28854,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27431,6 +28874,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27450,6 +28894,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27469,6 +28914,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27488,6 +28934,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27507,6 +28954,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27526,6 +28974,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27545,6 +28994,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27564,6 +29014,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27583,6 +29034,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27602,6 +29054,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27621,6 +29074,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27640,6 +29094,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27659,6 +29114,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27678,6 +29134,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27697,6 +29154,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27716,6 +29174,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27735,6 +29194,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27754,6 +29214,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27773,6 +29234,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27792,6 +29254,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27811,6 +29274,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27830,6 +29294,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27849,6 +29314,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27868,6 +29334,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27887,6 +29354,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27906,6 +29374,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27925,6 +29394,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27944,6 +29414,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27963,6 +29434,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -27982,6 +29454,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28001,6 +29474,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28020,6 +29494,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28039,6 +29514,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28058,6 +29534,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28077,6 +29554,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28096,6 +29574,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28115,6 +29594,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28134,6 +29614,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28153,6 +29634,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28172,6 +29654,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28191,6 +29674,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28210,6 +29694,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28229,6 +29714,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28248,6 +29734,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28267,6 +29754,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28286,6 +29774,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28305,6 +29794,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28324,6 +29814,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28343,6 +29834,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28362,6 +29854,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28381,6 +29874,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28400,6 +29894,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28419,6 +29914,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28438,6 +29934,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28457,6 +29954,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28476,6 +29974,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28495,6 +29994,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28514,6 +30014,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28533,6 +30034,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28552,6 +30054,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28571,6 +30074,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28590,6 +30094,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28609,6 +30114,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28628,6 +30134,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28647,6 +30154,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28666,6 +30174,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28685,6 +30194,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28704,6 +30214,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28723,6 +30234,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28742,6 +30254,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28761,6 +30274,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28780,6 +30294,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28799,6 +30314,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28818,6 +30334,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28837,6 +30354,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28856,6 +30374,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28875,6 +30394,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28894,6 +30414,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28913,6 +30434,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28932,6 +30454,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28951,6 +30474,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28970,6 +30494,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -28989,6 +30514,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29008,6 +30534,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29027,6 +30554,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29046,6 +30574,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29065,6 +30594,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29084,6 +30614,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29103,6 +30634,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29122,6 +30654,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29141,6 +30674,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29160,6 +30694,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29179,6 +30714,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29198,6 +30734,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29217,6 +30754,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29236,6 +30774,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29255,6 +30794,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29274,6 +30814,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29293,6 +30834,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29312,6 +30854,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29331,6 +30874,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29350,6 +30894,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29369,6 +30914,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29388,6 +30934,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29407,6 +30954,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29426,6 +30974,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29445,6 +30994,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29464,6 +31014,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29483,6 +31034,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29502,6 +31054,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29521,6 +31074,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29540,6 +31094,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29559,6 +31114,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29578,6 +31134,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29597,6 +31154,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29616,6 +31174,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29635,6 +31194,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29654,6 +31214,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29673,6 +31234,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29692,6 +31254,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29711,6 +31274,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29730,6 +31294,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29749,6 +31314,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29768,6 +31334,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29787,6 +31354,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29806,6 +31374,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29825,6 +31394,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29844,6 +31414,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29863,6 +31434,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29882,6 +31454,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29901,6 +31474,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29920,6 +31494,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29939,6 +31514,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29958,6 +31534,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29977,6 +31554,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -29996,6 +31574,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30015,6 +31594,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30034,6 +31614,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30053,6 +31634,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30072,6 +31654,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30091,6 +31674,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30110,6 +31694,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30129,6 +31714,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30148,6 +31734,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30167,6 +31754,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30186,6 +31774,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30205,6 +31794,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30224,6 +31814,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30243,6 +31834,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30262,6 +31854,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30281,6 +31874,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30300,6 +31894,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30319,6 +31914,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30338,6 +31934,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30357,6 +31954,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30376,6 +31974,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30395,6 +31994,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30414,6 +32014,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30433,6 +32034,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30452,6 +32054,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30471,6 +32074,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30490,6 +32094,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30509,6 +32114,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30528,6 +32134,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30547,6 +32154,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30566,6 +32174,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30585,6 +32194,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30604,6 +32214,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30623,6 +32234,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30642,6 +32254,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30661,6 +32274,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30680,6 +32294,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30699,6 +32314,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30718,6 +32334,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30737,6 +32354,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30756,6 +32374,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30775,6 +32394,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30794,6 +32414,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30813,6 +32434,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30832,6 +32454,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30851,6 +32474,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30870,6 +32494,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30889,6 +32514,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30908,6 +32534,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30927,6 +32554,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30946,6 +32574,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30965,6 +32594,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -30984,6 +32614,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31003,6 +32634,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31022,6 +32654,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31041,6 +32674,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31060,6 +32694,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31079,6 +32714,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31098,6 +32734,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31117,6 +32754,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31136,6 +32774,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31155,6 +32794,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31174,6 +32814,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31193,6 +32834,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31212,6 +32854,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31231,6 +32874,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31250,6 +32894,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31269,6 +32914,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31288,6 +32934,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31307,6 +32954,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31326,6 +32974,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31345,6 +32994,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31364,6 +33014,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31383,6 +33034,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31402,6 +33054,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31421,6 +33074,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31440,6 +33094,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31459,6 +33114,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31478,6 +33134,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31497,6 +33154,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31516,6 +33174,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31535,6 +33194,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31554,6 +33214,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31573,6 +33234,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31592,6 +33254,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31611,6 +33274,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31630,6 +33294,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31649,6 +33314,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31668,6 +33334,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31687,6 +33354,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31706,6 +33374,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31725,6 +33394,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31744,6 +33414,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31763,6 +33434,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31782,6 +33454,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31801,6 +33474,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31820,6 +33494,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31839,6 +33514,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31858,6 +33534,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31877,6 +33554,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31896,6 +33574,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31915,6 +33594,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31934,6 +33614,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31953,6 +33634,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31972,6 +33654,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -31991,6 +33674,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32010,6 +33694,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32029,6 +33714,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32048,6 +33734,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32067,6 +33754,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32086,6 +33774,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32105,6 +33794,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32124,6 +33814,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32143,6 +33834,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32162,6 +33854,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32181,6 +33874,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32200,6 +33894,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32219,6 +33914,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32238,6 +33934,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32257,6 +33954,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32276,6 +33974,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32295,6 +33994,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32314,6 +34014,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32333,6 +34034,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32352,6 +34054,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32371,6 +34074,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32390,6 +34094,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32409,6 +34114,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32428,6 +34134,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32447,6 +34154,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32466,6 +34174,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32485,6 +34194,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32504,6 +34214,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32523,6 +34234,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32542,6 +34254,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32561,6 +34274,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32580,6 +34294,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32599,6 +34314,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32618,6 +34334,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32637,6 +34354,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32656,6 +34374,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32675,6 +34394,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32694,6 +34414,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32713,6 +34434,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32732,6 +34454,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32751,6 +34474,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32770,6 +34494,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32789,6 +34514,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32808,6 +34534,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32827,6 +34554,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32846,6 +34574,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32865,6 +34594,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32884,6 +34614,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32903,6 +34634,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32922,6 +34654,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32941,6 +34674,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32960,6 +34694,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32979,6 +34714,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -32998,6 +34734,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33017,6 +34754,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33036,6 +34774,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33055,6 +34794,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33074,6 +34814,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33093,6 +34834,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33112,6 +34854,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33131,6 +34874,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33150,6 +34894,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33169,6 +34914,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33188,6 +34934,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33207,6 +34954,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33226,6 +34974,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33245,6 +34994,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33264,6 +35014,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33283,6 +35034,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33302,6 +35054,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33321,6 +35074,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33340,6 +35094,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33359,6 +35114,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33378,6 +35134,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33397,6 +35154,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33416,6 +35174,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33435,6 +35194,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33454,6 +35214,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33473,6 +35234,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33492,6 +35254,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33511,6 +35274,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33530,6 +35294,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33549,6 +35314,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33568,6 +35334,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33587,6 +35354,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33606,6 +35374,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33625,6 +35394,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33644,6 +35414,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33663,6 +35434,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33682,6 +35454,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33701,6 +35474,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33720,6 +35494,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33739,6 +35514,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33758,6 +35534,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33777,6 +35554,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33796,6 +35574,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33815,6 +35594,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33834,6 +35614,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33853,6 +35634,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33872,6 +35654,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33891,6 +35674,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33910,6 +35694,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33929,6 +35714,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33948,6 +35734,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33967,6 +35754,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -33986,6 +35774,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34005,6 +35794,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34024,6 +35814,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34043,6 +35834,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34062,6 +35854,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34081,6 +35874,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34100,6 +35894,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34119,6 +35914,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34138,6 +35934,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34157,6 +35954,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34176,6 +35974,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34195,6 +35994,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34214,6 +36014,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34233,6 +36034,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34252,6 +36054,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34271,6 +36074,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34290,6 +36094,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34309,6 +36114,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34328,6 +36134,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34347,6 +36154,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34366,6 +36174,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34385,6 +36194,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34404,6 +36214,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34423,6 +36234,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34442,6 +36254,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34461,6 +36274,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34480,6 +36294,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34499,6 +36314,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34518,6 +36334,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34537,6 +36354,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34556,6 +36374,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34575,6 +36394,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34594,6 +36414,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34613,6 +36434,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34632,6 +36454,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34651,6 +36474,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34670,6 +36494,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34689,6 +36514,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34708,6 +36534,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34727,6 +36554,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34746,6 +36574,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34765,6 +36594,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34784,6 +36614,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34803,6 +36634,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34822,6 +36654,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34841,6 +36674,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34860,6 +36694,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34879,6 +36714,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34898,6 +36734,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34917,6 +36754,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34936,6 +36774,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34955,6 +36794,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34974,6 +36814,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -34993,6 +36834,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35012,6 +36854,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35031,6 +36874,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35050,6 +36894,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35069,6 +36914,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35088,6 +36934,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35107,6 +36954,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35126,6 +36974,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35145,6 +36994,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35164,6 +37014,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35183,6 +37034,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35202,6 +37054,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35221,6 +37074,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35240,6 +37094,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35259,6 +37114,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35278,6 +37134,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35297,6 +37154,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35316,6 +37174,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35335,6 +37194,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35354,6 +37214,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35373,6 +37234,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35392,6 +37254,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35411,6 +37274,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35430,6 +37294,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35449,6 +37314,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35468,6 +37334,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35487,6 +37354,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35506,6 +37374,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35525,6 +37394,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35544,6 +37414,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35563,6 +37434,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35582,6 +37454,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35601,6 +37474,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35620,6 +37494,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35639,6 +37514,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35658,6 +37534,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35677,6 +37554,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35696,6 +37574,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35715,6 +37594,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35734,6 +37614,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35753,6 +37634,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35772,6 +37654,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35791,6 +37674,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35810,6 +37694,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35829,6 +37714,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35848,6 +37734,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35867,6 +37754,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35886,6 +37774,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35905,6 +37794,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35924,6 +37814,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35943,6 +37834,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35962,6 +37854,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -35981,6 +37874,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36000,6 +37894,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36019,6 +37914,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36038,6 +37934,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36057,6 +37954,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36076,6 +37974,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36095,6 +37994,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36114,6 +38014,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36133,6 +38034,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36152,6 +38054,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36171,6 +38074,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36190,6 +38094,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36209,6 +38114,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36228,6 +38134,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36247,6 +38154,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36266,6 +38174,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36285,6 +38194,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36304,6 +38214,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36323,6 +38234,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36342,6 +38254,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36361,6 +38274,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36380,6 +38294,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36399,6 +38314,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36418,6 +38334,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36437,6 +38354,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36456,6 +38374,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36475,6 +38394,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36494,6 +38414,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36513,6 +38434,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36532,6 +38454,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36551,6 +38474,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36570,6 +38494,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36589,6 +38514,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36608,6 +38534,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36627,6 +38554,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36646,6 +38574,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36665,6 +38594,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36684,6 +38614,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36703,6 +38634,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36722,6 +38654,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36741,6 +38674,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36760,6 +38694,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36779,6 +38714,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36798,6 +38734,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36817,6 +38754,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36836,6 +38774,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36855,6 +38794,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36874,6 +38814,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36893,6 +38834,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36912,6 +38854,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36931,6 +38874,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36950,6 +38894,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36969,6 +38914,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -36988,6 +38934,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37007,6 +38954,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37026,6 +38974,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37045,6 +38994,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37064,6 +39014,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37083,6 +39034,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37102,6 +39054,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37121,6 +39074,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37140,6 +39094,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37159,6 +39114,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37178,6 +39134,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37197,6 +39154,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37216,6 +39174,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37235,6 +39194,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37254,6 +39214,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37273,6 +39234,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37292,6 +39254,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37311,6 +39274,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37330,6 +39294,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37349,6 +39314,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37368,6 +39334,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37387,6 +39354,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37406,6 +39374,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37425,6 +39394,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37444,6 +39414,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37463,6 +39434,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37482,6 +39454,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37501,6 +39474,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37520,6 +39494,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37539,6 +39514,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37558,6 +39534,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37577,6 +39554,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37596,6 +39574,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37615,6 +39594,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37634,6 +39614,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37653,6 +39634,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37672,6 +39654,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37691,6 +39674,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37710,6 +39694,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37729,6 +39714,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37748,6 +39734,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37767,6 +39754,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37786,6 +39774,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37805,6 +39794,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37824,6 +39814,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37843,6 +39834,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37862,6 +39854,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37881,6 +39874,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37900,6 +39894,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37919,6 +39914,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37938,6 +39934,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37957,6 +39954,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37976,6 +39974,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -37995,6 +39994,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38014,6 +40014,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38033,6 +40034,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38052,6 +40054,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38071,6 +40074,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38090,6 +40094,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38109,6 +40114,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38128,6 +40134,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38147,6 +40154,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38166,6 +40174,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38185,6 +40194,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38204,6 +40214,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38223,6 +40234,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38242,6 +40254,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38261,6 +40274,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38280,6 +40294,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38299,6 +40314,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38318,6 +40334,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38337,6 +40354,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38356,6 +40374,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38375,6 +40394,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38394,6 +40414,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38413,6 +40434,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38432,6 +40454,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38451,6 +40474,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38470,6 +40494,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38489,6 +40514,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38508,6 +40534,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38527,6 +40554,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38546,6 +40574,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38565,6 +40594,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38584,6 +40614,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38603,6 +40634,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38622,6 +40654,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38641,6 +40674,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38660,6 +40694,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38679,6 +40714,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38698,6 +40734,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38717,6 +40754,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38736,6 +40774,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38755,6 +40794,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38774,6 +40814,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38793,6 +40834,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38812,6 +40854,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38831,6 +40874,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38850,6 +40894,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38869,6 +40914,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38888,6 +40934,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38907,6 +40954,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38926,6 +40974,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38945,6 +40994,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38964,6 +41014,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -38983,6 +41034,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39002,6 +41054,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39021,6 +41074,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39040,6 +41094,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39059,6 +41114,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39078,6 +41134,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39097,6 +41154,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39116,6 +41174,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39135,6 +41194,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39154,6 +41214,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39173,6 +41234,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39192,6 +41254,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39211,6 +41274,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39230,6 +41294,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39249,6 +41314,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39268,6 +41334,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39287,6 +41354,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39306,6 +41374,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39325,6 +41394,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39344,6 +41414,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39363,6 +41434,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39382,6 +41454,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39401,6 +41474,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39420,6 +41494,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39439,6 +41514,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39458,6 +41534,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39477,6 +41554,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39496,6 +41574,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39515,6 +41594,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39534,6 +41614,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39553,6 +41634,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39572,6 +41654,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39591,6 +41674,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39610,6 +41694,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39629,6 +41714,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39648,6 +41734,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39667,6 +41754,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39686,6 +41774,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39705,6 +41794,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39724,6 +41814,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39743,6 +41834,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39762,6 +41854,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39781,6 +41874,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39800,6 +41894,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39819,6 +41914,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39838,6 +41934,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39857,6 +41954,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39876,6 +41974,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39895,6 +41994,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39914,6 +42014,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39933,6 +42034,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39952,6 +42054,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39971,6 +42074,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -39990,6 +42094,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40009,6 +42114,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40028,6 +42134,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40047,6 +42154,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40066,6 +42174,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40085,6 +42194,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40104,6 +42214,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40123,6 +42234,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40142,6 +42254,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40161,6 +42274,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40180,6 +42294,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40199,6 +42314,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40218,6 +42334,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40237,6 +42354,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40256,6 +42374,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40275,6 +42394,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40294,6 +42414,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40313,6 +42434,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40332,6 +42454,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40351,6 +42474,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40370,6 +42494,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40389,6 +42514,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40408,6 +42534,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40427,6 +42554,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40446,6 +42574,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40465,6 +42594,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40484,6 +42614,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40503,6 +42634,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40522,6 +42654,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40541,6 +42674,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40560,6 +42694,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40579,6 +42714,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40598,6 +42734,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40617,6 +42754,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40636,6 +42774,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40655,6 +42794,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40674,6 +42814,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40693,6 +42834,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40712,6 +42854,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40731,6 +42874,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40750,6 +42894,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40769,6 +42914,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40788,6 +42934,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40807,6 +42954,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40826,6 +42974,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40845,6 +42994,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40864,6 +43014,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40883,6 +43034,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40902,6 +43054,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40921,6 +43074,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40940,6 +43094,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40959,6 +43114,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40978,6 +43134,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -40997,6 +43154,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41016,6 +43174,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41035,6 +43194,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41054,6 +43214,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41073,6 +43234,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41092,6 +43254,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41111,6 +43274,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41130,6 +43294,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41149,6 +43314,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41168,6 +43334,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41187,6 +43354,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41206,6 +43374,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41225,6 +43394,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41244,6 +43414,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41263,6 +43434,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41282,6 +43454,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41301,6 +43474,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41320,6 +43494,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41339,6 +43514,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41358,6 +43534,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41377,6 +43554,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41396,6 +43574,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41415,6 +43594,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41434,6 +43614,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41453,6 +43634,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41472,6 +43654,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41491,6 +43674,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41510,6 +43694,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41529,6 +43714,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41548,6 +43734,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41567,6 +43754,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41586,6 +43774,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41605,6 +43794,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41624,6 +43814,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41643,6 +43834,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41662,6 +43854,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41681,6 +43874,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41700,6 +43894,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41719,6 +43914,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41738,6 +43934,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41757,6 +43954,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41776,6 +43974,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41795,6 +43994,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41814,6 +44014,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41833,6 +44034,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41852,6 +44054,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41871,6 +44074,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41890,6 +44094,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41909,6 +44114,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41928,6 +44134,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41947,6 +44154,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41966,6 +44174,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -41985,6 +44194,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42004,6 +44214,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42023,6 +44234,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42042,6 +44254,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42061,6 +44274,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42080,6 +44294,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42099,6 +44314,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42118,6 +44334,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42137,6 +44354,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42156,6 +44374,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42175,6 +44394,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42194,6 +44414,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42213,6 +44434,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42232,6 +44454,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42251,6 +44474,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42270,6 +44494,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42289,6 +44514,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42308,6 +44534,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42327,6 +44554,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42346,6 +44574,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42365,6 +44594,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42384,6 +44614,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42403,6 +44634,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42422,6 +44654,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42441,6 +44674,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42460,6 +44694,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42479,6 +44714,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42498,6 +44734,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42517,6 +44754,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42536,6 +44774,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42555,6 +44794,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42574,6 +44814,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42593,6 +44834,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42612,6 +44854,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42631,6 +44874,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42650,6 +44894,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42669,6 +44914,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42688,6 +44934,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42707,6 +44954,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42726,6 +44974,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42745,6 +44994,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42764,6 +45014,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42783,6 +45034,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42802,6 +45054,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42821,6 +45074,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42840,6 +45094,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42859,6 +45114,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42878,6 +45134,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42897,6 +45154,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42916,6 +45174,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42935,6 +45194,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42954,6 +45214,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42973,6 +45234,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -42992,6 +45254,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43011,6 +45274,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43030,6 +45294,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43049,6 +45314,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43068,6 +45334,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43087,6 +45354,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43106,6 +45374,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43125,6 +45394,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43144,6 +45414,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43163,6 +45434,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43182,6 +45454,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43201,6 +45474,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43220,6 +45494,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43239,6 +45514,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43258,6 +45534,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43277,6 +45554,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43296,6 +45574,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43315,6 +45594,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43334,6 +45614,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43353,6 +45634,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43372,6 +45654,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43391,6 +45674,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43410,6 +45694,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43429,6 +45714,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43448,6 +45734,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43467,6 +45754,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43486,6 +45774,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43505,6 +45794,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43524,6 +45814,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43543,6 +45834,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43562,6 +45854,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43581,6 +45874,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43600,6 +45894,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43619,6 +45914,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43638,6 +45934,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43657,6 +45954,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43676,6 +45974,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43695,6 +45994,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43714,6 +46014,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43733,6 +46034,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43752,6 +46054,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43771,6 +46074,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43790,6 +46094,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43809,6 +46114,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43828,6 +46134,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43847,6 +46154,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43866,6 +46174,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43885,6 +46194,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43904,6 +46214,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43923,6 +46234,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43942,6 +46254,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43961,6 +46274,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43980,6 +46294,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -43999,6 +46314,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44018,6 +46334,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44037,6 +46354,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44056,6 +46374,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44075,6 +46394,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44094,6 +46414,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44113,6 +46434,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44132,6 +46454,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44151,6 +46474,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44170,6 +46494,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44189,6 +46514,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44208,6 +46534,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44227,6 +46554,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44246,6 +46574,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44265,6 +46594,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44284,6 +46614,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44303,6 +46634,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44322,6 +46654,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44341,6 +46674,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44360,6 +46694,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44379,6 +46714,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44398,6 +46734,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44417,6 +46754,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44436,6 +46774,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44455,6 +46794,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44474,6 +46814,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44493,6 +46834,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44512,6 +46854,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44531,6 +46874,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44550,6 +46894,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44569,6 +46914,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44588,6 +46934,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44607,6 +46954,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44626,6 +46974,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44645,6 +46994,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44664,6 +47014,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44683,6 +47034,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44702,6 +47054,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44721,6 +47074,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44740,6 +47094,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44759,6 +47114,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44778,6 +47134,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44797,6 +47154,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44816,6 +47174,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44835,6 +47194,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44854,6 +47214,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44873,6 +47234,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44892,6 +47254,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44911,6 +47274,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44930,6 +47294,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44949,6 +47314,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44968,6 +47334,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -44987,6 +47354,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45006,6 +47374,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45025,6 +47394,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45044,6 +47414,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45063,6 +47434,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45082,6 +47454,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45101,6 +47474,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45120,6 +47494,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45139,6 +47514,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45158,6 +47534,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45177,6 +47554,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45196,6 +47574,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45215,6 +47594,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45234,6 +47614,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45253,6 +47634,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45272,6 +47654,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45291,6 +47674,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45310,6 +47694,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45329,6 +47714,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45348,6 +47734,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45367,6 +47754,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45386,6 +47774,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45405,6 +47794,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45424,6 +47814,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45443,6 +47834,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45462,6 +47854,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45481,6 +47874,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45500,6 +47894,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45519,6 +47914,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45538,6 +47934,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45557,6 +47954,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45576,6 +47974,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45595,6 +47994,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45614,6 +48014,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45633,6 +48034,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45652,6 +48054,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45671,6 +48074,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45690,6 +48094,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45709,6 +48114,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45728,6 +48134,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45747,6 +48154,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45766,6 +48174,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45785,6 +48194,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45804,6 +48214,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45823,6 +48234,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45842,6 +48254,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45861,6 +48274,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45880,6 +48294,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45899,6 +48314,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45918,6 +48334,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45937,6 +48354,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45956,6 +48374,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45975,6 +48394,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -45994,6 +48414,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46013,6 +48434,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46032,6 +48454,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46051,6 +48474,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46070,6 +48494,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46089,6 +48514,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46108,6 +48534,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46127,6 +48554,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46146,6 +48574,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46165,6 +48594,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46184,6 +48614,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46203,6 +48634,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46222,6 +48654,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46241,6 +48674,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46260,6 +48694,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46279,6 +48714,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46298,6 +48734,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46317,6 +48754,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46336,6 +48774,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46355,6 +48794,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46374,6 +48814,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46393,6 +48834,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46412,6 +48854,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46431,6 +48874,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46450,6 +48894,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46469,6 +48914,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46488,6 +48934,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46507,6 +48954,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46526,6 +48974,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46545,6 +48994,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46564,6 +49014,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46583,6 +49034,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46602,6 +49054,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46621,6 +49074,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46640,6 +49094,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46659,6 +49114,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46678,6 +49134,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46697,6 +49154,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46716,6 +49174,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46735,6 +49194,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46754,6 +49214,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46773,6 +49234,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46792,6 +49254,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46811,6 +49274,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46830,6 +49294,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46849,6 +49314,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46868,6 +49334,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46887,6 +49354,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46906,6 +49374,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46925,6 +49394,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46944,6 +49414,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46963,6 +49434,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -46982,6 +49454,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47001,6 +49474,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47020,6 +49494,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47039,6 +49514,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47058,6 +49534,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47077,6 +49554,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47096,6 +49574,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47115,6 +49594,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47134,6 +49614,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47153,6 +49634,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47172,6 +49654,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47191,6 +49674,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47210,6 +49694,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47229,6 +49714,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47248,6 +49734,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47267,6 +49754,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47286,6 +49774,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47305,6 +49794,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47324,6 +49814,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47343,6 +49834,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47362,6 +49854,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47381,6 +49874,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47400,6 +49894,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47419,6 +49914,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47438,6 +49934,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47457,6 +49954,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47476,6 +49974,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47495,6 +49994,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47514,6 +50014,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47533,6 +50034,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47552,6 +50054,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47571,6 +50074,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47590,6 +50094,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47609,6 +50114,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47628,6 +50134,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47647,6 +50154,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47666,6 +50174,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47685,6 +50194,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47704,6 +50214,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47723,6 +50234,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47742,6 +50254,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47761,6 +50274,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47780,6 +50294,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47799,6 +50314,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47818,6 +50334,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47837,6 +50354,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47856,6 +50374,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47875,6 +50394,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47894,6 +50414,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47913,6 +50434,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47932,6 +50454,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47951,6 +50474,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47970,6 +50494,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -47989,6 +50514,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48008,6 +50534,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48027,6 +50554,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48046,6 +50574,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48065,6 +50594,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48084,6 +50614,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48103,6 +50634,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48122,6 +50654,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48141,6 +50674,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48160,6 +50694,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48179,6 +50714,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48198,6 +50734,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48217,6 +50754,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48236,6 +50774,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48255,6 +50794,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48274,6 +50814,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48293,6 +50834,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48312,6 +50854,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48331,6 +50874,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48350,6 +50894,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48369,6 +50914,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48388,6 +50934,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48407,6 +50954,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48426,6 +50974,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48445,6 +50994,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48464,6 +51014,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48483,6 +51034,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48502,6 +51054,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48521,6 +51074,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48540,6 +51094,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48559,6 +51114,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48578,6 +51134,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48597,6 +51154,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48616,6 +51174,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48635,6 +51194,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48654,6 +51214,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48673,6 +51234,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48692,6 +51254,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48711,6 +51274,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48730,6 +51294,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48749,6 +51314,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48768,6 +51334,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48787,6 +51354,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48806,6 +51374,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48825,6 +51394,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48844,6 +51414,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48863,6 +51434,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48882,6 +51454,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48901,6 +51474,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48920,6 +51494,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48939,6 +51514,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48958,6 +51534,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48977,6 +51554,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -48996,6 +51574,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49015,6 +51594,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49034,6 +51614,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49053,6 +51634,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49072,6 +51654,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49091,6 +51674,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49110,6 +51694,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49129,6 +51714,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49148,6 +51734,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49167,6 +51754,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49186,6 +51774,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49205,6 +51794,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49224,6 +51814,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49243,6 +51834,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49262,6 +51854,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49281,6 +51874,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49300,6 +51894,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49319,6 +51914,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49338,6 +51934,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49357,6 +51954,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49376,6 +51974,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49395,6 +51994,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49414,6 +52014,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49433,6 +52034,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49452,6 +52054,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49471,6 +52074,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49490,6 +52094,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49509,6 +52114,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49528,6 +52134,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49547,6 +52154,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49566,6 +52174,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49585,6 +52194,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49604,6 +52214,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49623,6 +52234,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49642,6 +52254,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49661,6 +52274,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49680,6 +52294,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49699,6 +52314,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49718,6 +52334,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49737,6 +52354,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49756,6 +52374,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49775,6 +52394,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49794,6 +52414,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49813,6 +52434,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49832,6 +52454,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49851,6 +52474,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49870,6 +52494,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49889,6 +52514,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49908,6 +52534,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49927,6 +52554,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49946,6 +52574,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49965,6 +52594,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -49984,6 +52614,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50003,6 +52634,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50022,6 +52654,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50041,6 +52674,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50060,6 +52694,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50079,6 +52714,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50098,6 +52734,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50117,6 +52754,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50136,6 +52774,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50155,6 +52794,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50174,6 +52814,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50193,6 +52834,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50212,6 +52854,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50231,6 +52874,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50250,6 +52894,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50269,6 +52914,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50288,6 +52934,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50307,6 +52954,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50326,6 +52974,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50345,6 +52994,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50364,6 +53014,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50383,6 +53034,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50402,6 +53054,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50421,6 +53074,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50440,6 +53094,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50459,6 +53114,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50478,6 +53134,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50497,6 +53154,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50516,6 +53174,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50535,6 +53194,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50554,6 +53214,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50573,6 +53234,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50592,6 +53254,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50611,6 +53274,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50630,6 +53294,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50649,6 +53314,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50668,6 +53334,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50687,6 +53354,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50706,6 +53374,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50725,6 +53394,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50744,6 +53414,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50763,6 +53434,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50782,6 +53454,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50801,6 +53474,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50820,6 +53494,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50839,6 +53514,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50858,6 +53534,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50877,6 +53554,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50896,6 +53574,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50915,6 +53594,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50934,6 +53614,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50953,6 +53634,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50972,6 +53654,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -50991,6 +53674,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51010,6 +53694,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51029,6 +53714,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51048,6 +53734,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51067,6 +53754,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51086,6 +53774,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51105,6 +53794,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51124,6 +53814,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51143,6 +53834,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51162,6 +53854,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51181,6 +53874,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51200,6 +53894,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51219,6 +53914,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51238,6 +53934,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51257,6 +53954,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51276,6 +53974,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51295,6 +53994,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51314,6 +54014,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51333,6 +54034,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51352,6 +54054,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51371,6 +54074,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51390,6 +54094,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51409,6 +54114,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51428,6 +54134,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51447,6 +54154,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51466,6 +54174,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51485,6 +54194,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51504,6 +54214,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51523,6 +54234,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51542,6 +54254,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51561,6 +54274,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51580,6 +54294,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51599,6 +54314,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51618,6 +54334,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51637,6 +54354,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51656,6 +54374,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51675,6 +54394,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51694,6 +54414,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51713,6 +54434,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51732,6 +54454,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51751,6 +54474,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51770,6 +54494,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51789,6 +54514,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51808,6 +54534,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51827,6 +54554,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51846,6 +54574,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51865,6 +54594,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51884,6 +54614,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51903,6 +54634,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51922,6 +54654,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51941,6 +54674,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51960,6 +54694,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51979,6 +54714,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -51998,6 +54734,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52017,6 +54754,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52036,6 +54774,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52055,6 +54794,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52074,6 +54814,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52093,6 +54834,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52112,6 +54854,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52131,6 +54874,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52150,6 +54894,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52169,6 +54914,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52188,6 +54934,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52207,6 +54954,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52226,6 +54974,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52245,6 +54994,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52264,6 +55014,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52283,6 +55034,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52302,6 +55054,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52321,6 +55074,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52340,6 +55094,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52359,6 +55114,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52378,6 +55134,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52397,6 +55154,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52416,6 +55174,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52435,6 +55194,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52454,6 +55214,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52473,6 +55234,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52492,6 +55254,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52511,6 +55274,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52530,6 +55294,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52549,6 +55314,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52568,6 +55334,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52587,6 +55354,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52606,6 +55374,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52625,6 +55394,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52644,6 +55414,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52663,6 +55434,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52682,6 +55454,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52701,6 +55474,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52720,6 +55494,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52739,6 +55514,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52758,6 +55534,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52777,6 +55554,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52796,6 +55574,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52815,6 +55594,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52834,6 +55614,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52853,6 +55634,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52872,6 +55654,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52891,6 +55674,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52910,6 +55694,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52929,6 +55714,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52948,6 +55734,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52967,6 +55754,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -52986,6 +55774,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53005,6 +55794,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53024,6 +55814,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53043,6 +55834,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53062,6 +55854,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53081,6 +55874,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53100,6 +55894,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53119,6 +55914,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53138,6 +55934,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53157,6 +55954,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53176,6 +55974,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53195,6 +55994,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53214,6 +56014,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53233,6 +56034,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53252,6 +56054,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53271,6 +56074,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53290,6 +56094,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53309,6 +56114,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53328,6 +56134,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53347,6 +56154,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53366,6 +56174,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53385,6 +56194,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53404,6 +56214,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53423,6 +56234,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53442,6 +56254,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53461,6 +56274,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53480,6 +56294,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53499,6 +56314,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53518,6 +56334,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53537,6 +56354,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53556,6 +56374,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53575,6 +56394,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53594,6 +56414,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53613,6 +56434,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53632,6 +56454,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53651,6 +56474,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53670,6 +56494,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53689,6 +56514,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53708,6 +56534,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53727,6 +56554,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53746,6 +56574,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53765,6 +56594,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53784,6 +56614,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53803,6 +56634,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53822,6 +56654,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53841,6 +56674,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53860,6 +56694,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53879,6 +56714,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53898,6 +56734,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53917,6 +56754,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53936,6 +56774,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53955,6 +56794,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53974,6 +56814,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -53993,6 +56834,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54012,6 +56854,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54031,6 +56874,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54050,6 +56894,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54069,6 +56914,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54088,6 +56934,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54107,6 +56954,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54126,6 +56974,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54145,6 +56994,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54164,6 +57014,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54183,6 +57034,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54202,6 +57054,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54221,6 +57074,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54240,6 +57094,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54259,6 +57114,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54278,6 +57134,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54297,6 +57154,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54316,6 +57174,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54335,6 +57194,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54354,6 +57214,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54373,6 +57234,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54392,6 +57254,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54411,6 +57274,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54430,6 +57294,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54449,6 +57314,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54468,6 +57334,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54487,6 +57354,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54506,6 +57374,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54525,6 +57394,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54544,6 +57414,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54563,6 +57434,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54582,6 +57454,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54601,6 +57474,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54620,6 +57494,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54639,6 +57514,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54658,6 +57534,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54677,6 +57554,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54696,6 +57574,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54715,6 +57594,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54734,6 +57614,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54753,6 +57634,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54772,6 +57654,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54791,6 +57674,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54810,6 +57694,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54829,6 +57714,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54848,6 +57734,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54867,6 +57754,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54886,6 +57774,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54905,6 +57794,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54924,6 +57814,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54943,6 +57834,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54962,6 +57854,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -54981,6 +57874,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55000,6 +57894,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55019,6 +57914,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55038,6 +57934,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55057,6 +57954,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55076,6 +57974,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55095,6 +57994,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55114,6 +58014,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55133,6 +58034,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55152,6 +58054,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55171,6 +58074,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55190,6 +58094,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55209,6 +58114,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55228,6 +58134,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55247,6 +58154,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55266,6 +58174,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55285,6 +58194,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55304,6 +58214,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55323,6 +58234,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55342,6 +58254,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55361,6 +58274,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55380,6 +58294,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55399,6 +58314,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55418,6 +58334,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55437,6 +58354,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55456,6 +58374,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55475,6 +58394,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55494,6 +58414,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55513,6 +58434,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55532,6 +58454,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55551,6 +58474,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55570,6 +58494,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55589,6 +58514,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55608,6 +58534,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55627,6 +58554,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55646,6 +58574,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55665,6 +58594,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55684,6 +58614,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55703,6 +58634,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55722,6 +58654,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55741,6 +58674,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55760,6 +58694,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55779,6 +58714,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55798,6 +58734,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55817,6 +58754,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55836,6 +58774,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55855,6 +58794,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55874,6 +58814,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55893,6 +58834,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55912,6 +58854,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55931,6 +58874,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55950,6 +58894,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55969,6 +58914,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -55988,6 +58934,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56007,6 +58954,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56026,6 +58974,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56045,6 +58994,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56064,6 +59014,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56083,6 +59034,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56102,6 +59054,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56121,6 +59074,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56140,6 +59094,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56159,6 +59114,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56178,6 +59134,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56197,6 +59154,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56216,6 +59174,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56235,6 +59194,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56254,6 +59214,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56273,6 +59234,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56292,6 +59254,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56311,6 +59274,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56330,6 +59294,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56349,6 +59314,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56368,6 +59334,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56387,6 +59354,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56406,6 +59374,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56425,6 +59394,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56444,6 +59414,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56463,6 +59434,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56482,6 +59454,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56501,6 +59474,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56520,6 +59494,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56539,6 +59514,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56558,6 +59534,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56577,6 +59554,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56596,6 +59574,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56615,6 +59594,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56634,6 +59614,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56653,6 +59634,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56672,6 +59654,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56691,6 +59674,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56710,6 +59694,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56729,6 +59714,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56748,6 +59734,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56767,6 +59754,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56786,6 +59774,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56805,6 +59794,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56824,6 +59814,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56843,6 +59834,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56862,6 +59854,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56881,6 +59874,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56900,6 +59894,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56919,6 +59914,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56938,6 +59934,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56957,6 +59954,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56976,6 +59974,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -56995,6 +59994,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57014,6 +60014,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57033,6 +60034,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57052,6 +60054,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57071,6 +60074,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57090,6 +60094,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57109,6 +60114,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57128,6 +60134,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57147,6 +60154,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57166,6 +60174,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57185,6 +60194,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57204,6 +60214,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57223,6 +60234,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57242,6 +60254,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57261,6 +60274,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57280,6 +60294,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57299,6 +60314,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57318,6 +60334,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57337,6 +60354,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57356,6 +60374,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57375,6 +60394,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57394,6 +60414,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57413,6 +60434,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57432,6 +60454,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57451,6 +60474,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57470,6 +60494,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57489,6 +60514,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57508,6 +60534,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57527,6 +60554,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57546,6 +60574,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57565,6 +60594,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57584,6 +60614,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57603,6 +60634,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57622,6 +60654,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57641,6 +60674,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57660,6 +60694,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57679,6 +60714,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57698,6 +60734,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57717,6 +60754,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57736,6 +60774,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57755,6 +60794,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57774,6 +60814,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57793,6 +60834,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57812,6 +60854,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57831,6 +60874,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57850,6 +60894,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57869,6 +60914,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57888,6 +60934,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57907,6 +60954,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57926,6 +60974,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57945,6 +60994,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57964,6 +61014,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -57983,6 +61034,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58002,6 +61054,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58021,6 +61074,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58040,6 +61094,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58059,6 +61114,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58078,6 +61134,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58097,6 +61154,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58116,6 +61174,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58135,6 +61194,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58154,6 +61214,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58173,6 +61234,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58192,6 +61254,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58211,6 +61274,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58230,6 +61294,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58249,6 +61314,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58268,6 +61334,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58287,6 +61354,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58306,6 +61374,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58325,6 +61394,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58344,6 +61414,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58363,6 +61434,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58382,6 +61454,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58401,6 +61474,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58420,6 +61494,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58439,6 +61514,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58458,6 +61534,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58477,6 +61554,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58496,6 +61574,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58515,6 +61594,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58534,6 +61614,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58553,6 +61634,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58572,6 +61654,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58591,6 +61674,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58610,6 +61694,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58629,6 +61714,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58648,6 +61734,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58667,6 +61754,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58686,6 +61774,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58705,6 +61794,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58724,6 +61814,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58743,6 +61834,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58762,6 +61854,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58781,6 +61874,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58800,6 +61894,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58819,6 +61914,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58838,6 +61934,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58857,6 +61954,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58876,6 +61974,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58895,6 +61994,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58914,6 +62014,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58933,6 +62034,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58952,6 +62054,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58971,6 +62074,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -58990,6 +62094,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59009,6 +62114,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59028,6 +62134,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59047,6 +62154,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59066,6 +62174,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59085,6 +62194,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59104,6 +62214,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59123,6 +62234,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59142,6 +62254,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59161,6 +62274,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59180,6 +62294,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59199,6 +62314,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59218,6 +62334,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59237,6 +62354,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59256,6 +62374,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59275,6 +62394,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59294,6 +62414,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59313,6 +62434,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59332,6 +62454,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59351,6 +62474,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59370,6 +62494,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59389,6 +62514,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59408,6 +62534,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59427,6 +62554,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59446,6 +62574,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59465,6 +62594,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59484,6 +62614,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59503,6 +62634,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59522,6 +62654,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59541,6 +62674,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59560,6 +62694,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59579,6 +62714,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59598,6 +62734,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59617,6 +62754,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59636,6 +62774,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59655,6 +62794,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59674,6 +62814,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59693,6 +62834,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59712,6 +62854,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59731,6 +62874,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59750,6 +62894,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59769,6 +62914,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59788,6 +62934,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59807,6 +62954,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59826,6 +62974,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59845,6 +62994,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59864,6 +63014,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59883,6 +63034,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59902,6 +63054,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59921,6 +63074,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59940,6 +63094,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59959,6 +63114,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59978,6 +63134,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -59997,6 +63154,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60016,6 +63174,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60035,6 +63194,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60054,6 +63214,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60073,6 +63234,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60092,6 +63254,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60111,6 +63274,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60130,6 +63294,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60149,6 +63314,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60168,6 +63334,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60187,6 +63354,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60206,6 +63374,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60225,6 +63394,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60244,6 +63414,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60263,6 +63434,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60282,6 +63454,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60301,6 +63474,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60320,6 +63494,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60339,6 +63514,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60358,6 +63534,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60377,6 +63554,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60396,6 +63574,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60415,6 +63594,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60434,6 +63614,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60453,6 +63634,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60472,6 +63654,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60491,6 +63674,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60510,6 +63694,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60529,6 +63714,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60548,6 +63734,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60567,6 +63754,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60586,6 +63774,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60605,6 +63794,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60624,6 +63814,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60643,6 +63834,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60662,6 +63854,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60681,6 +63874,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60700,6 +63894,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60719,6 +63914,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60738,6 +63934,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60757,6 +63954,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60776,6 +63974,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60795,6 +63994,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60814,6 +64014,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60833,6 +64034,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60852,6 +64054,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60871,6 +64074,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60890,6 +64094,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60909,6 +64114,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60928,6 +64134,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60947,6 +64154,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60966,6 +64174,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -60985,6 +64194,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61004,6 +64214,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61023,6 +64234,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61042,6 +64254,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61061,6 +64274,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61080,6 +64294,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61099,6 +64314,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61118,6 +64334,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61137,6 +64354,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61156,6 +64374,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61175,6 +64394,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61194,6 +64414,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61213,6 +64434,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61232,6 +64454,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61251,6 +64474,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61270,6 +64494,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61289,6 +64514,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61308,6 +64534,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61327,6 +64554,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61346,6 +64574,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61365,6 +64594,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61384,6 +64614,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61403,6 +64634,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61422,6 +64654,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61441,6 +64674,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61460,6 +64694,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61479,6 +64714,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61498,6 +64734,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61517,6 +64754,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61536,6 +64774,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61555,6 +64794,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61574,6 +64814,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61593,6 +64834,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61612,6 +64854,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61631,6 +64874,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61650,6 +64894,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61669,6 +64914,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61688,6 +64934,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61707,6 +64954,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61726,6 +64974,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61745,6 +64994,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61764,6 +65014,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61783,6 +65034,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61802,6 +65054,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61821,6 +65074,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61840,6 +65094,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61859,6 +65114,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61878,6 +65134,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61897,6 +65154,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61916,6 +65174,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61935,6 +65194,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61954,6 +65214,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61973,6 +65234,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -61992,6 +65254,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62011,6 +65274,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62030,6 +65294,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62049,6 +65314,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62068,6 +65334,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62087,6 +65354,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62106,6 +65374,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62125,6 +65394,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62144,6 +65414,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62163,6 +65434,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62182,6 +65454,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62201,6 +65474,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62220,6 +65494,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62239,6 +65514,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62258,6 +65534,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62277,6 +65554,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62296,6 +65574,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62315,6 +65594,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62334,6 +65614,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62353,6 +65634,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62372,6 +65654,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62391,6 +65674,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62410,6 +65694,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62429,6 +65714,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62448,6 +65734,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62467,6 +65754,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62486,6 +65774,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62505,6 +65794,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62524,6 +65814,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62543,6 +65834,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62562,6 +65854,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62581,6 +65874,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62600,6 +65894,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62619,6 +65914,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62638,6 +65934,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62657,6 +65954,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62676,6 +65974,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62695,6 +65994,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62714,6 +66014,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62733,6 +66034,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62752,6 +66054,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62771,6 +66074,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62790,6 +66094,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62809,6 +66114,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62828,6 +66134,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62847,6 +66154,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62866,6 +66174,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62885,6 +66194,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62904,6 +66214,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62923,6 +66234,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62942,6 +66254,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62961,6 +66274,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62980,6 +66294,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -62999,6 +66314,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63018,6 +66334,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63037,6 +66354,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63056,6 +66374,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63075,6 +66394,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63094,6 +66414,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63113,6 +66434,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63132,6 +66454,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63151,6 +66474,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63170,6 +66494,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63189,6 +66514,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63208,6 +66534,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63227,6 +66554,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63246,6 +66574,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63265,6 +66594,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63284,6 +66614,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63303,6 +66634,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63322,6 +66654,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63341,6 +66674,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63360,6 +66694,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63379,6 +66714,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63398,6 +66734,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63417,6 +66754,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63436,6 +66774,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63455,6 +66794,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63474,6 +66814,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63493,6 +66834,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63512,6 +66854,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63531,6 +66874,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63550,6 +66894,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63569,6 +66914,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63588,6 +66934,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63607,6 +66954,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63626,6 +66974,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63645,6 +66994,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63664,6 +67014,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63683,6 +67034,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63702,6 +67054,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63721,6 +67074,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63740,6 +67094,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63759,6 +67114,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63778,6 +67134,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63797,6 +67154,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63816,6 +67174,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63835,6 +67194,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63854,6 +67214,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63873,6 +67234,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63892,6 +67254,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63911,6 +67274,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63930,6 +67294,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63949,6 +67314,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63968,6 +67334,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -63987,6 +67354,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64006,6 +67374,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64025,6 +67394,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64044,6 +67414,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64063,6 +67434,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64082,6 +67454,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64101,6 +67474,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64120,6 +67494,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64139,6 +67514,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64158,6 +67534,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64177,6 +67554,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64196,6 +67574,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64215,6 +67594,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64234,6 +67614,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64253,6 +67634,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64272,6 +67654,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64291,6 +67674,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64310,6 +67694,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64329,6 +67714,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64348,6 +67734,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64367,6 +67754,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64386,6 +67774,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64405,6 +67794,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64424,6 +67814,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64443,6 +67834,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64462,6 +67854,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64481,6 +67874,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64500,6 +67894,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64519,6 +67914,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64538,6 +67934,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64557,6 +67954,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64576,6 +67974,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64595,6 +67994,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64614,6 +68014,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64633,6 +68034,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64652,6 +68054,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64671,6 +68074,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64690,6 +68094,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64709,6 +68114,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64728,6 +68134,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64747,6 +68154,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64766,6 +68174,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64785,6 +68194,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64804,6 +68214,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64823,6 +68234,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64842,6 +68254,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64861,6 +68274,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64880,6 +68294,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64899,6 +68314,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64918,6 +68334,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64937,6 +68354,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64956,6 +68374,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64975,6 +68394,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -64994,6 +68414,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65013,6 +68434,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65032,6 +68454,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65051,6 +68474,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65070,6 +68494,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65089,6 +68514,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65108,6 +68534,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65127,6 +68554,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65146,6 +68574,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65165,6 +68594,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65184,6 +68614,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65203,6 +68634,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65222,6 +68654,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65241,6 +68674,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65260,6 +68694,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65279,6 +68714,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65298,6 +68734,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65317,6 +68754,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65336,6 +68774,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65355,6 +68794,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65374,6 +68814,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65393,6 +68834,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65412,6 +68854,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65431,6 +68874,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65450,6 +68894,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65469,6 +68914,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65488,6 +68934,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65507,6 +68954,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65526,6 +68974,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65545,6 +68994,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65564,6 +69014,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65583,6 +69034,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65602,6 +69054,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65621,6 +69074,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65640,6 +69094,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65659,6 +69114,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65678,6 +69134,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65697,6 +69154,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65716,6 +69174,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65735,6 +69194,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65754,6 +69214,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65773,6 +69234,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65792,6 +69254,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65811,6 +69274,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65830,6 +69294,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65849,6 +69314,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65868,6 +69334,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65887,6 +69354,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65906,6 +69374,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65925,6 +69394,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65944,6 +69414,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65963,6 +69434,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -65982,6 +69454,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66001,6 +69474,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66020,6 +69494,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66039,6 +69514,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66058,6 +69534,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66077,6 +69554,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66096,6 +69574,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66115,6 +69594,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66134,6 +69614,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66153,6 +69634,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66172,6 +69654,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66191,6 +69674,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66210,6 +69694,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66229,6 +69714,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66248,6 +69734,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66267,6 +69754,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66286,6 +69774,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66305,6 +69794,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66324,6 +69814,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66343,6 +69834,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66362,6 +69854,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66381,6 +69874,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66400,6 +69894,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66419,6 +69914,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66438,6 +69934,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66457,6 +69954,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66476,6 +69974,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66495,6 +69994,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66514,6 +70014,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66533,6 +70034,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66552,6 +70054,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66571,6 +70074,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66590,6 +70094,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66609,6 +70114,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66628,6 +70134,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66647,6 +70154,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66666,6 +70174,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66685,6 +70194,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66812,6 +70322,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66831,6 +70342,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66850,6 +70362,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66869,6 +70382,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66888,6 +70402,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66907,6 +70422,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66926,6 +70442,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66945,6 +70462,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66964,6 +70482,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -66983,6 +70502,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67002,6 +70522,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67021,6 +70542,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67040,6 +70562,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67059,6 +70582,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67078,6 +70602,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67097,6 +70622,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67116,6 +70642,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67135,6 +70662,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67154,6 +70682,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67173,6 +70702,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67192,6 +70722,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67211,6 +70742,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67230,6 +70762,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67249,6 +70782,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67268,6 +70802,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67287,6 +70822,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67306,6 +70842,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67325,6 +70862,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67344,6 +70882,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67363,6 +70902,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67382,6 +70922,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67401,6 +70942,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67420,6 +70962,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67439,6 +70982,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67458,6 +71002,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67477,6 +71022,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67496,6 +71042,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67515,6 +71062,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67534,6 +71082,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67553,6 +71102,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67572,6 +71122,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67591,6 +71142,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67610,6 +71162,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67629,6 +71182,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67648,6 +71202,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67667,6 +71222,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67686,6 +71242,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67705,6 +71262,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67724,6 +71282,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67743,6 +71302,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67762,6 +71322,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67781,6 +71342,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67800,6 +71362,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67819,6 +71382,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67838,6 +71402,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67857,6 +71422,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67876,6 +71442,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67895,6 +71462,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67914,6 +71482,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67933,6 +71502,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67952,6 +71522,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67971,6 +71542,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -67990,6 +71562,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68009,6 +71582,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68028,6 +71602,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68047,6 +71622,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68066,6 +71642,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68085,6 +71662,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68104,6 +71682,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68123,6 +71702,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68142,6 +71722,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68161,6 +71742,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68180,6 +71762,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68199,6 +71782,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68218,6 +71802,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68237,6 +71822,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68256,6 +71842,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68275,6 +71862,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68294,6 +71882,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68313,6 +71902,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68332,6 +71922,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68351,6 +71942,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68370,6 +71962,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68389,6 +71982,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68408,6 +72002,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68427,6 +72022,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68446,6 +72042,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68465,6 +72062,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68484,6 +72082,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68503,6 +72102,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68522,6 +72122,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68541,6 +72142,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68560,6 +72162,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68579,6 +72182,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68598,6 +72202,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68617,6 +72222,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68636,6 +72242,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68655,6 +72262,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68674,6 +72282,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68693,6 +72302,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68712,6 +72322,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68731,6 +72342,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68750,6 +72362,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68769,6 +72382,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68788,6 +72402,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68807,6 +72422,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68826,6 +72442,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68845,6 +72462,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68864,6 +72482,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68883,6 +72502,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68902,6 +72522,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68921,6 +72542,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68940,6 +72562,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68959,6 +72582,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68978,6 +72602,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -68997,6 +72622,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69016,6 +72642,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69035,6 +72662,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69054,6 +72682,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69073,6 +72702,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69092,6 +72722,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69111,6 +72742,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69130,6 +72762,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69149,6 +72782,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69168,6 +72802,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69187,6 +72822,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69206,6 +72842,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69225,6 +72862,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69244,6 +72882,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69263,6 +72902,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69282,6 +72922,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69301,6 +72942,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69320,6 +72962,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69339,6 +72982,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69358,6 +73002,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69377,6 +73022,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69396,6 +73042,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69415,6 +73062,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69434,6 +73082,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69453,6 +73102,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69472,6 +73122,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69491,6 +73142,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69510,6 +73162,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69529,6 +73182,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69656,6 +73310,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69675,6 +73330,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69694,6 +73350,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69713,6 +73370,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69732,6 +73390,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -69751,6 +73410,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101654,6 +105314,7 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101673,6 +105334,7 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101692,6 +105354,7 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101711,6 +105374,7 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101730,6 +105394,7 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101749,6 +105414,7 @@
 		"songID": 901,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101768,6 +105434,7 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101787,6 +105454,7 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101806,6 +105474,7 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101825,6 +105494,7 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101844,6 +105514,7 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101863,6 +105534,7 @@
 		"songID": 902,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101882,6 +105554,7 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101901,6 +105574,7 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101920,6 +105594,7 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101939,6 +105614,7 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101958,6 +105634,7 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101977,6 +105654,7 @@
 		"songID": 903,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -101996,6 +105674,7 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102015,6 +105694,7 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102034,6 +105714,7 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102053,6 +105734,7 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102072,6 +105754,7 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102091,6 +105774,7 @@
 		"songID": 904,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102110,6 +105794,7 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102129,6 +105814,7 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102148,6 +105834,7 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102167,6 +105854,7 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102186,6 +105874,7 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102205,6 +105894,7 @@
 		"songID": 905,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102224,6 +105914,7 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102243,6 +105934,7 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102262,6 +105954,7 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102281,6 +105974,7 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102300,6 +105994,7 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102319,6 +106014,7 @@
 		"songID": 906,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102338,6 +106034,7 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102357,6 +106054,7 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102376,6 +106074,7 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102395,6 +106094,7 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102414,6 +106114,7 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102433,6 +106134,7 @@
 		"songID": 907,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102452,6 +106154,7 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102471,6 +106174,7 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102490,6 +106194,7 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102509,6 +106214,7 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102528,6 +106234,7 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102547,6 +106254,7 @@
 		"songID": 908,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102566,6 +106274,7 @@
 		"songID": 909,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102584,6 +106293,7 @@
 		"songID": 909,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102602,6 +106312,7 @@
 		"songID": 909,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102620,6 +106331,7 @@
 		"songID": 909,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102638,6 +106350,7 @@
 		"songID": 909,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102656,6 +106369,7 @@
 		"songID": 909,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102674,6 +106388,7 @@
 		"songID": 910,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102692,6 +106407,7 @@
 		"songID": 910,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102710,6 +106426,7 @@
 		"songID": 910,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102728,6 +106445,7 @@
 		"songID": 910,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102746,6 +106464,7 @@
 		"songID": 910,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102764,6 +106483,7 @@
 		"songID": 910,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -102782,6 +106502,7 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102801,6 +106522,7 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102820,6 +106542,7 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102839,6 +106562,7 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102858,6 +106582,7 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102877,6 +106602,7 @@
 		"songID": 911,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102896,6 +106622,7 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102915,6 +106642,7 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102934,6 +106662,7 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102953,6 +106682,7 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102972,6 +106702,7 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -102991,6 +106722,7 @@
 		"songID": 912,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103010,6 +106742,7 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103029,6 +106762,7 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103048,6 +106782,7 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103067,6 +106802,7 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103086,6 +106822,7 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103105,6 +106842,7 @@
 		"songID": 913,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103124,6 +106862,7 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103143,6 +106882,7 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103162,6 +106902,7 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103181,6 +106922,7 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103200,6 +106942,7 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103219,6 +106962,7 @@
 		"songID": 914,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103238,6 +106982,7 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103257,6 +107002,7 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103276,6 +107022,7 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103295,6 +107042,7 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103314,6 +107062,7 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103333,6 +107082,7 @@
 		"songID": 915,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103352,6 +107102,7 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103371,6 +107122,7 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103390,6 +107142,7 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103409,6 +107162,7 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103428,6 +107182,7 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103447,6 +107202,7 @@
 		"songID": 916,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103466,6 +107222,7 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103485,6 +107242,7 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103504,6 +107262,7 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103523,6 +107282,7 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103542,6 +107302,7 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103561,6 +107322,7 @@
 		"songID": 917,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103580,6 +107342,7 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103599,6 +107362,7 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103618,6 +107382,7 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103637,6 +107402,7 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103656,6 +107422,7 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103675,6 +107442,7 @@
 		"songID": 918,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103694,6 +107462,7 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103713,6 +107482,7 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103732,6 +107502,7 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103751,6 +107522,7 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103770,6 +107542,7 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103789,6 +107562,7 @@
 		"songID": 919,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103808,6 +107582,7 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103827,6 +107602,7 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103846,6 +107622,7 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103865,6 +107642,7 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103884,6 +107662,7 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103903,6 +107682,7 @@
 		"songID": 920,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103922,6 +107702,7 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103941,6 +107722,7 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103960,6 +107742,7 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103979,6 +107762,7 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -103998,6 +107782,7 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104017,6 +107802,7 @@
 		"songID": 921,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104036,6 +107822,7 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104055,6 +107842,7 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104074,6 +107862,7 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104093,6 +107882,7 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104112,6 +107902,7 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104131,6 +107922,7 @@
 		"songID": 922,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104150,6 +107942,7 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104169,6 +107962,7 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104188,6 +107982,7 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104207,6 +108002,7 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104226,6 +108022,7 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104245,6 +108042,7 @@
 		"songID": 923,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104264,6 +108062,7 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104283,6 +108082,7 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104302,6 +108102,7 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104321,6 +108122,7 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104340,6 +108142,7 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104359,6 +108162,7 @@
 		"songID": 924,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104378,6 +108182,7 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104397,6 +108202,7 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104416,6 +108222,7 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104435,6 +108242,7 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104454,6 +108262,7 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104473,6 +108282,7 @@
 		"songID": 925,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104492,6 +108302,7 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104511,6 +108322,7 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104530,6 +108342,7 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104549,6 +108362,7 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104568,6 +108382,7 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104587,6 +108402,7 @@
 		"songID": 926,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104606,6 +108422,7 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104625,6 +108442,7 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104644,6 +108462,7 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104663,6 +108482,7 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104682,6 +108502,7 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104701,6 +108522,7 @@
 		"songID": 927,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104720,6 +108542,7 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104739,6 +108562,7 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104758,6 +108582,7 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104777,6 +108602,7 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104796,6 +108622,7 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104815,6 +108642,7 @@
 		"songID": 928,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104834,6 +108662,7 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104853,6 +108682,7 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104872,6 +108702,7 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104891,6 +108722,7 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104910,6 +108742,7 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104929,6 +108762,7 @@
 		"songID": 929,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104948,6 +108782,7 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104967,6 +108802,7 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -104986,6 +108822,7 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105005,6 +108842,7 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105024,6 +108862,7 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105043,6 +108882,7 @@
 		"songID": 930,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105062,6 +108902,7 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105081,6 +108922,7 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105100,6 +108942,7 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105119,6 +108962,7 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105138,6 +108982,7 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105157,6 +109002,7 @@
 		"songID": 931,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105176,6 +109022,7 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105195,6 +109042,7 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105214,6 +109062,7 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105233,6 +109082,7 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105252,6 +109102,7 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105271,6 +109122,7 @@
 		"songID": 932,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105290,6 +109142,7 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105309,6 +109162,7 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105328,6 +109182,7 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105347,6 +109202,7 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105366,6 +109222,7 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105385,6 +109242,7 @@
 		"songID": 933,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105404,6 +109262,7 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105423,6 +109282,7 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105442,6 +109302,7 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105461,6 +109322,7 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105480,6 +109342,7 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105499,6 +109362,7 @@
 		"songID": 934,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105518,6 +109382,7 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105537,6 +109402,7 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105556,6 +109422,7 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105575,6 +109442,7 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105594,6 +109462,7 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105613,6 +109482,7 @@
 		"songID": 935,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105632,6 +109502,7 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105651,6 +109522,7 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105670,6 +109542,7 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105689,6 +109562,7 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105708,6 +109582,7 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105727,6 +109602,7 @@
 		"songID": 936,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -105746,6 +109622,7 @@
 		"songID": 937,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105764,6 +109641,7 @@
 		"songID": 937,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105782,6 +109660,7 @@
 		"songID": 937,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105800,6 +109679,7 @@
 		"songID": 937,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105818,6 +109698,7 @@
 		"songID": 937,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105836,6 +109717,7 @@
 		"songID": 937,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105854,6 +109736,7 @@
 		"songID": 938,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105872,6 +109755,7 @@
 		"songID": 938,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105890,6 +109774,7 @@
 		"songID": 938,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105908,6 +109793,7 @@
 		"songID": 938,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105926,6 +109812,7 @@
 		"songID": 938,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105944,6 +109831,7 @@
 		"songID": 938,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105962,6 +109850,7 @@
 		"songID": 939,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105980,6 +109869,7 @@
 		"songID": 939,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -105998,6 +109888,7 @@
 		"songID": 939,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106016,6 +109907,7 @@
 		"songID": 939,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106034,6 +109926,7 @@
 		"songID": 939,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106052,6 +109945,7 @@
 		"songID": 939,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106070,6 +109964,7 @@
 		"songID": 940,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106088,6 +109983,7 @@
 		"songID": 940,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106106,6 +110002,7 @@
 		"songID": 940,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106124,6 +110021,7 @@
 		"songID": 940,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106142,6 +110040,7 @@
 		"songID": 940,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106160,6 +110059,7 @@
 		"songID": 940,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106178,6 +110078,7 @@
 		"songID": 941,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106196,6 +110097,7 @@
 		"songID": 941,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106214,6 +110116,7 @@
 		"songID": 941,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106232,6 +110135,7 @@
 		"songID": 941,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106250,6 +110154,7 @@
 		"songID": 941,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106268,6 +110173,7 @@
 		"songID": 941,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106286,6 +110192,7 @@
 		"songID": 942,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106304,6 +110211,7 @@
 		"songID": 942,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106322,6 +110230,7 @@
 		"songID": 942,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106340,6 +110249,7 @@
 		"songID": 942,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106358,6 +110268,7 @@
 		"songID": 942,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106376,6 +110287,7 @@
 		"songID": 942,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106394,6 +110306,7 @@
 		"songID": 943,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106412,6 +110325,7 @@
 		"songID": 943,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106430,6 +110344,7 @@
 		"songID": 943,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106448,6 +110363,7 @@
 		"songID": 943,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106466,6 +110382,7 @@
 		"songID": 943,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106484,6 +110401,7 @@
 		"songID": 943,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106502,6 +110420,7 @@
 		"songID": 944,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106520,6 +110439,7 @@
 		"songID": 944,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106538,6 +110458,7 @@
 		"songID": 944,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106556,6 +110477,7 @@
 		"songID": 944,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106574,6 +110496,7 @@
 		"songID": 944,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106592,6 +110515,7 @@
 		"songID": 944,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106610,6 +110534,7 @@
 		"songID": 945,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106628,6 +110553,7 @@
 		"songID": 945,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106646,6 +110572,7 @@
 		"songID": 945,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106664,6 +110591,7 @@
 		"songID": 945,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106682,6 +110610,7 @@
 		"songID": 945,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106700,6 +110629,7 @@
 		"songID": 945,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan"
 		]
 	},
@@ -106718,6 +110648,7 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106737,6 +110668,7 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106756,6 +110688,7 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106775,6 +110708,7 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106794,6 +110728,7 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106813,6 +110748,7 @@
 		"songID": 946,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106832,6 +110768,7 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106851,6 +110788,7 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106870,6 +110808,7 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106889,6 +110828,7 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106908,6 +110848,7 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106927,6 +110868,7 @@
 		"songID": 947,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106946,6 +110888,7 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106965,6 +110908,7 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -106984,6 +110928,7 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107003,6 +110948,7 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107022,6 +110968,7 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107041,6 +110988,7 @@
 		"songID": 948,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107060,6 +111008,7 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107079,6 +111028,7 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107098,6 +111048,7 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107117,6 +111068,7 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107136,6 +111088,7 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107155,6 +111108,7 @@
 		"songID": 949,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107174,6 +111128,7 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107193,6 +111148,7 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107212,6 +111168,7 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107231,6 +111188,7 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107250,6 +111208,7 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107269,6 +111228,7 @@
 		"songID": 950,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107288,6 +111248,7 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107307,6 +111268,7 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107326,6 +111288,7 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107345,6 +111308,7 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107364,6 +111328,7 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107383,6 +111348,7 @@
 		"songID": 951,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107402,6 +111368,7 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107421,6 +111388,7 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107440,6 +111408,7 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107459,6 +111428,7 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107478,6 +111448,7 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107497,6 +111468,7 @@
 		"songID": 952,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107516,6 +111488,7 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107535,6 +111508,7 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107554,6 +111528,7 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107573,6 +111548,7 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107592,6 +111568,7 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107611,6 +111588,7 @@
 		"songID": 953,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107630,6 +111608,7 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107649,6 +111628,7 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107668,6 +111648,7 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107687,6 +111668,7 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107706,6 +111688,7 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107725,6 +111708,7 @@
 		"songID": 954,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107744,6 +111728,7 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107763,6 +111748,7 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107782,6 +111768,7 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107801,6 +111788,7 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107820,6 +111808,7 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107839,6 +111828,7 @@
 		"songID": 955,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107858,6 +111848,7 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107877,6 +111868,7 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107896,6 +111888,7 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107915,6 +111908,7 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107934,6 +111928,7 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107953,6 +111948,7 @@
 		"songID": 956,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107972,6 +111968,7 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -107991,6 +111988,7 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108010,6 +112008,7 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108029,6 +112028,7 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108048,6 +112048,7 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108067,6 +112068,7 @@
 		"songID": 957,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108086,6 +112088,7 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108105,6 +112108,7 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108124,6 +112128,7 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108143,6 +112148,7 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108162,6 +112168,7 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108181,6 +112188,7 @@
 		"songID": 958,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108200,6 +112208,7 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108219,6 +112228,7 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108238,6 +112248,7 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108257,6 +112268,7 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108276,6 +112288,7 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108295,6 +112308,7 @@
 		"songID": 959,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108314,6 +112328,7 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108333,6 +112348,7 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108352,6 +112368,7 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108371,6 +112388,7 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108390,6 +112408,7 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108409,6 +112428,7 @@
 		"songID": 960,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108428,6 +112448,7 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108447,6 +112468,7 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108466,6 +112488,7 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108485,6 +112508,7 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108504,6 +112528,7 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108523,6 +112548,7 @@
 		"songID": 961,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108542,6 +112568,7 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108561,6 +112588,7 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108580,6 +112608,7 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108599,6 +112628,7 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108618,6 +112648,7 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108637,6 +112668,7 @@
 		"songID": 962,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108656,6 +112688,7 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108675,6 +112708,7 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108694,6 +112728,7 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108713,6 +112748,7 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108732,6 +112768,7 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108751,6 +112788,7 @@
 		"songID": 963,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108770,6 +112808,7 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108789,6 +112828,7 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108808,6 +112848,7 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108827,6 +112868,7 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108846,6 +112888,7 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108865,6 +112908,7 @@
 		"songID": 964,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108884,6 +112928,7 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108903,6 +112948,7 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108922,6 +112968,7 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108941,6 +112988,7 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108960,6 +113008,7 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108979,6 +113028,7 @@
 		"songID": 965,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -108998,6 +113048,7 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109017,6 +113068,7 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109036,6 +113088,7 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109055,6 +113108,7 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109074,6 +113128,7 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109093,6 +113148,7 @@
 		"songID": 966,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109112,6 +113168,7 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109131,6 +113188,7 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109150,6 +113208,7 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109169,6 +113228,7 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109188,6 +113248,7 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109207,6 +113268,7 @@
 		"songID": 967,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109226,6 +113288,7 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109245,6 +113308,7 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109264,6 +113328,7 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109283,6 +113348,7 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109302,6 +113368,7 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109321,6 +113388,7 @@
 		"songID": 968,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109340,6 +113408,7 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109359,6 +113428,7 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109378,6 +113448,7 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109397,6 +113468,7 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109416,6 +113488,7 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109435,6 +113508,7 @@
 		"songID": 969,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109454,6 +113528,7 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109473,6 +113548,7 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109492,6 +113568,7 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109511,6 +113588,7 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109530,6 +113608,7 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109549,6 +113628,7 @@
 		"songID": 970,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109568,6 +113648,7 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109587,6 +113668,7 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109606,6 +113688,7 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109625,6 +113708,7 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109644,6 +113728,7 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109663,6 +113748,7 @@
 		"songID": 971,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109682,6 +113768,7 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109701,6 +113788,7 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109720,6 +113808,7 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109739,6 +113828,7 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109758,6 +113848,7 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109777,6 +113868,7 @@
 		"songID": 972,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109796,6 +113888,7 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109815,6 +113908,7 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109834,6 +113928,7 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109853,6 +113948,7 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109872,6 +113968,7 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109891,6 +113988,7 @@
 		"songID": 973,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109910,6 +114008,7 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109929,6 +114028,7 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109948,6 +114048,7 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109967,6 +114068,7 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -109986,6 +114088,7 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110005,6 +114108,7 @@
 		"songID": 974,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110024,6 +114128,7 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110043,6 +114148,7 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110062,6 +114168,7 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110081,6 +114188,7 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110100,6 +114208,7 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110119,6 +114228,7 @@
 		"songID": 975,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110138,6 +114248,7 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110157,6 +114268,7 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110176,6 +114288,7 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110195,6 +114308,7 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110214,6 +114328,7 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110233,6 +114348,7 @@
 		"songID": 976,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110252,6 +114368,7 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110271,6 +114388,7 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110290,6 +114408,7 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110309,6 +114428,7 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110328,6 +114448,7 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110347,6 +114468,7 @@
 		"songID": 977,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110366,6 +114488,7 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110385,6 +114508,7 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110404,6 +114528,7 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110423,6 +114548,7 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110442,6 +114568,7 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110461,6 +114588,7 @@
 		"songID": 978,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110480,6 +114608,7 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110499,6 +114628,7 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110518,6 +114648,7 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110537,6 +114668,7 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110556,6 +114688,7 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110575,6 +114708,7 @@
 		"songID": 979,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110594,6 +114728,7 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110613,6 +114748,7 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110632,6 +114768,7 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110651,6 +114788,7 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110670,6 +114808,7 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110689,6 +114828,7 @@
 		"songID": 980,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110708,6 +114848,7 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110727,6 +114868,7 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110746,6 +114888,7 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110765,6 +114908,7 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110784,6 +114928,7 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110803,6 +114948,7 @@
 		"songID": 981,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110822,6 +114968,7 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110841,6 +114988,7 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110860,6 +115008,7 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110879,6 +115028,7 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110898,6 +115048,7 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110917,6 +115068,7 @@
 		"songID": 982,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110936,6 +115088,7 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110955,6 +115108,7 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110974,6 +115128,7 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -110993,6 +115148,7 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111012,6 +115168,7 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111031,6 +115188,7 @@
 		"songID": 983,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111050,6 +115208,7 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111069,6 +115228,7 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111088,6 +115248,7 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111107,6 +115268,7 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111126,6 +115288,7 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111145,6 +115308,7 @@
 		"songID": 984,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111164,6 +115328,7 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111183,6 +115348,7 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111202,6 +115368,7 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111221,6 +115388,7 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111240,6 +115408,7 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111259,6 +115428,7 @@
 		"songID": 985,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111278,6 +115448,7 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111297,6 +115468,7 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111316,6 +115488,7 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111335,6 +115508,7 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111354,6 +115528,7 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111373,6 +115548,7 @@
 		"songID": 986,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111392,6 +115568,7 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111411,6 +115588,7 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111430,6 +115608,7 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111449,6 +115628,7 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111468,6 +115648,7 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111487,6 +115668,7 @@
 		"songID": 987,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111506,6 +115688,7 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111525,6 +115708,7 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111544,6 +115728,7 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111563,6 +115748,7 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111582,6 +115768,7 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111601,6 +115788,7 @@
 		"songID": 988,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111620,6 +115808,7 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111639,6 +115828,7 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111658,6 +115848,7 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111677,6 +115868,7 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111696,6 +115888,7 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111715,6 +115908,7 @@
 		"songID": 989,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111734,6 +115928,7 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111753,6 +115948,7 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111772,6 +115968,7 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111791,6 +115988,7 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111810,6 +116008,7 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111829,6 +116028,7 @@
 		"songID": 990,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111848,6 +116048,7 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111867,6 +116068,7 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111886,6 +116088,7 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111905,6 +116108,7 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111924,6 +116128,7 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111943,6 +116148,7 @@
 		"songID": 991,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111962,6 +116168,7 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -111981,6 +116188,7 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112000,6 +116208,7 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112019,6 +116228,7 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112038,6 +116248,7 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112057,6 +116268,7 @@
 		"songID": 992,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112076,6 +116288,7 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112095,6 +116308,7 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112114,6 +116328,7 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112133,6 +116348,7 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112152,6 +116368,7 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112171,6 +116388,7 @@
 		"songID": 993,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112190,6 +116408,7 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112209,6 +116428,7 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112228,6 +116448,7 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112247,6 +116468,7 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112266,6 +116488,7 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -112285,6 +116508,7 @@
 		"songID": 994,
 		"tierlistInfo": {},
 		"versions": [
+			"qubell",
 			"clan",
 			"festo"
 		]
@@ -121803,6 +126027,3678 @@
 		"tierlistInfo": {},
 		"versions": [
 			"festo"
+		]
+	},
+	{
+		"chartID": "028ebadefa1ca387e7097fc8f22a07e335495483",
+		"data": {
+			"inGameID": 10000030,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1080,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ed4cfa86e59ae5d33cdeb542901f79b00db87b40",
+		"data": {
+			"inGameID": 10000030,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1080,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "b42896dd4c42885468713cc99bab8d6792010c68",
+		"data": {
+			"inGameID": 10000030,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1080,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c624663c571bb8367eff33ddeebf9bbca6672151",
+		"data": {
+			"inGameID": 10000030,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1080,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "98ed9b3b93313fdabe80881dd3a80a49c48520bd",
+		"data": {
+			"inGameID": 10000030,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1080,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "2125f477b76e8c935b0a9b68a343c29291013755",
+		"data": {
+			"inGameID": 10000030,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1080,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ff31697cbf5abe9f20619e61c90b5a2f7463b9d3",
+		"data": {
+			"inGameID": 20000003,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1081,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "a2eb74b066f78c2d9110525da6a7ab4d43431561",
+		"data": {
+			"inGameID": 20000003,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1081,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "bddac07ccd0806dfacc1ab613424ea52af5787ae",
+		"data": {
+			"inGameID": 20000003,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1081,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "d33adf08f35aab5d55fa023acfecb03e4ff66df6",
+		"data": {
+			"inGameID": 20000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1081,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "5bb9214ef1cad4ac96736dd8fbb7a88fb3d522c6",
+		"data": {
+			"inGameID": 20000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1081,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "404065982553965860859c54fe3b7523751fce6d",
+		"data": {
+			"inGameID": 20000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1081,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "7acb740f5c94c8124bfd717df7ea4361b4361d46",
+		"data": {
+			"inGameID": 20000014,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1082,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "5275d9d398d776a81fdf7f2b2d2402de9196d8bb",
+		"data": {
+			"inGameID": 20000014,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1082,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "60b041848f99d44e905c7276c1cffcb62b2daca8",
+		"data": {
+			"inGameID": 20000014,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1082,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "cefdfb921fcaac163f2ddffff72d130f7f80b00c",
+		"data": {
+			"inGameID": 20000014,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1082,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "5005f4664fb185b0ab1dca2bc7a122ae185c3f19",
+		"data": {
+			"inGameID": 20000014,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1082,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "6b9797a2f58514aafdc9378a21ea5ff7bdf2a7e2",
+		"data": {
+			"inGameID": 20000014,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1082,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "17b0ed1132fc50e6eaf05a6e0298cdcc1f28db56",
+		"data": {
+			"inGameID": 30000003,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1083,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "d649d4296f1513e6404311d6fe6783c115ddb803",
+		"data": {
+			"inGameID": 30000003,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1083,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ad67cc6a4f46627e7ac659d8c58d0e4baf464ef5",
+		"data": {
+			"inGameID": 30000003,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1083,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "23c7c29efd5ad80c66a17bde5a737489ff7d7124",
+		"data": {
+			"inGameID": 30000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1083,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "660b3fd14d8e3953143ebc098230b0d6b79f6334",
+		"data": {
+			"inGameID": 30000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1083,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "3b85526d0ac026cd2e305333bc5a5ee86f736cc0",
+		"data": {
+			"inGameID": 30000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1083,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "f2d6909feb477e93c25361de014aa4621b77c5e5",
+		"data": {
+			"inGameID": 40000022,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1084,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "709668a71ed2082f38b62311c018a329abaac5fe",
+		"data": {
+			"inGameID": 40000022,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1084,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "52078b7fa9a3893b248339023a3e35c58f0d89bb",
+		"data": {
+			"inGameID": 40000022,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1084,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "a858e81feab794ee9096f36396b766ff4d2ff120",
+		"data": {
+			"inGameID": 40000022,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1084,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "aa9fee01361479627873711d1b89fdd261f5f970",
+		"data": {
+			"inGameID": 40000022,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1084,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "322a0945756a6c24993d5e9875d515e65df768e1",
+		"data": {
+			"inGameID": 40000022,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1084,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "1ed2f5051653cae0a81bb5dbfeb926b5cf645562",
+		"data": {
+			"inGameID": 50000001,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1085,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "d621d72090d7517629c97936e1e8fe74a7ba857f",
+		"data": {
+			"inGameID": 50000001,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1085,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "e8fb52f557f6f6c4041f6475b6db9506b9256aa5",
+		"data": {
+			"inGameID": 50000001,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1085,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "595966aa8ee67acf8fd7fc9e6c246a0211079fd1",
+		"data": {
+			"inGameID": 50000001,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1085,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "6472d26937cb661a9f439edddd1e24dc675561db",
+		"data": {
+			"inGameID": 50000001,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1085,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "207af4a6fbc8c1904b779d49c79f519c1a47e11d",
+		"data": {
+			"inGameID": 50000001,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1085,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "68fbd633b77afb0f5027474cefc54c810f7dda17",
+		"data": {
+			"inGameID": 50000003,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1086,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c2a0ffded791003dc6fee7c58e405085a651d458",
+		"data": {
+			"inGameID": 50000003,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1086,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "89eeb4e2c2eba99ec0320e6ac0688ef079bf5542",
+		"data": {
+			"inGameID": 50000003,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1086,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "80eed770d1975c4b74d0008b68230f22ef796b7a",
+		"data": {
+			"inGameID": 50000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1086,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c3c871ce67c8640052a7c81f09e8da074974f246",
+		"data": {
+			"inGameID": 50000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1086,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "f764a4a20744d19e2bc73643d574424ac0caa95a",
+		"data": {
+			"inGameID": 50000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1086,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "e588ee5c7b488f398335b71c7ee2f9ac9c196e01",
+		"data": {
+			"inGameID": 50000009,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1087,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "44b9b507e33cc5ece81e879b5101e1230868e8f3",
+		"data": {
+			"inGameID": 50000009,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1087,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c233b9cd3aac9f50cb9e8362f419e6960b407bed",
+		"data": {
+			"inGameID": 50000009,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1087,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "45159634d0ffa0f332d450e7e412afad1980adb6",
+		"data": {
+			"inGameID": 50000009,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1087,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "0841f157a0a5f20bbfbdadbd9f97dad832334011",
+		"data": {
+			"inGameID": 50000009,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1087,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "50b39c8b3d002ddc42ca54af4de64dc517642aa1",
+		"data": {
+			"inGameID": 50000009,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1087,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "835008d47b2a89d9c5e7296e8b9d2412c19393a2",
+		"data": {
+			"inGameID": 50000010,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1088,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "9af0b0de16ff9690e9bbbebb89ce720da3a003e1",
+		"data": {
+			"inGameID": 50000010,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1088,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ae4d769c2961e7087b822f0d2597764d69f3e882",
+		"data": {
+			"inGameID": 50000010,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1088,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "cd64ff14fdc02e333e9c12930dddc791f567179e",
+		"data": {
+			"inGameID": 50000010,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1088,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "46522c384101ec5d891d8e92479110046644c15f",
+		"data": {
+			"inGameID": 50000010,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1088,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "3264208d637b1ae20c30c5446b7b21fb972c4008",
+		"data": {
+			"inGameID": 50000010,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1088,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "78fa9265ffa3b9709f23156710f3d8753f1f5dc1",
+		"data": {
+			"inGameID": 50000011,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1089,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "f5e2d10359abea9b823efb9b1c2e3927b4699535",
+		"data": {
+			"inGameID": 50000011,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1089,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "9bf73107ef388bd92b03ffa0fe0128e0aec0fa45",
+		"data": {
+			"inGameID": 50000011,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1089,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c16e9f1a3b362b17899b80c95334a1795caa36a7",
+		"data": {
+			"inGameID": 50000011,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1089,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "8b234804796b1ab130cdc098e0d67518e4b1c0d2",
+		"data": {
+			"inGameID": 50000011,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1089,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "7d4f9bd83e19445e71af05e29c635ef2d8269171",
+		"data": {
+			"inGameID": 50000011,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1089,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "1afbc7011e56436899c6e148fcc54ce2af94ee4f",
+		"data": {
+			"inGameID": 50000015,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1090,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "eb9d3a79832329e464201e7a9818e721be0c1818",
+		"data": {
+			"inGameID": 50000015,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1090,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "90bf7547efd62b06b0d010d953780d22070b64d6",
+		"data": {
+			"inGameID": 50000015,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1090,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ef4009f4d03572671d995cf279da25cf63609f3e",
+		"data": {
+			"inGameID": 50000015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1090,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "0f481f7a37145d36cb6c794a4e6ad606a47f8537",
+		"data": {
+			"inGameID": 50000015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1090,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "8fbd3028f97f1b2a7698f72003d28c7b712c7929",
+		"data": {
+			"inGameID": 50000015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1090,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "f8d58a8cdb81dc67ba35c3d98ba60c972d9ce99e",
+		"data": {
+			"inGameID": 60000012,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1091,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "078e3078aedafb2a2b025d79dcc14ca294c668d0",
+		"data": {
+			"inGameID": 60000012,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1091,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "992783e24e1b2710d9de74918aa40a9fd67eb73c",
+		"data": {
+			"inGameID": 60000012,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1091,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "a323c1028838885ca2082ba45beb9a77ec16560b",
+		"data": {
+			"inGameID": 60000012,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1091,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "21cf73fe60d7c3094d4c09a72055c04f3b44a23a",
+		"data": {
+			"inGameID": 60000012,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1091,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "acc2e87c000e84e58c8656f812af84f5583d6535",
+		"data": {
+			"inGameID": 60000012,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1091,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "bc00ca52da5b95900dfd3c54f8adb5476b8c8e33",
+		"data": {
+			"inGameID": 60000013,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1092,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "bd6ffae345eb89ed4a7fd3c9dbbfb85f9e9c6ff7",
+		"data": {
+			"inGameID": 60000013,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1092,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "272d1108846ba0f92c56dd0dffa82a21bd750e73",
+		"data": {
+			"inGameID": 60000013,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1092,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "dd0d74f088ff6c5383b52d1942c93d4fc9623f1f",
+		"data": {
+			"inGameID": 60000013,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1092,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "4290c697b071106822330b077a1d08764e87d643",
+		"data": {
+			"inGameID": 60000013,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1092,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "5b3108ab6ba0cf82e2443ffbd17b69d0fb4361ac",
+		"data": {
+			"inGameID": 60000013,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1092,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "a06ea87dfe521676e536abd2577cd57978fc4773",
+		"data": {
+			"inGameID": 60000014,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1093,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "d21ccd6b57492101cc777ddb2e5d183ef0ba4426",
+		"data": {
+			"inGameID": 60000014,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1093,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "3c94ff3c770f45009f1d548a9ceca9ee9436b5f9",
+		"data": {
+			"inGameID": 60000014,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1093,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "9d6e5364808659b3954e022dbf1dcc6c4151ad7e",
+		"data": {
+			"inGameID": 60000014,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1093,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c149eb93b5219b81c55dac70f63e78840f841385",
+		"data": {
+			"inGameID": 60000014,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1093,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "1f46693374f0c9cff79d9217bf5e4553b8fd2478",
+		"data": {
+			"inGameID": 60000014,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1093,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "32e0e782233d7bfb7cc8e7f719963d96c435f617",
+		"data": {
+			"inGameID": 60000015,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1094,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "e8b699d0bda7f06f70a31f35a34048b422a3e507",
+		"data": {
+			"inGameID": 60000015,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1094,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "8ebec9efe6c361cf0fd54cb6148fe3bd7fd357fb",
+		"data": {
+			"inGameID": 60000015,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1094,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "1963ae4727a406a88d2426be190269f052857a28",
+		"data": {
+			"inGameID": 60000015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1094,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "23f9fb1727b3318aca59a2afcdac24cfc8a48caa",
+		"data": {
+			"inGameID": 60000015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1094,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "16650322b7a7b137594bc84b8225f8ca97d16470",
+		"data": {
+			"inGameID": 60000015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1094,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "40713f5a8bca305cfce2e29715d2b820270980c0",
+		"data": {
+			"inGameID": 60000016,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1095,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "d891b805853bac92d17346f2f2b3edc349a01ad1",
+		"data": {
+			"inGameID": 60000016,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1095,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "8fda3f3f96facec7386c49cce0f4e36c52ed0f67",
+		"data": {
+			"inGameID": 60000016,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1095,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "cea7c834e3a52dff32174bd75a9267ba2c30227a",
+		"data": {
+			"inGameID": 60000016,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1095,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ed82aeda7f864df001c64d7bb4028dd12cb57fa3",
+		"data": {
+			"inGameID": 60000016,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1095,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "24e40c3212c2396b5739bb09f1c35530883a7128",
+		"data": {
+			"inGameID": 60000016,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1095,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "be72bb9042a339e3f1ee6eec9f71990d350c6f42",
+		"data": {
+			"inGameID": 60000017,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1096,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ad6cecccf2382844e0c09cc3c288f16b99a6e77b",
+		"data": {
+			"inGameID": 60000017,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1096,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "69f93cf1659a06582478d4d362497e9be191181e",
+		"data": {
+			"inGameID": 60000017,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1096,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "a72287b74bfec4e7e8e0f7c7509fe2654e39547a",
+		"data": {
+			"inGameID": 60000017,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1096,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "04568897c7b89f6b6d87bebbf42a41a5c3132aa0",
+		"data": {
+			"inGameID": 60000017,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1096,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "1d0be085ffa7400c634f778afb4f30064ad0a887",
+		"data": {
+			"inGameID": 60000017,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1096,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ea09836a17cb302d3775aaf4dd09e11dd668c1e6",
+		"data": {
+			"inGameID": 60000018,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1097,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "647c0e5409658d5a829e377ea8791eac311623b8",
+		"data": {
+			"inGameID": 60000018,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1097,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "947727859f6d3749485c733370788ddfa0bf1e39",
+		"data": {
+			"inGameID": 60000018,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1097,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "21484ebb8215ab181a40af02ce113c62f2e43bef",
+		"data": {
+			"inGameID": 60000018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1097,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "378ab6e27c907e52a9c9045aed231af5d50acd8c",
+		"data": {
+			"inGameID": 60000018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1097,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "51f442f0e082f1c0dd2b51f704d93ba90534b07c",
+		"data": {
+			"inGameID": 60000018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1097,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "04238edca97c0a41995aa773907672de0037f06d",
+		"data": {
+			"inGameID": 60000019,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1098,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "d1f539f465c62898cfe1f465aa60e0db419fdb3d",
+		"data": {
+			"inGameID": 60000019,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1098,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "8f6caa9632f109442cb364c3cd28de9e0895783c",
+		"data": {
+			"inGameID": 60000019,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1098,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ebe0a4ea84d734390eb4922cd1d58e1233b467bb",
+		"data": {
+			"inGameID": 60000019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1098,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "d47cf6b9443f4eed43b353ddef1a6d8207a0bf5d",
+		"data": {
+			"inGameID": 60000019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1098,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "907c644dcd087ca03f07f84a3663d3d97988e66d",
+		"data": {
+			"inGameID": 60000019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1098,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "af3730427859dde3c80d25f4b242e4998f3f1ebf",
+		"data": {
+			"inGameID": 60000022,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1099,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "26310386ff87a5c0cc1be618b2f18349498572b6",
+		"data": {
+			"inGameID": 60000022,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1099,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "3d72918d383f5cca1aaefadab768ac9ccb88327c",
+		"data": {
+			"inGameID": 60000022,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1099,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "0d4881eabc0b4b7d9c47503ed54f3d0b97264cbc",
+		"data": {
+			"inGameID": 60000022,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1099,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "f2b1aba046267a6c985b2ff5b6b64f1e1944b125",
+		"data": {
+			"inGameID": 60000022,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1099,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "41b3e88658f4383c89a5c05a209ea2679b552467",
+		"data": {
+			"inGameID": 60000022,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1099,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "64f5a31a03c6d3f066c70efe53924d596c23d486",
+		"data": {
+			"inGameID": 60000023,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1100,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "a85e5c815b9ab8068bd3c903ffba39c0cc9ca787",
+		"data": {
+			"inGameID": 60000023,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1100,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ae06016d4e3566f09e91fe1a1b1abc254fe69d75",
+		"data": {
+			"inGameID": 60000023,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1100,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "2b3fba122ed43f6e3afe44771ad1ed459dba2111",
+		"data": {
+			"inGameID": 60000023,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1100,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "32a7e9a7d64777861abf7b4472c7ee16a80965c0",
+		"data": {
+			"inGameID": 60000023,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1100,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ee3cce4eb4de10a39389f64a2c0b0fc9e6c1605b",
+		"data": {
+			"inGameID": 60000023,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1100,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c6e8719e35db420935d1dbc6abe96ca48e4721ae",
+		"data": {
+			"inGameID": 60000061,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1101,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "78ea970a3784d30c2c2ffff4bfdb49c32cdd9985",
+		"data": {
+			"inGameID": 60000061,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1101,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "45fa2c4f4ef8960895f1a56acf2eaebc608081b1",
+		"data": {
+			"inGameID": 60000061,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1101,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "38a7410298dcdfd402e9670f53888ead4a69613b",
+		"data": {
+			"inGameID": 60000061,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1101,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "6ded2032537fb725ec5883fc2dc6fb298c34898c",
+		"data": {
+			"inGameID": 60000061,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1101,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "2cf17312530bb0d84cc463da8e829f5e12495bea",
+		"data": {
+			"inGameID": 60000061,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1101,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "3dc38e298b6e993c8283cbc15f2a425f1e41008c",
+		"data": {
+			"inGameID": 60000062,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1102,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "225caf1543640cda6b5a400d86c8645f361f6706",
+		"data": {
+			"inGameID": 60000062,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1102,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "30497d075581d7b88e41e1284977e1e1ae10df81",
+		"data": {
+			"inGameID": 60000062,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1102,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "0b26372580fa6fa22e98bbdce2706000428b0cd3",
+		"data": {
+			"inGameID": 60000062,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1102,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "b0efd16f5c8e8a31d2d8883d1a378da28b955bb1",
+		"data": {
+			"inGameID": 60000062,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1102,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "1718a14dd9733bfb2d5c5271302306b31142074f",
+		"data": {
+			"inGameID": 60000062,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1102,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c8f857480ede6da6432061ad37f50cf8b4ccadc4",
+		"data": {
+			"inGameID": 60000084,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1103,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ff18d2f6652aeda735793d7328a711fe0381f1dd",
+		"data": {
+			"inGameID": 60000084,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1103,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "e6611ff6dce13aeacac38abfc272e49ce3bb3505",
+		"data": {
+			"inGameID": 60000084,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1103,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "0d33c3d0d06170a45dbe49ab7d09d1701976aa67",
+		"data": {
+			"inGameID": 60000084,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1103,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "a568124eafda962697be971791fa3e88532c01e7",
+		"data": {
+			"inGameID": 60000084,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1103,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "d40496651526d00d872a2faa341b8ef7acb07b8e",
+		"data": {
+			"inGameID": 60000084,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1103,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "1bcae3325c8b3bfd4bfafbdca662c512f59987e5",
+		"data": {
+			"inGameID": 60000085,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1104,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "da7c31e455c76b41863a90b5833144e72fe85603",
+		"data": {
+			"inGameID": 60000085,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1104,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "3fcc01e5654324c8991500827385d4df046bd512",
+		"data": {
+			"inGameID": 60000085,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1104,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "619c991f10c8d0543c8281c336e663bf94904103",
+		"data": {
+			"inGameID": 60000085,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1104,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "92e46e16999d2b1aa0b2ff82655279274a6b8c02",
+		"data": {
+			"inGameID": 60000085,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1104,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "83fe3ac03bd0ee8a0b9a660b5c43bec9d7d45eb4",
+		"data": {
+			"inGameID": 60000085,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1104,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "70e8d47cb9ee98ec35e0a95c64372d5c7647b0ee",
+		"data": {
+			"inGameID": 60001012,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1105,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "22e76ea629c43ea159c9e2f97721150f7657130f",
+		"data": {
+			"inGameID": 60001012,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1105,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "8b996345bb152ec846d5b2539754d01061cfcde9",
+		"data": {
+			"inGameID": 60001012,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1105,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "b386b36504954e06491e81bb405810ec113cbf05",
+		"data": {
+			"inGameID": 60001012,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1105,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "04f15cce3cd422dda7a941a5afa5808228de0d8d",
+		"data": {
+			"inGameID": 60001012,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1105,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "4cc674e2212aecc974d8c0575d79dec7f41728b9",
+		"data": {
+			"inGameID": 60001012,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1105,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c929c6afcd847772708f00a310afdcb6cda3d952",
+		"data": {
+			"inGameID": 60001018,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1106,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "5929540704156485a823c483c9cbd0a2e3a3e74f",
+		"data": {
+			"inGameID": 60001018,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1106,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "6b5729070f3ce452821c583177f19d945b627942",
+		"data": {
+			"inGameID": 60001018,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1106,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "9a11e77d694ec1dc75ac8988d17f8205b1ada8a4",
+		"data": {
+			"inGameID": 60001018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1106,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "620ed1ff3a6f8044448e64461d9768cb0948f3dd",
+		"data": {
+			"inGameID": 60001018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1106,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "b249ecbabffa527dcca521ee7c7786bb42ca14c2",
+		"data": {
+			"inGameID": 60001018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1106,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "95318e12ae56816d85e18f9133a8269b7a39275a",
+		"data": {
+			"inGameID": 60001019,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1107,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "045a2e837c95e73f908a7135b3d4059c9e44b3c0",
+		"data": {
+			"inGameID": 60001019,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1107,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "0b557a5a52d0021ddeb0e3c89952317841d5e64a",
+		"data": {
+			"inGameID": 60001019,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1107,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ef42debaeee5f055ac8eeb6c88630bf5772f4c07",
+		"data": {
+			"inGameID": 60001019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1107,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "d570c29491000355947d4c71a37b053f2cef5632",
+		"data": {
+			"inGameID": 60001019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1107,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "346c104d9cdccadf964fe34d363ceba899ea166e",
+		"data": {
+			"inGameID": 60001019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1107,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "52cc21a38eb57c38a2dfc944f78c39d826724c2b",
+		"data": {
+			"inGameID": 70000024,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1108,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c7c97e5868c907fd65f334badec63828b51426a4",
+		"data": {
+			"inGameID": 70000024,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1108,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "80daffeb3dcb00b6d2bafb15662f7e4d3c38d1dc",
+		"data": {
+			"inGameID": 70000024,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1108,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c29ab25e96fedbd3e082b4df0de24cc404d8428b",
+		"data": {
+			"inGameID": 70000024,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1108,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "b24328357daec51828d5c4badafc9d723a8b0571",
+		"data": {
+			"inGameID": 70000024,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1108,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "181aa51d510909851314e280588982880bca160c",
+		"data": {
+			"inGameID": 70000024,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1108,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "084ca758fee000504b2eafcace441b03ffbee06c",
+		"data": {
+			"inGameID": 70000080,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1109,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "c5a4e77e9d8a481fa25508c2ebac31225b27f2e3",
+		"data": {
+			"inGameID": 70000080,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1109,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "37efb4f4240b24691dc4d160ef860f1277bfa976",
+		"data": {
+			"inGameID": 70000080,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1109,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "5e47c527b1de9d02f5dbd59558ff723c0b934959",
+		"data": {
+			"inGameID": 70000080,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1109,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "a408fdcb169a8ab7e76b3a3dc261df1155435199",
+		"data": {
+			"inGameID": 70000080,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1109,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "445be828392f7ed211cc6111516805b1dbfd5b35",
+		"data": {
+			"inGameID": 70000080,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1109,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "765d163797d8731aa2a7c96022575ab18056d616",
+		"data": {
+			"inGameID": 70000081,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1110,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "b4748d58d65b8d944f9f72ad15c1124f7475ad17",
+		"data": {
+			"inGameID": 70000081,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1110,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ce264d80c603d109f8ee01bc7ba50085a8447672",
+		"data": {
+			"inGameID": 70000081,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1110,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "40563f97cf4b5d7c8245b516e148bee5284899a0",
+		"data": {
+			"inGameID": 70000081,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1110,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "8091bc297397f98dcaf24dffc3ec0f3c561b70ce",
+		"data": {
+			"inGameID": 70000081,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1110,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "645855bc7e0dc17af87509b3fd1fdf232f83b44f",
+		"data": {
+			"inGameID": 70000081,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1110,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "bfe42b7d33ecb4cc6a1bcb44110fbc7401fdf857",
+		"data": {
+			"inGameID": 70000082,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1111,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "b5ecb4b29c1908b31a7b1950986032bc538af1b7",
+		"data": {
+			"inGameID": 70000082,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1111,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "2c4cf2a8e7354b52c58ba30acc78ceb3f03e52ff",
+		"data": {
+			"inGameID": 70000082,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1111,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "60cf239046703dac0372d280db1af2e2859a679a",
+		"data": {
+			"inGameID": 70000082,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1111,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "725c7292602822bdceb108817a5e59d9dceb2825",
+		"data": {
+			"inGameID": 70000082,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1111,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "5984ffd4b4699c289e92a2689c11a6d4ff9c981f",
+		"data": {
+			"inGameID": 70000082,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1111,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "3b9fceec20a80f6e77be478fe8a8ea322d0f235e",
+		"data": {
+			"inGameID": 70001002,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1112,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "dab47a58444f2a1e364eeff8e9a7a83176193bae",
+		"data": {
+			"inGameID": 70001002,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1112,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "a1b028f06534ac65209d9699d817d6ba72988459",
+		"data": {
+			"inGameID": 70001002,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1112,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "e784fe9528afe2af84f06751fa6f7a6e4fe76497",
+		"data": {
+			"inGameID": 70001002,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1112,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ed93b12c98a062bd84233aa14b0a98699fe514eb",
+		"data": {
+			"inGameID": 70001002,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1112,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "ecc5866a9f21ff121c91ff629930af444c8fc8a7",
+		"data": {
+			"inGameID": 70001002,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1112,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "25c1de0e1da3424928a79cb87fb3d65fece97636",
+		"data": {
+			"inGameID": 70001005,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1113,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "14bea6b3f9b9d7c7140920318895ee7859bef1a8",
+		"data": {
+			"inGameID": 70001005,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1113,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "6ee923af6c4eea90bee755cce56b1813ef9b933d",
+		"data": {
+			"inGameID": 70001005,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1113,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "70dc0f00c946f3c5d6fb768829b4acd55490009e",
+		"data": {
+			"inGameID": 70001005,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1113,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "a2203ba2d0a0b5f519c90fc26f3979de20875160",
+		"data": {
+			"inGameID": 70001005,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1113,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
+		]
+	},
+	{
+		"chartID": "581555a9ffac2b39a899b28ef3bb48699857cedf",
+		"data": {
+			"inGameID": 70001005,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1113,
+		"tierlistInfo": {},
+		"versions": [
+			"qubell"
 		]
 	}
 ]

--- a/database-seeds/collections/folders.json
+++ b/database-seeds/collections/folders.json
@@ -23330,5 +23330,857 @@
 		"searchTerms": [],
 		"title": "Level 9+ (Reverse)",
 		"type": "charts"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "1",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 1 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fdf5a9b9db3a846505e65fa996c9aa3592bc464b80959bb0cbd68c82025a89c06"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "2",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 2 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fbc77f5489a783e2a8a02550f1e19abab42d08625de76d0e30b379b922a358ac4"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "3",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 3 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Ffe634635103f8e289ecff87894fd6626ae1525180d34892b33d571b301cb805e"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "4",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 4 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Ffa8da604e42a607981a3e6756775fc5cd2e5c1b66a7e55c487155c0c2d4f2001"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "5",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 5 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F081f60e92df88ac830eab351bee8c0ed0b34c97d4e1ce732fc48197710f986b7"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "6",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 6 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F954803ab7d11ba39f1a39cec9ba304f18cc82d543d7b2d9b559f9045e34f6399"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "7",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 7 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F6e97f425059c30cf2fec0f1290a72dd605ef3922163ee44f535d8cd9e02b58e8"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "8",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 8 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F71077a2b710e331361cb1152ecd5a0e205ac2d2c1cfae744cef02092912d682a"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"levelNum": {
+				"~gte": 9,
+				"~lt": 10
+			},
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.0-9.9 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fe5d29f7a4113f0d6997566df019deb693f9cb9ba2e55d3aa2cc12c4dec5069ee"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"levelNum": {
+				"~gte": 10,
+				"~lt": 11
+			},
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.0-10.9 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F14c64144cc655f472282883777a7e39ae12ef28e7abebe728de7eb0806b342c3"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "1",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 1 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fc229e8c6176ac6ad734cb867cfbc5e6ba7fed0a0f49a89a17e9e4cad5d2c237d"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "2",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 2 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fd171cb52932779b7890bdabb2e0f7eaab98a6bb02272ccca66b7c3aa94c270a8"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "3",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 3 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F7dac3ad5c93e4e077f9fbceebd2d65000cdaa0045a97bb6d944cbc195b1bc99b"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "4",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 4 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fca6afd35e745b949876127b6b8513ed8232bb91c62d405f8f5ac224ecd625f3d"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "5",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 5 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F410910648e59593e0fca50f420c64b57ba97a0eeab6d2c53eff96103f22518c2"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "6",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 6 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fbe2c71a29c52f0f8bad023d301e708aaaca9f142410ba1a2624f64f7434533fd"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "7",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 7 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F4afded0ec1884418369acb285c8dac9d25a0b7bdb89c97f8c84ade506e9d5988"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "8",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 8 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fb06f06975fe60068bc848eb4bf92feae52cb23e4ea5f86abe65b977da8698608"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"levelNum": {
+				"~gte": 9,
+				"~lt": 10
+			},
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.0-9.9 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F63c2d607302677d5c81742f230678135d108140484481ee9c794f8d666837729"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"levelNum": {
+				"~gte": 10,
+				"~lt": 11
+			},
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.0-10.9 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F4ca952c9f50ab0640a893f145cd0c8854d9dcb7399cb15a03f519c80f07568c0"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.0",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.0 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fb07ace67223ed8dd542cc21424ea99a91bdec53a45793ba53679fb45c19a0f54"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.1",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.1 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F502fd71ce5622ec22abc63eb74e0fc0edd434ea449ce1bde695a897f72191e52"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.2",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.2 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fcff6dd5cd759f9ecadb0e62f3606488d722e95bd871afb4dbd485b3315a01e87"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.3",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.3 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fa48061e93f68acb104eeb38701b22818e06cf5eed599fa4983fe50c45caf5cdb"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.4",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.4 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F0632e541366f9013a6c34c5757b80adbb41d5f88c6bb55dd5b5acf59a9afab6d"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.5",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.5 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F65a46e91483c5292ee2a018488ce4487ecab42f1e63df5de889e4d433ee35c71"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.6",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.6 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F7de03e7edc965bcfa3d5d6e69f0cc041c692314af9b88428e335df21f4d503a1"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.7",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.7 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F464fa2b661d89300bc1858dc833f2f8fc0a756fa024f6a6706bba3a363981af6"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.8",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.8 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F6933c622828b50eea323d1a89b0de584461260a11cd84b5ff4f2f3527735e9ff"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.9",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 9.9 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fd6d9a697ba24218a77335a74d409a03d410357092c5f51b542674f4c01549e35"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.0",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.0 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fe89d98f9b48079e73adad0ad97b3719e40bf19111c057396fd3d0c82e8cb8189"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.1",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.1 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Faea9f0b700a7a7a0cc93643adc3b6bee78ce98609897fa74a9720a84ae2628ae"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.2",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.2 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F0931caa15839163cbe1df581552c7bbe6cdfee2f35342e7b61ae5a98101e86ec"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.3",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.3 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fd9375a97bd14e7a27a18ffe7dd78b14d9fe95229f27e135876a03e663441972a"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.4",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.4 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F15ca96d7b48552ea47fb8d4c2549c9b13abe66e47a8bc389c8da947401e91501"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.5",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.5 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F1a1ae8df53ecbc685d8e1263ec5423167982d0de2385e90e7c57c5d37e98ce7f"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.6",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.6 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F97aaca476c15c73ee4b77251cb545322ce55765965a878681bbb766d44b0d0e6"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.7",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.7 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fe64ecb99fe815e308363a1c4f84c988e2626ff4804021ba298cfa31ce234f439"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.8",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.8 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F42a00e626ca7ada4a7d52bb027cbb192ff76e0117f01b147ec704b1ccb5eaabf"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.9",
+			"versions": "qubell",
+			"data¬isHardMode": false
+		},
+		"searchTerms": [],
+		"title": "Level 10.9 (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F5775764ff67636311085b6b44d7c717a67c57eab16ffcde2ec75d80913331633"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.0",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.0 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fcf781e3d42a2d53803fa842088fa401362554932f481a7996e0a87a809ff0e85"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.1",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.1 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fbb1c319e0d8ce1c3eaa1ea1e5dc8bebd85428bd4f4313f6f6d294815062d7f8c"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.2",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.2 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F532bda0170903df3d241bbdafd2c466766c911c74b3160951aecfd952f44fcca"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.3",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.3 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fed4a75299f42c66358dd603e384ab3736365bba0db5d36e85f4a20b773f63250"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.4",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.4 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fffa286f2bb3816731cd2fefaf9d9287af073ba55ac4beb78a867d692b876aef6"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.5",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.5 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F09e1c75fc5cfdea4d2f57a40b9cc647804079c8300558ef17f2dd11305445635"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.6",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.6 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fabe8505e35aa0bf43aa0ed8e443bcf7227bb40b19bb840f826952178afa03b25"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.7",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.7 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fc7ed27d1fc78a0b1f52da21b2282a40273d663fdf79ca48d63cead20571cfab8"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.8",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.8 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fdbe14321b1cdd3d612109a408994502ca68ed3757969ca53b0ecf82221fa2091"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "9.9",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 9.9 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F3dec6f227b21f562a95b78785ca68468a25e157901d6b34e2c9c60d9e46ad39c"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.0",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.0 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fff7db1aca35042626dd7ae1ddf09178b9dc17be9d88e3b494f09af06d05ad2b4"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.1",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.1 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fa0a13dcc4939de466ed417b7d47f361ec448930ad772790bd83e9de3d22b8ca6"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.2",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.2 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F3de7c9091d8898d15bb5a761bba2d089651fc9fe5e2261df00232f2287c79b49"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.3",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.3 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fe050024d4ed37987581c9a53f79adee055879907a6fc529471d82aafe7bc9f9c"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.4",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.4 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "Fdef00951dfba618c310a201e8c465639caf2efb9147b6751a3bb0604ee6051e0"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.5",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.5 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F64c0d4a03a28c9f95bbc3799a2e74cba3fc3b28b08c3c447fc9a1b8828466ca5"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.6",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.6 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F13c1998f798d989eb11f7ef254327cf2ac26b088049ccb642ffa2fa9fd902fe1"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.7",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.7 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F9e07f649f8f195aeeab7c70291d350ea9b33643358c0460bd17059fd0ab59cc0"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.8",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.8 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F83dd467c6426344c1e46806d1b70b09f2ea5a1111fcefdc8483781ec4303e876"
+	},
+	{
+		"game": "jubeat",
+		"playtype": "Single",
+		"data": {
+			"level": "10.9",
+			"versions": "qubell",
+			"data¬isHardMode": true
+		},
+		"searchTerms": [],
+		"title": "Level 10.9 (Hard Mode) (Qubell)",
+		"type": "charts",
+		"inactive": false,
+		"folderID": "F844e8d8ae236ea42ca7848e509f4c4a6965562505fd83f5792c2e75cad565390"
 	}
 ]

--- a/database-seeds/collections/folders.json
+++ b/database-seeds/collections/folders.json
@@ -14590,6 +14590,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "1",
+			"versions": "qubell"
+		},
+		"folderID": "Fe6eca44eb7688565d6dfbbd942866c1e1ad3569ca6c2a17c1e10f2ba207ca7e3",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 1 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "1",
+			"versions": "qubell"
+		},
+		"folderID": "Fe6eca44eb7688565d6dfbbd942866c1e1ad3569ca6c2a17c1e10f2ba207ca7e3",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 1 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "1",
+			"versions": "qubell"
+		},
+		"folderID": "F5597b8e01373f3ed99e7e65ab2cd73abc7dee912edf2bacd146c4e6957da271f",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 1 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "1",
+			"versions": "qubell"
+		},
+		"folderID": "F5597b8e01373f3ed99e7e65ab2cd73abc7dee912edf2bacd146c4e6957da271f",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 1 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "10.0",
 			"versions": "festo"
@@ -14614,6 +14670,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.0 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.0",
+			"versions": "qubell"
+		},
+		"folderID": "F27815177696466ed771e1e8254143affd578719428955e6804e6df83783be2d7",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.0 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.0",
+			"versions": "qubell"
+		},
+		"folderID": "F27815177696466ed771e1e8254143affd578719428955e6804e6df83783be2d7",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.0 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.0",
+			"versions": "qubell"
+		},
+		"folderID": "F896456d42e285a3897f50dabc1bd382f60c7de09fdebb023a4a0e6eabb3cc086",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.0 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.0",
+			"versions": "qubell"
+		},
+		"folderID": "F896456d42e285a3897f50dabc1bd382f60c7de09fdebb023a4a0e6eabb3cc086",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.0 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -14652,6 +14764,74 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"levelNum": {
+				"~gte": 10,
+				"~lt": 11
+			},
+			"versions": "qubell"
+		},
+		"folderID": "F8a63e5b8ff8a5843ef4f2da6472f6325042b1bf338b1e15d12f0e2550ca93501",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.0-10.9 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"levelNum": {
+				"~gte": 10,
+				"~lt": 11
+			},
+			"versions": "qubell"
+		},
+		"folderID": "F8a63e5b8ff8a5843ef4f2da6472f6325042b1bf338b1e15d12f0e2550ca93501",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.0-10.9 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"levelNum": {
+				"~gte": 10,
+				"~lt": 11
+			},
+			"versions": "qubell"
+		},
+		"folderID": "Fdf50d447333221c279fe2179b7cb36812cafc03b05626a7880f21e6b346bb6f7",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.0-10.9 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"levelNum": {
+				"~gte": 10,
+				"~lt": 11
+			},
+			"versions": "qubell"
+		},
+		"folderID": "Fdf50d447333221c279fe2179b7cb36812cafc03b05626a7880f21e6b346bb6f7",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.0-10.9 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "10.1",
 			"versions": "festo"
@@ -14676,6 +14856,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.1 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.1",
+			"versions": "qubell"
+		},
+		"folderID": "Faf8e169b4b834733fb25d236fb0f4ad92af219cd0f42caf5cacf257ea5171ccc",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.1 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.1",
+			"versions": "qubell"
+		},
+		"folderID": "Faf8e169b4b834733fb25d236fb0f4ad92af219cd0f42caf5cacf257ea5171ccc",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.1 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.1",
+			"versions": "qubell"
+		},
+		"folderID": "F4c397041db53903b22865b8c390eef02f73ede5255ce56579a73d0bd70c4f995",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.1 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.1",
+			"versions": "qubell"
+		},
+		"folderID": "F4c397041db53903b22865b8c390eef02f73ede5255ce56579a73d0bd70c4f995",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.1 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -14708,6 +14944,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "10.2",
+			"versions": "qubell"
+		},
+		"folderID": "F7b118b28476578326314a935d67be1fdd2ad39f23b8e4ff2b5021c706713028a",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.2 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.2",
+			"versions": "qubell"
+		},
+		"folderID": "F7b118b28476578326314a935d67be1fdd2ad39f23b8e4ff2b5021c706713028a",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.2 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.2",
+			"versions": "qubell"
+		},
+		"folderID": "Fdfcb195fb263ff6752d64dd733b3fae721e7f020160ea8de8620a7065f5a5b66",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.2 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.2",
+			"versions": "qubell"
+		},
+		"folderID": "Fdfcb195fb263ff6752d64dd733b3fae721e7f020160ea8de8620a7065f5a5b66",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.2 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "10.3",
 			"versions": "festo"
@@ -14732,6 +15024,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.3 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.3",
+			"versions": "qubell"
+		},
+		"folderID": "F7f48e642b63ac308dad6e90b465c609b9ac7cc3c41d68a41f4773e5d276b54c8",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.3 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.3",
+			"versions": "qubell"
+		},
+		"folderID": "F7f48e642b63ac308dad6e90b465c609b9ac7cc3c41d68a41f4773e5d276b54c8",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.3 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.3",
+			"versions": "qubell"
+		},
+		"folderID": "F27a2a9846643e93056b6b9f156e22a1ed8a76438de0e01414bc1b6fa8a19850e",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.3 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.3",
+			"versions": "qubell"
+		},
+		"folderID": "F27a2a9846643e93056b6b9f156e22a1ed8a76438de0e01414bc1b6fa8a19850e",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.3 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -14764,6 +15112,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "10.4",
+			"versions": "qubell"
+		},
+		"folderID": "F202b8591c0a11c8828f8d10da55f823fef26137a04c2109218a667031dbd1a8b",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.4 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.4",
+			"versions": "qubell"
+		},
+		"folderID": "F202b8591c0a11c8828f8d10da55f823fef26137a04c2109218a667031dbd1a8b",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.4 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.4",
+			"versions": "qubell"
+		},
+		"folderID": "Fba5ae25a820d1a91907e87f8520fcd8aa54c341aa886c7f4f0769bea53cf2e7d",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.4 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.4",
+			"versions": "qubell"
+		},
+		"folderID": "Fba5ae25a820d1a91907e87f8520fcd8aa54c341aa886c7f4f0769bea53cf2e7d",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.4 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "10.5",
 			"versions": "festo"
@@ -14788,6 +15192,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.5 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.5",
+			"versions": "qubell"
+		},
+		"folderID": "Faad10d5ab6eb6aea155cab78a244b0b785b26132e752b6231f0e27bfae46b010",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.5 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.5",
+			"versions": "qubell"
+		},
+		"folderID": "Faad10d5ab6eb6aea155cab78a244b0b785b26132e752b6231f0e27bfae46b010",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.5 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.5",
+			"versions": "qubell"
+		},
+		"folderID": "F3f666e978ff44ae33810fa590ba3af10683d5fb7b40c418766a643f3911e5fd9",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.5 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.5",
+			"versions": "qubell"
+		},
+		"folderID": "F3f666e978ff44ae33810fa590ba3af10683d5fb7b40c418766a643f3911e5fd9",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.5 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -14820,6 +15280,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "10.6",
+			"versions": "qubell"
+		},
+		"folderID": "Fbe7f0fd9cf8899d5d637913c5fa49a87ce137c10280d21103ef9c9a9ff3efdfe",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.6 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.6",
+			"versions": "qubell"
+		},
+		"folderID": "Fbe7f0fd9cf8899d5d637913c5fa49a87ce137c10280d21103ef9c9a9ff3efdfe",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.6 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.6",
+			"versions": "qubell"
+		},
+		"folderID": "F528c7671d51c792696940a0f84a218fbbd34839b08096bf42681f2e75dac0a4b",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.6 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.6",
+			"versions": "qubell"
+		},
+		"folderID": "F528c7671d51c792696940a0f84a218fbbd34839b08096bf42681f2e75dac0a4b",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.6 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "10.7",
 			"versions": "festo"
@@ -14844,6 +15360,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.7 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.7",
+			"versions": "qubell"
+		},
+		"folderID": "F4f07a4cd561323f986c4cfb7c76ada1da2e1bc41b76e8c74b798fe71e5e6253c",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.7 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.7",
+			"versions": "qubell"
+		},
+		"folderID": "F4f07a4cd561323f986c4cfb7c76ada1da2e1bc41b76e8c74b798fe71e5e6253c",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.7 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.7",
+			"versions": "qubell"
+		},
+		"folderID": "F9b9e1d5f6e99168be8b6b4ff4397fb4b5dc51e89c008d10dcefd5e9a29ae76fd",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.7 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.7",
+			"versions": "qubell"
+		},
+		"folderID": "F9b9e1d5f6e99168be8b6b4ff4397fb4b5dc51e89c008d10dcefd5e9a29ae76fd",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.7 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -14876,6 +15448,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "10.8",
+			"versions": "qubell"
+		},
+		"folderID": "F0a9e942ed85ddddf3aef43c3ddb888c9e0ab8a2cdddbaeb4b3109a16f6cbdfb9",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.8 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.8",
+			"versions": "qubell"
+		},
+		"folderID": "F0a9e942ed85ddddf3aef43c3ddb888c9e0ab8a2cdddbaeb4b3109a16f6cbdfb9",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.8 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.8",
+			"versions": "qubell"
+		},
+		"folderID": "F2dec754c1fa1878a8573af3f6f4357cc2d59f540081da9ad1613bc1949f4691f",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.8 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.8",
+			"versions": "qubell"
+		},
+		"folderID": "F2dec754c1fa1878a8573af3f6f4357cc2d59f540081da9ad1613bc1949f4691f",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.8 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "10.9",
 			"versions": "festo"
@@ -14900,6 +15528,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.9 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.9",
+			"versions": "qubell"
+		},
+		"folderID": "F93a79e8959e267ae2c2a8a626e52c30c98b5bd1f6abac612562a5e34be8e08a6",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.9 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "10.9",
+			"versions": "qubell"
+		},
+		"folderID": "F93a79e8959e267ae2c2a8a626e52c30c98b5bd1f6abac612562a5e34be8e08a6",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.9 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.9",
+			"versions": "qubell"
+		},
+		"folderID": "Fcae67acaf13ad278cf94b17ac08ec53deaead9421dc27c569e708d49737acdf4",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.9 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "10.9",
+			"versions": "qubell"
+		},
+		"folderID": "Fcae67acaf13ad278cf94b17ac08ec53deaead9421dc27c569e708d49737acdf4",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 10.9 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -14932,6 +15616,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "2",
+			"versions": "qubell"
+		},
+		"folderID": "F208f1a0585dd99b71f2d214235b01d697dc9c78973df90caae6a4b76249f09f1",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 2 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "2",
+			"versions": "qubell"
+		},
+		"folderID": "F208f1a0585dd99b71f2d214235b01d697dc9c78973df90caae6a4b76249f09f1",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 2 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "2",
+			"versions": "qubell"
+		},
+		"folderID": "F901bbbbac9b53f49d32c041051064862d118018e2f9fa719e9b38b2689464c4d",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 2 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "2",
+			"versions": "qubell"
+		},
+		"folderID": "F901bbbbac9b53f49d32c041051064862d118018e2f9fa719e9b38b2689464c4d",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 2 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "3",
 			"versions": "festo"
@@ -14956,6 +15696,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 3 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "3",
+			"versions": "qubell"
+		},
+		"folderID": "F151ef81c121d531a222977c94a5dbbc256f7e2edcbae38869a293b2f6271b6b6",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 3 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "3",
+			"versions": "qubell"
+		},
+		"folderID": "F151ef81c121d531a222977c94a5dbbc256f7e2edcbae38869a293b2f6271b6b6",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 3 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "3",
+			"versions": "qubell"
+		},
+		"folderID": "Ff70993ed87bcadc48d957c29d5173868c34a904038234d50bb525d7eb7eb55e6",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 3 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "3",
+			"versions": "qubell"
+		},
+		"folderID": "Ff70993ed87bcadc48d957c29d5173868c34a904038234d50bb525d7eb7eb55e6",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 3 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -14988,6 +15784,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "4",
+			"versions": "qubell"
+		},
+		"folderID": "F87fbdd58a2c247307bfa1c8c46868ad71fd0f8747b51468266df033a5a051177",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 4 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "4",
+			"versions": "qubell"
+		},
+		"folderID": "F87fbdd58a2c247307bfa1c8c46868ad71fd0f8747b51468266df033a5a051177",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 4 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "4",
+			"versions": "qubell"
+		},
+		"folderID": "Fe5dd037701ac40f5b134585231bd23cffed503141261bdfc23aad73e44f748cc",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 4 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "4",
+			"versions": "qubell"
+		},
+		"folderID": "Fe5dd037701ac40f5b134585231bd23cffed503141261bdfc23aad73e44f748cc",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 4 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "5",
 			"versions": "festo"
@@ -15012,6 +15864,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 5 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "5",
+			"versions": "qubell"
+		},
+		"folderID": "Fcb4327d3ac9a2e863f7899347cb14cdf29e1f35f45bf623b4b40aa1b32045939",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 5 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "5",
+			"versions": "qubell"
+		},
+		"folderID": "Fcb4327d3ac9a2e863f7899347cb14cdf29e1f35f45bf623b4b40aa1b32045939",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 5 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "5",
+			"versions": "qubell"
+		},
+		"folderID": "Fc334e07ec305b4bde36800a13538e6d061d9d476386435d3db5ab47dcb9ec2c0",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 5 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "5",
+			"versions": "qubell"
+		},
+		"folderID": "Fc334e07ec305b4bde36800a13538e6d061d9d476386435d3db5ab47dcb9ec2c0",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 5 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15044,6 +15952,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "6",
+			"versions": "qubell"
+		},
+		"folderID": "F72a0fae6c5eecda2ead01c2043f8e6ed4f8a5ef9a6d702a2cb54e824f8c9a67d",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 6 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "6",
+			"versions": "qubell"
+		},
+		"folderID": "F72a0fae6c5eecda2ead01c2043f8e6ed4f8a5ef9a6d702a2cb54e824f8c9a67d",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 6 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "6",
+			"versions": "qubell"
+		},
+		"folderID": "F34637877cb994285dd864e417a3d2e27dc1454ab2fe1686abb5392c49c784af9",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 6 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "6",
+			"versions": "qubell"
+		},
+		"folderID": "F34637877cb994285dd864e417a3d2e27dc1454ab2fe1686abb5392c49c784af9",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 6 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "7",
 			"versions": "festo"
@@ -15068,6 +16032,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 7 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "7",
+			"versions": "qubell"
+		},
+		"folderID": "F8b6f9d77733d0e21d181cfad3bcfe3e355588692d80a4cfc620f4d3ba5e932ed",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 7 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "7",
+			"versions": "qubell"
+		},
+		"folderID": "F8b6f9d77733d0e21d181cfad3bcfe3e355588692d80a4cfc620f4d3ba5e932ed",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 7 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "7",
+			"versions": "qubell"
+		},
+		"folderID": "F5d27bfbb6406037c128bda07923226c7b7285ed5b6e181fb859cba602570df3d",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 7 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "7",
+			"versions": "qubell"
+		},
+		"folderID": "F5d27bfbb6406037c128bda07923226c7b7285ed5b6e181fb859cba602570df3d",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 7 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15100,6 +16120,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "8",
+			"versions": "qubell"
+		},
+		"folderID": "Ff1decf8630c85a73ec485792b2efb41a7d167e1645f1b5db2ed2af6f92fa3a0c",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 8 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "8",
+			"versions": "qubell"
+		},
+		"folderID": "Ff1decf8630c85a73ec485792b2efb41a7d167e1645f1b5db2ed2af6f92fa3a0c",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 8 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "8",
+			"versions": "qubell"
+		},
+		"folderID": "Fda5de4a190e4d4f3cf8324babade6046663b820b14f7a519803dc2401f8609ba",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 8 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "8",
+			"versions": "qubell"
+		},
+		"folderID": "Fda5de4a190e4d4f3cf8324babade6046663b820b14f7a519803dc2401f8609ba",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 8 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "9.0",
 			"versions": "festo"
@@ -15124,6 +16200,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.0 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.0",
+			"versions": "qubell"
+		},
+		"folderID": "F09219275678563e904ab9dc25c3741166f4cb35bff9f9a8520148395a7b312af",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.0 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.0",
+			"versions": "qubell"
+		},
+		"folderID": "F09219275678563e904ab9dc25c3741166f4cb35bff9f9a8520148395a7b312af",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.0 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.0",
+			"versions": "qubell"
+		},
+		"folderID": "F20ae291c14499228ea751fa248696429796f5e62ee783fe651b3c103eda659f5",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.0 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.0",
+			"versions": "qubell"
+		},
+		"folderID": "F20ae291c14499228ea751fa248696429796f5e62ee783fe651b3c103eda659f5",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.0 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15162,6 +16294,74 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"levelNum": {
+				"~gte": 9,
+				"~lt": 10
+			},
+			"versions": "qubell"
+		},
+		"folderID": "Fb6d2c97d0ba9392fd8eed8c95f8744236e549b1a86828c372c3abf8ba5920f33",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.0-9.9 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"levelNum": {
+				"~gte": 9,
+				"~lt": 10
+			},
+			"versions": "qubell"
+		},
+		"folderID": "Fb6d2c97d0ba9392fd8eed8c95f8744236e549b1a86828c372c3abf8ba5920f33",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.0-9.9 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"levelNum": {
+				"~gte": 9,
+				"~lt": 10
+			},
+			"versions": "qubell"
+		},
+		"folderID": "Fffa3c667d9eeecc9fd9d404fdef7d4f67d5ff28cb75d7c8e3a7039b44e0aa4a4",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.0-9.9 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"levelNum": {
+				"~gte": 9,
+				"~lt": 10
+			},
+			"versions": "qubell"
+		},
+		"folderID": "Fffa3c667d9eeecc9fd9d404fdef7d4f67d5ff28cb75d7c8e3a7039b44e0aa4a4",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.0-9.9 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "9.1",
 			"versions": "festo"
@@ -15186,6 +16386,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.1 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.1",
+			"versions": "qubell"
+		},
+		"folderID": "F32b98c655d8e4c9ed1e31f8e45e4cd0dfccb1b69645899677a237e388fea36db",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.1 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.1",
+			"versions": "qubell"
+		},
+		"folderID": "F32b98c655d8e4c9ed1e31f8e45e4cd0dfccb1b69645899677a237e388fea36db",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.1 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.1",
+			"versions": "qubell"
+		},
+		"folderID": "Ff7c38930fb3ca0020356ae6e4b670164b47a5592be8b047212c7e120f2862642",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.1 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.1",
+			"versions": "qubell"
+		},
+		"folderID": "Ff7c38930fb3ca0020356ae6e4b670164b47a5592be8b047212c7e120f2862642",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.1 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15218,6 +16474,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "9.2",
+			"versions": "qubell"
+		},
+		"folderID": "F69d54c0e3d60411370a1ae429f16b7a53e29d09c074354ede5d0ba2e56bc3a07",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.2 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.2",
+			"versions": "qubell"
+		},
+		"folderID": "F69d54c0e3d60411370a1ae429f16b7a53e29d09c074354ede5d0ba2e56bc3a07",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.2 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.2",
+			"versions": "qubell"
+		},
+		"folderID": "F8801ade829e863add502acab3c0a12244b06404855d285b5cf83b7a67bf2bdfe",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.2 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.2",
+			"versions": "qubell"
+		},
+		"folderID": "F8801ade829e863add502acab3c0a12244b06404855d285b5cf83b7a67bf2bdfe",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.2 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "9.3",
 			"versions": "festo"
@@ -15242,6 +16554,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.3 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.3",
+			"versions": "qubell"
+		},
+		"folderID": "F4a21c50763e0c8d98be6ccd6fc643c4eb72ba2f305b1164bb7f2d1a7c7d8e2c7",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.3 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.3",
+			"versions": "qubell"
+		},
+		"folderID": "F4a21c50763e0c8d98be6ccd6fc643c4eb72ba2f305b1164bb7f2d1a7c7d8e2c7",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.3 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.3",
+			"versions": "qubell"
+		},
+		"folderID": "Fb6b6147f2e7c6b0ad7c2058035883b005c1446b1308eeaf3ce6bbf937b7e6dc1",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.3 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.3",
+			"versions": "qubell"
+		},
+		"folderID": "Fb6b6147f2e7c6b0ad7c2058035883b005c1446b1308eeaf3ce6bbf937b7e6dc1",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.3 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15274,6 +16642,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "9.4",
+			"versions": "qubell"
+		},
+		"folderID": "Fafd825da4667bbde09ae3d11c236724032b86a7b7329e103299da4567feae448",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.4 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.4",
+			"versions": "qubell"
+		},
+		"folderID": "Fafd825da4667bbde09ae3d11c236724032b86a7b7329e103299da4567feae448",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.4 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.4",
+			"versions": "qubell"
+		},
+		"folderID": "F3fce8b8d04e7ba2d707ea2e7051d3205d2fcc9a8b6c58eb71f5402cfd0997a48",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.4 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.4",
+			"versions": "qubell"
+		},
+		"folderID": "F3fce8b8d04e7ba2d707ea2e7051d3205d2fcc9a8b6c58eb71f5402cfd0997a48",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.4 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "9.5",
 			"versions": "festo"
@@ -15298,6 +16722,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.5 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.5",
+			"versions": "qubell"
+		},
+		"folderID": "Ff60b9959e9dd7ca4b508c707bd1d38ac53121f79ba87e3bab73dd4ca1e6d6ccc",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.5 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.5",
+			"versions": "qubell"
+		},
+		"folderID": "Ff60b9959e9dd7ca4b508c707bd1d38ac53121f79ba87e3bab73dd4ca1e6d6ccc",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.5 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.5",
+			"versions": "qubell"
+		},
+		"folderID": "F249dd63ae3b329ac8b5bbcd1e7a0b336797cf7a238cb8260fab0e4975adf13e5",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.5 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.5",
+			"versions": "qubell"
+		},
+		"folderID": "F249dd63ae3b329ac8b5bbcd1e7a0b336797cf7a238cb8260fab0e4975adf13e5",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.5 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15330,6 +16810,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "9.6",
+			"versions": "qubell"
+		},
+		"folderID": "Fc861d6bc47e38ce078c550341bc55aa24af9c732a2bdc98c9b10bf27673d1fc3",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.6 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.6",
+			"versions": "qubell"
+		},
+		"folderID": "Fc861d6bc47e38ce078c550341bc55aa24af9c732a2bdc98c9b10bf27673d1fc3",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.6 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.6",
+			"versions": "qubell"
+		},
+		"folderID": "Fcce4156df9a12a4103b2392e72b1f75d60c262bca01fb839eec8e30e7d522744",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.6 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.6",
+			"versions": "qubell"
+		},
+		"folderID": "Fcce4156df9a12a4103b2392e72b1f75d60c262bca01fb839eec8e30e7d522744",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.6 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "9.7",
 			"versions": "festo"
@@ -15354,6 +16890,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.7 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.7",
+			"versions": "qubell"
+		},
+		"folderID": "F14abe58c1100e9def6786f8a0009edd29b899e4e53c135e55ef48324eeb41449",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.7 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.7",
+			"versions": "qubell"
+		},
+		"folderID": "F14abe58c1100e9def6786f8a0009edd29b899e4e53c135e55ef48324eeb41449",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.7 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.7",
+			"versions": "qubell"
+		},
+		"folderID": "F9d76c89ed6c2f35e9aa1d9742bf3ee4a596cd9bcdc5357db9afb911021b7d387",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.7 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.7",
+			"versions": "qubell"
+		},
+		"folderID": "F9d76c89ed6c2f35e9aa1d9742bf3ee4a596cd9bcdc5357db9afb911021b7d387",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.7 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15386,6 +16978,62 @@
 	},
 	{
 		"data": {
+			"data¬isHardMode": true,
+			"level": "9.8",
+			"versions": "qubell"
+		},
+		"folderID": "F872641c086f45fbb52a14eb7e53604979b792b36fb6f4e9c2d476fd7d5e63770",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.8 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.8",
+			"versions": "qubell"
+		},
+		"folderID": "F872641c086f45fbb52a14eb7e53604979b792b36fb6f4e9c2d476fd7d5e63770",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.8 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.8",
+			"versions": "qubell"
+		},
+		"folderID": "Fe430c1ee08c016a0c941602c0a8efdfb17bc11758f4534b6169d153b45bf9972",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.8 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.8",
+			"versions": "qubell"
+		},
+		"folderID": "Fe430c1ee08c016a0c941602c0a8efdfb17bc11758f4534b6169d153b45bf9972",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.8 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
 			"data¬isHardMode": false,
 			"level": "9.9",
 			"versions": "festo"
@@ -15410,6 +17058,62 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.9 (Hard Mode) (festo)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.9",
+			"versions": "qubell"
+		},
+		"folderID": "F59d3adb67561e2ec175c0e971b8c688c8c15310a09fc0cb689f34d98ec4eacf1",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.9 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": true,
+			"level": "9.9",
+			"versions": "qubell"
+		},
+		"folderID": "F59d3adb67561e2ec175c0e971b8c688c8c15310a09fc0cb689f34d98ec4eacf1",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.9 (Hard Mode) (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.9",
+			"versions": "qubell"
+		},
+		"folderID": "F4d2fb041630da3c62e179cfae79ce545262ff59e40be2e23f8ce7a49c04a1f0a",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.9 (Qubell)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"data¬isHardMode": false,
+			"level": "9.9",
+			"versions": "qubell"
+		},
+		"folderID": "F4d2fb041630da3c62e179cfae79ce545262ff59e40be2e23f8ce7a49c04a1f0a",
+		"game": "jubeat",
+		"inactive": false,
+		"playtype": "Single",
+		"searchTerms": [],
+		"title": "Level 9.9 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -23330,857 +25034,5 @@
 		"searchTerms": [],
 		"title": "Level 9+ (Reverse)",
 		"type": "charts"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "1",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 1 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fdf5a9b9db3a846505e65fa996c9aa3592bc464b80959bb0cbd68c82025a89c06"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "2",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 2 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fbc77f5489a783e2a8a02550f1e19abab42d08625de76d0e30b379b922a358ac4"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "3",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 3 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Ffe634635103f8e289ecff87894fd6626ae1525180d34892b33d571b301cb805e"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "4",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 4 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Ffa8da604e42a607981a3e6756775fc5cd2e5c1b66a7e55c487155c0c2d4f2001"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "5",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 5 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F081f60e92df88ac830eab351bee8c0ed0b34c97d4e1ce732fc48197710f986b7"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "6",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 6 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F954803ab7d11ba39f1a39cec9ba304f18cc82d543d7b2d9b559f9045e34f6399"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "7",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 7 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F6e97f425059c30cf2fec0f1290a72dd605ef3922163ee44f535d8cd9e02b58e8"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "8",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 8 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F71077a2b710e331361cb1152ecd5a0e205ac2d2c1cfae744cef02092912d682a"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"levelNum": {
-				"~gte": 9,
-				"~lt": 10
-			},
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.0-9.9 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fe5d29f7a4113f0d6997566df019deb693f9cb9ba2e55d3aa2cc12c4dec5069ee"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"levelNum": {
-				"~gte": 10,
-				"~lt": 11
-			},
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.0-10.9 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F14c64144cc655f472282883777a7e39ae12ef28e7abebe728de7eb0806b342c3"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "1",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 1 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fc229e8c6176ac6ad734cb867cfbc5e6ba7fed0a0f49a89a17e9e4cad5d2c237d"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "2",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 2 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fd171cb52932779b7890bdabb2e0f7eaab98a6bb02272ccca66b7c3aa94c270a8"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "3",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 3 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F7dac3ad5c93e4e077f9fbceebd2d65000cdaa0045a97bb6d944cbc195b1bc99b"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "4",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 4 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fca6afd35e745b949876127b6b8513ed8232bb91c62d405f8f5ac224ecd625f3d"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "5",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 5 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F410910648e59593e0fca50f420c64b57ba97a0eeab6d2c53eff96103f22518c2"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "6",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 6 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fbe2c71a29c52f0f8bad023d301e708aaaca9f142410ba1a2624f64f7434533fd"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "7",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 7 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F4afded0ec1884418369acb285c8dac9d25a0b7bdb89c97f8c84ade506e9d5988"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "8",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 8 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fb06f06975fe60068bc848eb4bf92feae52cb23e4ea5f86abe65b977da8698608"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"levelNum": {
-				"~gte": 9,
-				"~lt": 10
-			},
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.0-9.9 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F63c2d607302677d5c81742f230678135d108140484481ee9c794f8d666837729"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"levelNum": {
-				"~gte": 10,
-				"~lt": 11
-			},
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.0-10.9 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F4ca952c9f50ab0640a893f145cd0c8854d9dcb7399cb15a03f519c80f07568c0"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.0",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.0 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fb07ace67223ed8dd542cc21424ea99a91bdec53a45793ba53679fb45c19a0f54"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.1",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.1 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F502fd71ce5622ec22abc63eb74e0fc0edd434ea449ce1bde695a897f72191e52"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.2",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.2 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fcff6dd5cd759f9ecadb0e62f3606488d722e95bd871afb4dbd485b3315a01e87"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.3",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.3 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fa48061e93f68acb104eeb38701b22818e06cf5eed599fa4983fe50c45caf5cdb"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.4",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.4 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F0632e541366f9013a6c34c5757b80adbb41d5f88c6bb55dd5b5acf59a9afab6d"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.5",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.5 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F65a46e91483c5292ee2a018488ce4487ecab42f1e63df5de889e4d433ee35c71"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.6",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.6 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F7de03e7edc965bcfa3d5d6e69f0cc041c692314af9b88428e335df21f4d503a1"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.7",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.7 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F464fa2b661d89300bc1858dc833f2f8fc0a756fa024f6a6706bba3a363981af6"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.8",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.8 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F6933c622828b50eea323d1a89b0de584461260a11cd84b5ff4f2f3527735e9ff"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.9",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 9.9 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fd6d9a697ba24218a77335a74d409a03d410357092c5f51b542674f4c01549e35"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.0",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.0 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fe89d98f9b48079e73adad0ad97b3719e40bf19111c057396fd3d0c82e8cb8189"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.1",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.1 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Faea9f0b700a7a7a0cc93643adc3b6bee78ce98609897fa74a9720a84ae2628ae"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.2",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.2 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F0931caa15839163cbe1df581552c7bbe6cdfee2f35342e7b61ae5a98101e86ec"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.3",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.3 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fd9375a97bd14e7a27a18ffe7dd78b14d9fe95229f27e135876a03e663441972a"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.4",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.4 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F15ca96d7b48552ea47fb8d4c2549c9b13abe66e47a8bc389c8da947401e91501"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.5",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.5 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F1a1ae8df53ecbc685d8e1263ec5423167982d0de2385e90e7c57c5d37e98ce7f"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.6",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.6 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F97aaca476c15c73ee4b77251cb545322ce55765965a878681bbb766d44b0d0e6"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.7",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.7 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fe64ecb99fe815e308363a1c4f84c988e2626ff4804021ba298cfa31ce234f439"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.8",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.8 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F42a00e626ca7ada4a7d52bb027cbb192ff76e0117f01b147ec704b1ccb5eaabf"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.9",
-			"versions": "qubell",
-			"data¬isHardMode": false
-		},
-		"searchTerms": [],
-		"title": "Level 10.9 (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F5775764ff67636311085b6b44d7c717a67c57eab16ffcde2ec75d80913331633"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.0",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.0 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fcf781e3d42a2d53803fa842088fa401362554932f481a7996e0a87a809ff0e85"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.1",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.1 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fbb1c319e0d8ce1c3eaa1ea1e5dc8bebd85428bd4f4313f6f6d294815062d7f8c"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.2",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.2 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F532bda0170903df3d241bbdafd2c466766c911c74b3160951aecfd952f44fcca"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.3",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.3 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fed4a75299f42c66358dd603e384ab3736365bba0db5d36e85f4a20b773f63250"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.4",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.4 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fffa286f2bb3816731cd2fefaf9d9287af073ba55ac4beb78a867d692b876aef6"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.5",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.5 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F09e1c75fc5cfdea4d2f57a40b9cc647804079c8300558ef17f2dd11305445635"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.6",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.6 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fabe8505e35aa0bf43aa0ed8e443bcf7227bb40b19bb840f826952178afa03b25"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.7",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.7 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fc7ed27d1fc78a0b1f52da21b2282a40273d663fdf79ca48d63cead20571cfab8"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.8",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.8 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fdbe14321b1cdd3d612109a408994502ca68ed3757969ca53b0ecf82221fa2091"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "9.9",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 9.9 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F3dec6f227b21f562a95b78785ca68468a25e157901d6b34e2c9c60d9e46ad39c"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.0",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.0 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fff7db1aca35042626dd7ae1ddf09178b9dc17be9d88e3b494f09af06d05ad2b4"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.1",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.1 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fa0a13dcc4939de466ed417b7d47f361ec448930ad772790bd83e9de3d22b8ca6"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.2",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.2 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F3de7c9091d8898d15bb5a761bba2d089651fc9fe5e2261df00232f2287c79b49"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.3",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.3 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fe050024d4ed37987581c9a53f79adee055879907a6fc529471d82aafe7bc9f9c"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.4",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.4 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "Fdef00951dfba618c310a201e8c465639caf2efb9147b6751a3bb0604ee6051e0"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.5",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.5 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F64c0d4a03a28c9f95bbc3799a2e74cba3fc3b28b08c3c447fc9a1b8828466ca5"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.6",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.6 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F13c1998f798d989eb11f7ef254327cf2ac26b088049ccb642ffa2fa9fd902fe1"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.7",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.7 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F9e07f649f8f195aeeab7c70291d350ea9b33643358c0460bd17059fd0ab59cc0"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.8",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.8 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F83dd467c6426344c1e46806d1b70b09f2ea5a1111fcefdc8483781ec4303e876"
-	},
-	{
-		"game": "jubeat",
-		"playtype": "Single",
-		"data": {
-			"level": "10.9",
-			"versions": "qubell",
-			"data¬isHardMode": true
-		},
-		"searchTerms": [],
-		"title": "Level 10.9 (Hard Mode) (Qubell)",
-		"type": "charts",
-		"inactive": false,
-		"folderID": "F844e8d8ae236ea42ca7848e509f4c4a6965562505fd83f5792c2e75cad565390"
 	}
 ]

--- a/database-seeds/collections/folders.json
+++ b/database-seeds/collections/folders.json
@@ -14604,34 +14604,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "1",
-			"versions": "qubell"
-		},
-		"folderID": "Fe6eca44eb7688565d6dfbbd942866c1e1ad3569ca6c2a17c1e10f2ba207ca7e3",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 1 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "1",
-			"versions": "qubell"
-		},
-		"folderID": "F5597b8e01373f3ed99e7e65ab2cd73abc7dee912edf2bacd146c4e6957da271f",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 1 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "1",
 			"versions": "qubell"
@@ -14684,34 +14656,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.0 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "10.0",
-			"versions": "qubell"
-		},
-		"folderID": "F27815177696466ed771e1e8254143affd578719428955e6804e6df83783be2d7",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.0 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "10.0",
-			"versions": "qubell"
-		},
-		"folderID": "F896456d42e285a3897f50dabc1bd382f60c7de09fdebb023a4a0e6eabb3cc086",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.0 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -14781,40 +14725,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"levelNum": {
-				"~gte": 10,
-				"~lt": 11
-			},
-			"versions": "qubell"
-		},
-		"folderID": "F8a63e5b8ff8a5843ef4f2da6472f6325042b1bf338b1e15d12f0e2550ca93501",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.0-10.9 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"levelNum": {
-				"~gte": 10,
-				"~lt": 11
-			},
-			"versions": "qubell"
-		},
-		"folderID": "Fdf50d447333221c279fe2179b7cb36812cafc03b05626a7880f21e6b346bb6f7",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.0-10.9 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"levelNum": {
 				"~gte": 10,
@@ -14870,34 +14780,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.1 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "10.1",
-			"versions": "qubell"
-		},
-		"folderID": "Faf8e169b4b834733fb25d236fb0f4ad92af219cd0f42caf5cacf257ea5171ccc",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.1 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "10.1",
-			"versions": "qubell"
-		},
-		"folderID": "F4c397041db53903b22865b8c390eef02f73ede5255ce56579a73d0bd70c4f995",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.1 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -14958,34 +14840,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "10.2",
-			"versions": "qubell"
-		},
-		"folderID": "F7b118b28476578326314a935d67be1fdd2ad39f23b8e4ff2b5021c706713028a",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.2 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "10.2",
-			"versions": "qubell"
-		},
-		"folderID": "Fdfcb195fb263ff6752d64dd733b3fae721e7f020160ea8de8620a7065f5a5b66",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.2 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "10.2",
 			"versions": "qubell"
@@ -15038,34 +14892,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.3 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "10.3",
-			"versions": "qubell"
-		},
-		"folderID": "F7f48e642b63ac308dad6e90b465c609b9ac7cc3c41d68a41f4773e5d276b54c8",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.3 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "10.3",
-			"versions": "qubell"
-		},
-		"folderID": "F27a2a9846643e93056b6b9f156e22a1ed8a76438de0e01414bc1b6fa8a19850e",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.3 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15126,34 +14952,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "10.4",
-			"versions": "qubell"
-		},
-		"folderID": "F202b8591c0a11c8828f8d10da55f823fef26137a04c2109218a667031dbd1a8b",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.4 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "10.4",
-			"versions": "qubell"
-		},
-		"folderID": "Fba5ae25a820d1a91907e87f8520fcd8aa54c341aa886c7f4f0769bea53cf2e7d",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.4 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "10.4",
 			"versions": "qubell"
@@ -15206,34 +15004,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.5 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "10.5",
-			"versions": "qubell"
-		},
-		"folderID": "Faad10d5ab6eb6aea155cab78a244b0b785b26132e752b6231f0e27bfae46b010",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.5 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "10.5",
-			"versions": "qubell"
-		},
-		"folderID": "F3f666e978ff44ae33810fa590ba3af10683d5fb7b40c418766a643f3911e5fd9",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.5 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15294,34 +15064,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "10.6",
-			"versions": "qubell"
-		},
-		"folderID": "Fbe7f0fd9cf8899d5d637913c5fa49a87ce137c10280d21103ef9c9a9ff3efdfe",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.6 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "10.6",
-			"versions": "qubell"
-		},
-		"folderID": "F528c7671d51c792696940a0f84a218fbbd34839b08096bf42681f2e75dac0a4b",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.6 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "10.6",
 			"versions": "qubell"
@@ -15374,34 +15116,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.7 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "10.7",
-			"versions": "qubell"
-		},
-		"folderID": "F4f07a4cd561323f986c4cfb7c76ada1da2e1bc41b76e8c74b798fe71e5e6253c",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.7 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "10.7",
-			"versions": "qubell"
-		},
-		"folderID": "F9b9e1d5f6e99168be8b6b4ff4397fb4b5dc51e89c008d10dcefd5e9a29ae76fd",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.7 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15462,34 +15176,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "10.8",
-			"versions": "qubell"
-		},
-		"folderID": "F0a9e942ed85ddddf3aef43c3ddb888c9e0ab8a2cdddbaeb4b3109a16f6cbdfb9",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.8 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "10.8",
-			"versions": "qubell"
-		},
-		"folderID": "F2dec754c1fa1878a8573af3f6f4357cc2d59f540081da9ad1613bc1949f4691f",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.8 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "10.8",
 			"versions": "qubell"
@@ -15542,34 +15228,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 10.9 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "10.9",
-			"versions": "qubell"
-		},
-		"folderID": "F93a79e8959e267ae2c2a8a626e52c30c98b5bd1f6abac612562a5e34be8e08a6",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.9 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "10.9",
-			"versions": "qubell"
-		},
-		"folderID": "Fcae67acaf13ad278cf94b17ac08ec53deaead9421dc27c569e708d49737acdf4",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 10.9 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15630,34 +15288,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "2",
-			"versions": "qubell"
-		},
-		"folderID": "F208f1a0585dd99b71f2d214235b01d697dc9c78973df90caae6a4b76249f09f1",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 2 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "2",
-			"versions": "qubell"
-		},
-		"folderID": "F901bbbbac9b53f49d32c041051064862d118018e2f9fa719e9b38b2689464c4d",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 2 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "2",
 			"versions": "qubell"
@@ -15710,34 +15340,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 3 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "3",
-			"versions": "qubell"
-		},
-		"folderID": "F151ef81c121d531a222977c94a5dbbc256f7e2edcbae38869a293b2f6271b6b6",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 3 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "3",
-			"versions": "qubell"
-		},
-		"folderID": "Ff70993ed87bcadc48d957c29d5173868c34a904038234d50bb525d7eb7eb55e6",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 3 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15798,34 +15400,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "4",
-			"versions": "qubell"
-		},
-		"folderID": "F87fbdd58a2c247307bfa1c8c46868ad71fd0f8747b51468266df033a5a051177",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 4 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "4",
-			"versions": "qubell"
-		},
-		"folderID": "Fe5dd037701ac40f5b134585231bd23cffed503141261bdfc23aad73e44f748cc",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 4 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "4",
 			"versions": "qubell"
@@ -15878,34 +15452,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 5 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "5",
-			"versions": "qubell"
-		},
-		"folderID": "Fcb4327d3ac9a2e863f7899347cb14cdf29e1f35f45bf623b4b40aa1b32045939",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 5 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "5",
-			"versions": "qubell"
-		},
-		"folderID": "Fc334e07ec305b4bde36800a13538e6d061d9d476386435d3db5ab47dcb9ec2c0",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 5 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -15966,34 +15512,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "6",
-			"versions": "qubell"
-		},
-		"folderID": "F72a0fae6c5eecda2ead01c2043f8e6ed4f8a5ef9a6d702a2cb54e824f8c9a67d",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 6 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "6",
-			"versions": "qubell"
-		},
-		"folderID": "F34637877cb994285dd864e417a3d2e27dc1454ab2fe1686abb5392c49c784af9",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 6 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "6",
 			"versions": "qubell"
@@ -16046,34 +15564,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 7 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "7",
-			"versions": "qubell"
-		},
-		"folderID": "F8b6f9d77733d0e21d181cfad3bcfe3e355588692d80a4cfc620f4d3ba5e932ed",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 7 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "7",
-			"versions": "qubell"
-		},
-		"folderID": "F5d27bfbb6406037c128bda07923226c7b7285ed5b6e181fb859cba602570df3d",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 7 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -16134,34 +15624,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "8",
-			"versions": "qubell"
-		},
-		"folderID": "Ff1decf8630c85a73ec485792b2efb41a7d167e1645f1b5db2ed2af6f92fa3a0c",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 8 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "8",
-			"versions": "qubell"
-		},
-		"folderID": "Fda5de4a190e4d4f3cf8324babade6046663b820b14f7a519803dc2401f8609ba",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 8 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "8",
 			"versions": "qubell"
@@ -16214,34 +15676,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.0 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "9.0",
-			"versions": "qubell"
-		},
-		"folderID": "F09219275678563e904ab9dc25c3741166f4cb35bff9f9a8520148395a7b312af",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.0 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "9.0",
-			"versions": "qubell"
-		},
-		"folderID": "F20ae291c14499228ea751fa248696429796f5e62ee783fe651b3c103eda659f5",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.0 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -16311,40 +15745,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"levelNum": {
-				"~gte": 9,
-				"~lt": 10
-			},
-			"versions": "qubell"
-		},
-		"folderID": "Fb6d2c97d0ba9392fd8eed8c95f8744236e549b1a86828c372c3abf8ba5920f33",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.0-9.9 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"levelNum": {
-				"~gte": 9,
-				"~lt": 10
-			},
-			"versions": "qubell"
-		},
-		"folderID": "Fffa3c667d9eeecc9fd9d404fdef7d4f67d5ff28cb75d7c8e3a7039b44e0aa4a4",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.0-9.9 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"levelNum": {
 				"~gte": 9,
@@ -16400,34 +15800,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.1 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "9.1",
-			"versions": "qubell"
-		},
-		"folderID": "F32b98c655d8e4c9ed1e31f8e45e4cd0dfccb1b69645899677a237e388fea36db",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.1 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "9.1",
-			"versions": "qubell"
-		},
-		"folderID": "Ff7c38930fb3ca0020356ae6e4b670164b47a5592be8b047212c7e120f2862642",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.1 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -16488,34 +15860,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "9.2",
-			"versions": "qubell"
-		},
-		"folderID": "F69d54c0e3d60411370a1ae429f16b7a53e29d09c074354ede5d0ba2e56bc3a07",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.2 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "9.2",
-			"versions": "qubell"
-		},
-		"folderID": "F8801ade829e863add502acab3c0a12244b06404855d285b5cf83b7a67bf2bdfe",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.2 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "9.2",
 			"versions": "qubell"
@@ -16568,34 +15912,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.3 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "9.3",
-			"versions": "qubell"
-		},
-		"folderID": "F4a21c50763e0c8d98be6ccd6fc643c4eb72ba2f305b1164bb7f2d1a7c7d8e2c7",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.3 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "9.3",
-			"versions": "qubell"
-		},
-		"folderID": "Fb6b6147f2e7c6b0ad7c2058035883b005c1446b1308eeaf3ce6bbf937b7e6dc1",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.3 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -16656,34 +15972,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "9.4",
-			"versions": "qubell"
-		},
-		"folderID": "Fafd825da4667bbde09ae3d11c236724032b86a7b7329e103299da4567feae448",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.4 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "9.4",
-			"versions": "qubell"
-		},
-		"folderID": "F3fce8b8d04e7ba2d707ea2e7051d3205d2fcc9a8b6c58eb71f5402cfd0997a48",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.4 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "9.4",
 			"versions": "qubell"
@@ -16736,34 +16024,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.5 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "9.5",
-			"versions": "qubell"
-		},
-		"folderID": "Ff60b9959e9dd7ca4b508c707bd1d38ac53121f79ba87e3bab73dd4ca1e6d6ccc",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.5 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "9.5",
-			"versions": "qubell"
-		},
-		"folderID": "F249dd63ae3b329ac8b5bbcd1e7a0b336797cf7a238cb8260fab0e4975adf13e5",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.5 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -16824,34 +16084,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "9.6",
-			"versions": "qubell"
-		},
-		"folderID": "Fc861d6bc47e38ce078c550341bc55aa24af9c732a2bdc98c9b10bf27673d1fc3",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.6 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "9.6",
-			"versions": "qubell"
-		},
-		"folderID": "Fcce4156df9a12a4103b2392e72b1f75d60c262bca01fb839eec8e30e7d522744",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.6 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "9.6",
 			"versions": "qubell"
@@ -16904,34 +16136,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.7 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "9.7",
-			"versions": "qubell"
-		},
-		"folderID": "F14abe58c1100e9def6786f8a0009edd29b899e4e53c135e55ef48324eeb41449",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.7 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "9.7",
-			"versions": "qubell"
-		},
-		"folderID": "F9d76c89ed6c2f35e9aa1d9742bf3ee4a596cd9bcdc5357db9afb911021b7d387",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.7 (Qubell)",
 		"type": "charts"
 	},
 	{
@@ -16992,34 +16196,6 @@
 	},
 	{
 		"data": {
-			"data¬isHardMode": true,
-			"level": "9.8",
-			"versions": "qubell"
-		},
-		"folderID": "F872641c086f45fbb52a14eb7e53604979b792b36fb6f4e9c2d476fd7d5e63770",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.8 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "9.8",
-			"versions": "qubell"
-		},
-		"folderID": "Fe430c1ee08c016a0c941602c0a8efdfb17bc11758f4534b6169d153b45bf9972",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.8 (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
 			"data¬isHardMode": false,
 			"level": "9.8",
 			"versions": "qubell"
@@ -17072,34 +16248,6 @@
 		"playtype": "Single",
 		"searchTerms": [],
 		"title": "Level 9.9 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": true,
-			"level": "9.9",
-			"versions": "qubell"
-		},
-		"folderID": "F59d3adb67561e2ec175c0e971b8c688c8c15310a09fc0cb689f34d98ec4eacf1",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.9 (Hard Mode) (Qubell)",
-		"type": "charts"
-	},
-	{
-		"data": {
-			"data¬isHardMode": false,
-			"level": "9.9",
-			"versions": "qubell"
-		},
-		"folderID": "F4d2fb041630da3c62e179cfae79ce545262ff59e40be2e23f8ce7a49c04a1f0a",
-		"game": "jubeat",
-		"inactive": false,
-		"playtype": "Single",
-		"searchTerms": [],
-		"title": "Level 9.9 (Qubell)",
 		"type": "charts"
 	},
 	{

--- a/database-seeds/collections/songs-jubeat.json
+++ b/database-seeds/collections/songs-jubeat.json
@@ -10788,5 +10788,345 @@
 		"id": 1079,
 		"searchTerms": [],
 		"title": "Still Lonesome"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "jubeat"
+		},
+		"id": 1080,
+		"searchTerms": [],
+		"title": "BLUE BIRD"
+	},
+	{
+		"altTitles": [],
+		"artist": "ガガSP",
+		"data": {
+			"displayVersion": "ripples"
+		},
+		"id": 1081,
+		"searchTerms": [],
+		"title": "にんげんっていいな"
+	},
+	{
+		"altTitles": [],
+		"artist": "ALI PROJECT",
+		"data": {
+			"displayVersion": "ripples"
+		},
+		"id": 1082,
+		"searchTerms": [],
+		"title": "鬼帝の剣"
+	},
+	{
+		"altTitles": [],
+		"artist": "9mm Parabellum Bullet",
+		"data": {
+			"displayVersion": "knit"
+		},
+		"id": 1083,
+		"searchTerms": [],
+		"title": "Supernova"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "copious"
+		},
+		"id": 1084,
+		"searchTerms": [],
+		"title": "Let's ダバダバ"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 1085,
+		"searchTerms": [],
+		"title": "Synchrogazer"
+	},
+	{
+		"altTitles": [],
+		"artist": "坂本真綾",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 1086,
+		"searchTerms": [],
+		"title": "Buddy"
+	},
+	{
+		"altTitles": [],
+		"artist": "Fear,and Loathing in Las Vegas",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 1087,
+		"searchTerms": [],
+		"title": "Just Awake"
+	},
+	{
+		"altTitles": [],
+		"artist": "ももいろクローパーZ",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 1088,
+		"searchTerms": [],
+		"title": "猛烈宇宙交響曲・第七楽章「無限の愛」"
+	},
+	{
+		"altTitles": [],
+		"artist": "きゃりーぱみゅぱみゆ",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 1089,
+		"searchTerms": [],
+		"title": "つけまつける"
+	},
+	{
+		"altTitles": [],
+		"artist": "家入レオ",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 1090,
+		"searchTerms": [],
+		"title": "サブリナ"
+	},
+	{
+		"altTitles": [],
+		"artist": "パスピエ",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1091,
+		"searchTerms": [],
+		"title": "MATATABISTEP"
+	},
+	{
+		"altTitles": [],
+		"artist": "SEKAI NO OWARI",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1092,
+		"searchTerms": [],
+		"title": "Dragon Night"
+	},
+	{
+		"altTitles": [],
+		"artist": "UNISON SQUARE GARDEN",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1093,
+		"searchTerms": [],
+		"title": "天国と地獄"
+	},
+	{
+		"altTitles": [],
+		"artist": "MY FIRST STORY",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1094,
+		"searchTerms": [],
+		"title": "不可逆リプレイス"
+	},
+	{
+		"altTitles": [],
+		"artist": "Czecho No Republic",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1095,
+		"searchTerms": [],
+		"title": "Amazing Parade"
+	},
+	{
+		"altTitles": [],
+		"artist": "E-girls",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1096,
+		"searchTerms": [],
+		"title": "Highschool ♡ Love"
+	},
+	{
+		"altTitles": [],
+		"artist": "AAA",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1097,
+		"searchTerms": [],
+		"title": "Wake Up!"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1098,
+		"searchTerms": [],
+		"title": "レット・イット・ゴー~ありのままで~"
+	},
+	{
+		"altTitles": [],
+		"artist": "大原櫻子",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1099,
+		"searchTerms": [],
+		"title": "サンキュー。"
+	},
+	{
+		"altTitles": [],
+		"artist": "KANA-BOON",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1100,
+		"searchTerms": [],
+		"title": "シルエット"
+	},
+	{
+		"altTitles": [],
+		"artist": "にゃ~たん(CV:村川梨衣)",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1101,
+		"searchTerms": [],
+		"title": "リトライ☆ランデヴー"
+	},
+	{
+		"altTitles": [],
+		"artist": "ソルラルBOB",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1102,
+		"searchTerms": [],
+		"title": "blue moment"
+	},
+	{
+		"altTitles": [],
+		"artist": "ST☆RISH",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1103,
+		"searchTerms": [],
+		"title": "マジLOVEレボリューションズ"
+	},
+	{
+		"altTitles": [],
+		"artist": "宮野真守",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1104,
+		"searchTerms": [],
+		"title": "シャイン"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1105,
+		"searchTerms": [],
+		"title": "Synchrogazer [ 2 ]"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1106,
+		"searchTerms": [],
+		"title": "レット・イット・ゴー~ありのままで~[ 2 ]"
+	},
+	{
+		"altTitles": [],
+		"artist": "SEKAI NO OWARI",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 1107,
+		"searchTerms": [],
+		"title": "Dragon Night [ 2 ]"
+	},
+	{
+		"altTitles": [],
+		"artist": "サカナクション",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 1108,
+		"searchTerms": [],
+		"title": "新宝島"
+	},
+	{
+		"altTitles": [],
+		"artist": "fourfolium",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 1109,
+		"searchTerms": [],
+		"title": "Now Loading!!!!"
+	},
+	{
+		"altTitles": [],
+		"artist": "fourfolium",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 1110,
+		"searchTerms": [],
+		"title": "Shake!"
+	},
+	{
+		"altTitles": [],
+		"artist": "fourfolium",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 1111,
+		"searchTerms": [],
+		"title": "ほっし-の!"
+	},
+	{
+		"altTitles": [],
+		"artist": "あさき",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 1112,
+		"searchTerms": [],
+		"title": "イ号零型 [ 2 ]"
+	},
+	{
+		"altTitles": [],
+		"artist": "iroha",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 1113,
+		"searchTerms": [],
+		"title": "炉心融解[ 2 ]"
 	}
 ]

--- a/database-seeds/collections/tables.json
+++ b/database-seeds/collections/tables.json
@@ -1910,6 +1910,37 @@
 	},
 	{
 		"default": false,
+		"description": "Decimal Level Folders for jubeat Qubell.",
+		"folders": [
+			"F20ae291c14499228ea751fa248696429796f5e62ee783fe651b3c103eda659f5",
+			"Ff7c38930fb3ca0020356ae6e4b670164b47a5592be8b047212c7e120f2862642",
+			"F8801ade829e863add502acab3c0a12244b06404855d285b5cf83b7a67bf2bdfe",
+			"Fb6b6147f2e7c6b0ad7c2058035883b005c1446b1308eeaf3ce6bbf937b7e6dc1",
+			"F3fce8b8d04e7ba2d707ea2e7051d3205d2fcc9a8b6c58eb71f5402cfd0997a48",
+			"F249dd63ae3b329ac8b5bbcd1e7a0b336797cf7a238cb8260fab0e4975adf13e5",
+			"Fcce4156df9a12a4103b2392e72b1f75d60c262bca01fb839eec8e30e7d522744",
+			"F9d76c89ed6c2f35e9aa1d9742bf3ee4a596cd9bcdc5357db9afb911021b7d387",
+			"Fe430c1ee08c016a0c941602c0a8efdfb17bc11758f4534b6169d153b45bf9972",
+			"F4d2fb041630da3c62e179cfae79ce545262ff59e40be2e23f8ce7a49c04a1f0a",
+			"F896456d42e285a3897f50dabc1bd382f60c7de09fdebb023a4a0e6eabb3cc086",
+			"F4c397041db53903b22865b8c390eef02f73ede5255ce56579a73d0bd70c4f995",
+			"Fdfcb195fb263ff6752d64dd733b3fae721e7f020160ea8de8620a7065f5a5b66",
+			"F27a2a9846643e93056b6b9f156e22a1ed8a76438de0e01414bc1b6fa8a19850e",
+			"Fba5ae25a820d1a91907e87f8520fcd8aa54c341aa886c7f4f0769bea53cf2e7d",
+			"F3f666e978ff44ae33810fa590ba3af10683d5fb7b40c418766a643f3911e5fd9",
+			"F528c7671d51c792696940a0f84a218fbbd34839b08096bf42681f2e75dac0a4b",
+			"F9b9e1d5f6e99168be8b6b4ff4397fb4b5dc51e89c008d10dcefd5e9a29ae76fd",
+			"F2dec754c1fa1878a8573af3f6f4357cc2d59f540081da9ad1613bc1949f4691f",
+			"Fcae67acaf13ad278cf94b17ac08ec53deaead9421dc27c569e708d49737acdf4"
+		],
+		"game": "jubeat",
+		"inactive": true,
+		"playtype": "Single",
+		"tableID": "jubeat-Single-declv-qubell",
+		"title": "Decimal Level Folders (Qubell)"
+	},
+	{
+		"default": false,
 		"description": "Hard Mode Decimal Level Folders for jubeat.",
 		"folders": [
 			"Fb04d0483611fbfa76e6e615f0df4d5b9092b720fcb09b714e3bf9536c9749a94",
@@ -1941,6 +1972,37 @@
 	},
 	{
 		"default": false,
+		"description": "Hard Mode Decimal Level Folders for jubeat Qubell.",
+		"folders": [
+			"F09219275678563e904ab9dc25c3741166f4cb35bff9f9a8520148395a7b312af",
+			"F32b98c655d8e4c9ed1e31f8e45e4cd0dfccb1b69645899677a237e388fea36db",
+			"F69d54c0e3d60411370a1ae429f16b7a53e29d09c074354ede5d0ba2e56bc3a07",
+			"F4a21c50763e0c8d98be6ccd6fc643c4eb72ba2f305b1164bb7f2d1a7c7d8e2c7",
+			"Fafd825da4667bbde09ae3d11c236724032b86a7b7329e103299da4567feae448",
+			"Ff60b9959e9dd7ca4b508c707bd1d38ac53121f79ba87e3bab73dd4ca1e6d6ccc",
+			"Fc861d6bc47e38ce078c550341bc55aa24af9c732a2bdc98c9b10bf27673d1fc3",
+			"F14abe58c1100e9def6786f8a0009edd29b899e4e53c135e55ef48324eeb41449",
+			"F872641c086f45fbb52a14eb7e53604979b792b36fb6f4e9c2d476fd7d5e63770",
+			"F59d3adb67561e2ec175c0e971b8c688c8c15310a09fc0cb689f34d98ec4eacf1",
+			"F27815177696466ed771e1e8254143affd578719428955e6804e6df83783be2d7",
+			"Faf8e169b4b834733fb25d236fb0f4ad92af219cd0f42caf5cacf257ea5171ccc",
+			"F7b118b28476578326314a935d67be1fdd2ad39f23b8e4ff2b5021c706713028a",
+			"F7f48e642b63ac308dad6e90b465c609b9ac7cc3c41d68a41f4773e5d276b54c8",
+			"F202b8591c0a11c8828f8d10da55f823fef26137a04c2109218a667031dbd1a8b",
+			"Faad10d5ab6eb6aea155cab78a244b0b785b26132e752b6231f0e27bfae46b010",
+			"Fbe7f0fd9cf8899d5d637913c5fa49a87ce137c10280d21103ef9c9a9ff3efdfe",
+			"F4f07a4cd561323f986c4cfb7c76ada1da2e1bc41b76e8c74b798fe71e5e6253c",
+			"F0a9e942ed85ddddf3aef43c3ddb888c9e0ab8a2cdddbaeb4b3109a16f6cbdfb9",
+			"F93a79e8959e267ae2c2a8a626e52c30c98b5bd1f6abac612562a5e34be8e08a6"
+		],
+		"game": "jubeat",
+		"inactive": true,
+		"playtype": "Single",
+		"tableID": "jubeat-Single-declvhd-qubell",
+		"title": "Hard Mode Decimal Level Folders (Qubell)"
+	},
+	{
+		"default": false,
 		"description": "Hard Mode Level Folders for jubeat. This table does not have separate folders for each decimal.",
 		"folders": [
 			"F761a8099a3d537432f7d939c10025b3d0ca6813fd26e10acbcb557645d15ce0d",
@@ -1959,6 +2021,27 @@
 		"playtype": "Single",
 		"tableID": "jubeat-Single-lvhd",
 		"title": "Hard Mode Level Folders (festo)"
+	},
+	{
+		"default": false,
+		"description": "Hard Mode Level Folders for jubeat Qubell. This table does not have separate folders for each decimal.",
+		"folders": [
+			"Fe6eca44eb7688565d6dfbbd942866c1e1ad3569ca6c2a17c1e10f2ba207ca7e3",
+			"F208f1a0585dd99b71f2d214235b01d697dc9c78973df90caae6a4b76249f09f1",
+			"F151ef81c121d531a222977c94a5dbbc256f7e2edcbae38869a293b2f6271b6b6",
+			"F87fbdd58a2c247307bfa1c8c46868ad71fd0f8747b51468266df033a5a051177",
+			"Fcb4327d3ac9a2e863f7899347cb14cdf29e1f35f45bf623b4b40aa1b32045939",
+			"F72a0fae6c5eecda2ead01c2043f8e6ed4f8a5ef9a6d702a2cb54e824f8c9a67d",
+			"F8b6f9d77733d0e21d181cfad3bcfe3e355588692d80a4cfc620f4d3ba5e932ed",
+			"Ff1decf8630c85a73ec485792b2efb41a7d167e1645f1b5db2ed2af6f92fa3a0c",
+			"Fb6d2c97d0ba9392fd8eed8c95f8744236e549b1a86828c372c3abf8ba5920f33",
+			"F8a63e5b8ff8a5843ef4f2da6472f6325042b1bf338b1e15d12f0e2550ca93501"
+		],
+		"game": "jubeat",
+		"inactive": true,
+		"playtype": "Single",
+		"tableID": "jubeat-Single-lvhd-qubell",
+		"title": "Hard Mode Level Folders (Qubell)"
 	},
 	{
 		"default": true,
@@ -1980,6 +2063,27 @@
 		"playtype": "Single",
 		"tableID": "jubeat-Single-lv",
 		"title": "Level Folders (festo)"
+	},
+	{
+		"default": false,
+		"description": "Level Folders for jubeat Qubell. This table does not have separate folders for each decimal.",
+		"folders": [
+			"F5597b8e01373f3ed99e7e65ab2cd73abc7dee912edf2bacd146c4e6957da271f",
+			"F901bbbbac9b53f49d32c041051064862d118018e2f9fa719e9b38b2689464c4d",
+			"Ff70993ed87bcadc48d957c29d5173868c34a904038234d50bb525d7eb7eb55e6",
+			"Fe5dd037701ac40f5b134585231bd23cffed503141261bdfc23aad73e44f748cc",
+			"Fc334e07ec305b4bde36800a13538e6d061d9d476386435d3db5ab47dcb9ec2c0",
+			"F34637877cb994285dd864e417a3d2e27dc1454ab2fe1686abb5392c49c784af9",
+			"F5d27bfbb6406037c128bda07923226c7b7285ed5b6e181fb859cba602570df3d",
+			"Fda5de4a190e4d4f3cf8324babade6046663b820b14f7a519803dc2401f8609ba",
+			"Fffa3c667d9eeecc9fd9d404fdef7d4f67d5ff28cb75d7c8e3a7039b44e0aa4a4",
+			"Fdf50d447333221c279fe2179b7cb36812cafc03b05626a7880f21e6b346bb6f7"
+		],
+		"game": "jubeat",
+		"inactive": true,
+		"playtype": "Single",
+		"tableID": "jubeat-Single-lv-qubell",
+		"title": "Level Folders (Qubell)"
 	},
 	{
 		"default": true,
@@ -2058,7 +2162,7 @@
 			"F347921c8d57ccc0eb20eb092c9b55bf5eabb4f9fe7da00738876699cf1035c8c",
 			"F56d1157c3e10438262dfb2af88569075a8f5c484a7aef08a6a84566319af24ea",
 			"Fc5911b7640bf2db62d2acca372f1c5f6c7baf12fec05d990bb8c927ca6241b77",
-			"Fe1171c1e6c031cddc03080911b081e494e3bd526d4274b99b72043135ff6e17d",
+			"Fc5911b7640bf2db62d2acca372f1c5f6c7baf12fec05d990bb8c927ca6241b77",
 			"F9ae7894021d3a3ee23d7a5079e75e2a2234bd54c4735b7caf6327a7c9f4642ed"
 		],
 		"game": "museca",
@@ -2322,7 +2426,6 @@
 			"F0eba4509733294349b3d9140e943f33c80cc545050a61f87b62ebd9980916f0a",
 			"Fa30199d64c0e5c0962bd1a341a0da7c44a923e893d2746eb2d0d996cb1586c7b",
 			"Fb429c7dd6ccb37a4fdab99947c9af2532ac08342bd17acfd2e62898be2488310",
-			"Ff054ed80f6a4aa50038ce84860f6c9a8108b9141a66f1065c868b8ad7d5411dc",
 			"F3c5715f6595048ac14d54980b10ba9cb0ed43ca6c42e3b81c5ec7ad647309a9d",
 			"F66c687a6be070e65ca7bd4cec04d41a90cbda979b560fdd2384c3f5286d8b736",
 			"Fdf1271c9394a91419295534351babe28aaf609dfc98521511848df6271412d9a",

--- a/database-seeds/scripts/.eslintrc
+++ b/database-seeds/scripts/.eslintrc
@@ -22,6 +22,7 @@
 		"plugin:import/errors"
 	],
 	"rules": {
+		// TODO: Use cadence here.
 		"prettier/prettier": [
 			"error",
 			{
@@ -87,6 +88,8 @@
 		"no-unused-expressions": "error",
 		"no-useless-call": "error",
 		"no-useless-return": "error",
-		"require-unicode-regexp": "error"
+		"require-unicode-regexp": "error",
+		// breaks our wacky tachi-common imports
+		"import/no-unresolved": "off"
 	}
 }

--- a/database-seeds/scripts/rerunners/add-jubeat-folders.js
+++ b/database-seeds/scripts/rerunners/add-jubeat-folders.js
@@ -1,0 +1,157 @@
+const { MutateCollection, CreateFolderID } = require("../util");
+
+function CreateFolder(criteria, title) {
+	const f = {
+		game: "jubeat",
+		playtype: "Single",
+		data: criteria,
+		searchTerms: [],
+		title,
+		type: "charts",
+		inactive: false,
+	};
+
+	const folderID = CreateFolderID(f);
+
+	f.folderID = folderID;
+
+	return f;
+}
+
+const version = "qubell";
+const versionPretty = "Qubell";
+
+const levelFolders = [];
+const levelHardFolders = [];
+
+for (const level of ["1", "2", "3", "4", "5", "6", "7", "8"]) {
+	const f = CreateFolder(
+		{ level, versions: version, "data¬isHardMode": false },
+		`Level ${level} (Qubell)`
+	);
+	const fh = CreateFolder(
+		{ level, versions: version, "data¬isHardMode": true },
+		`Level ${level} (Hard Mode) (Qubell)`
+	);
+
+	levelFolders.push(f);
+	levelHardFolders.push(fh);
+}
+
+levelFolders.push(
+	CreateFolder(
+		{ levelNum: { "~gte": 9, "~lt": 10 }, versions: version, "data¬isHardMode": false },
+		`Level 9.0-9.9 (${versionPretty})`
+	)
+);
+levelFolders.push(
+	CreateFolder(
+		{ levelNum: { "~gte": 10, "~lt": 11 }, versions: version, "data¬isHardMode": false },
+		`Level 10.0-10.9 (${versionPretty})`
+	)
+);
+
+levelHardFolders.push(
+	CreateFolder(
+		{ levelNum: { "~gte": 9, "~lt": 10 }, versions: version, "data¬isHardMode": true },
+		`Level 9.0-9.9 (Hard Mode) (${versionPretty})`
+	)
+);
+levelHardFolders.push(
+	CreateFolder(
+		{ levelNum: { "~gte": 10, "~lt": 11 }, versions: version, "data¬isHardMode": true },
+		`Level 10.0-10.9 (Hard Mode) (${versionPretty})`
+	)
+);
+
+const detailFolders = [];
+const detailHardFolders = [];
+
+for (const level of [
+	"9.0",
+	"9.1",
+	"9.2",
+	"9.3",
+	"9.4",
+	"9.5",
+	"9.6",
+	"9.7",
+	"9.8",
+	"9.9",
+	"10.0",
+	"10.1",
+	"10.2",
+	"10.3",
+	"10.4",
+	"10.5",
+	"10.6",
+	"10.7",
+	"10.8",
+	"10.9",
+]) {
+	const f = CreateFolder(
+		{ level, versions: version, "data¬isHardMode": false },
+		`Level ${level} (${versionPretty})`
+	);
+	const fh = CreateFolder(
+		{ level, versions: version, "data¬isHardMode": true },
+		`Level ${level} (Hard Mode) (${versionPretty})`
+	);
+
+	detailFolders.push(f);
+	detailHardFolders.push(fh);
+}
+
+MutateCollection("folders.json", (folders) => {
+	folders.push(...levelFolders);
+	folders.push(...levelHardFolders);
+	folders.push(...detailFolders);
+	folders.push(...detailHardFolders);
+
+	return folders;
+});
+
+MutateCollection("tables.json", (tables) => {
+	tables.push({
+		title: `Level Folders (${versionPretty})`,
+		inactive: true,
+		tableID: `jubeat-Single-lv-${version}`,
+		game: "jubeat",
+		folders: levelFolders.map((e) => e.folderID),
+		description:
+			"Level Folders for jubeat. This table does not have separate folders for each decimal.",
+	});
+
+	tables.push({
+		title: `Decimal Level Folders (${versionPretty})`,
+		inactive: true,
+		tableID: `jubeat-Single-declv-${version}`,
+		game: "jubeat",
+		playtype: "Single",
+		folders: detailFolders.map((e) => e.folderID),
+		description: "Decimal Level Folders for jubeat.",
+	});
+
+	tables.push({
+		title: `Hard Mode Level Folders (${versionPretty})`,
+		inactive: true,
+		tableID: `jubeat-Single-lvhd-${version}`,
+		game: "jubeat",
+		playtype: "Single",
+		folders: levelHardFolders.map((e) => e.folderID),
+		description:
+			"Hard Mode Level Folders for jubeat. This table does not have separate folders for each decimal.",
+	});
+
+	tables.push({
+		title: `Hard Mode Decimal Level Folders (${versionPretty})`,
+		inactive: true,
+		tableID: `jubeat-Single-declvhd-${version}`,
+		game: "jubeat",
+		playtype: "Single",
+		folders: detailHardFolders.map((e) => e.folderID),
+		description: "Hard Mode Decimal Level Folders for jubeat.",
+	});
+
+	return tables;
+});

--- a/database-seeds/scripts/rerunners/add-jubeat-folders.js
+++ b/database-seeds/scripts/rerunners/add-jubeat-folders.js
@@ -11,7 +11,7 @@ function CreateFolder(criteria, title) {
 		inactive: false,
 	};
 
-	const folderID = CreateFolderID(f);
+	const folderID = CreateFolderID(f.data, f.game, f.playtype);
 
 	f.folderID = folderID;
 
@@ -117,9 +117,10 @@ MutateCollection("tables.json", (tables) => {
 		inactive: true,
 		tableID: `jubeat-Single-lv-${version}`,
 		game: "jubeat",
+		playtype: "Single",
 		folders: levelFolders.map((e) => e.folderID),
-		description:
-			"Level Folders for jubeat. This table does not have separate folders for each decimal.",
+		description: `Level Folders for jubeat ${versionPretty}. This table does not have separate folders for each decimal.`,
+		default: false,
 	});
 
 	tables.push({
@@ -129,7 +130,8 @@ MutateCollection("tables.json", (tables) => {
 		game: "jubeat",
 		playtype: "Single",
 		folders: detailFolders.map((e) => e.folderID),
-		description: "Decimal Level Folders for jubeat.",
+		description: `Decimal Level Folders for jubeat ${versionPretty}.`,
+		default: false,
 	});
 
 	tables.push({
@@ -139,8 +141,8 @@ MutateCollection("tables.json", (tables) => {
 		game: "jubeat",
 		playtype: "Single",
 		folders: levelHardFolders.map((e) => e.folderID),
-		description:
-			"Hard Mode Level Folders for jubeat. This table does not have separate folders for each decimal.",
+		description: `Hard Mode Level Folders for jubeat ${versionPretty}. This table does not have separate folders for each decimal.`,
+		default: false,
 	});
 
 	tables.push({
@@ -150,7 +152,8 @@ MutateCollection("tables.json", (tables) => {
 		game: "jubeat",
 		playtype: "Single",
 		folders: detailHardFolders.map((e) => e.folderID),
-		description: "Hard Mode Decimal Level Folders for jubeat.",
+		description: `Hard Mode Decimal Level Folders for jubeat ${versionPretty}.`,
+		default: false,
 	});
 
 	return tables;

--- a/database-seeds/scripts/rerunners/add-level-version-folders.js
+++ b/database-seeds/scripts/rerunners/add-level-version-folders.js
@@ -61,4 +61,4 @@ module.exports = function AddLevelVersionFolders(name, game, playtypes, version,
 // 	levels.push(i.toString())
 // }
 //
-// addLevelVersionFolders("CastHour", "iidx", ["SP", "DP"], "29", levels);
+// AddLevelVersionFolders("CastHour", "iidx", ["SP", "DP"], "29", levels);

--- a/database-seeds/scripts/run-tests.sh
+++ b/database-seeds/scripts/run-tests.sh
@@ -2,10 +2,38 @@
 
 cd "$(dirname "$0")" || exit 1
 
-# Output stderr and stdout to the terminal, but only save stderr to a file
-# Isn't bash wonderful?
 
-ts-node test/collections.test.ts 2> >(tee failed-tests.log >&2)
-ts-node test/id.test.ts 2> >(tee -a failed-tests.log >&2)
-ts-node test/folder-id.test.ts 2> >(tee -a failed-tests.log >&2)
-ts-node test/table-folders.test.ts 2> >(tee -a failed-tests.log >&2)
+
+failed=()
+function onFailure() {
+	failed+=( "$?" )
+}
+
+trap onFailure ERR
+
+tests=("collections" "id" "folder-id" "table-folders")
+
+# for all tests
+for test in "${tests[@]}"
+do
+	# Output stderr and stdout to the terminal, but only save stderr to a file
+	# Isn't bash wonderful?
+	ts-node "test/$test.test.ts" 2> >(tee failed-tests.log >&2)
+done
+
+# if more than 0 commands failed
+if [ "${#failed[@]}" -ne 0 ]; then
+	# iterate through the error codes and zip them with their
+	# test equivalent
+	for (( i = 0; i < ${#failed[@]}; i++ ));
+	do
+		if [ "${failed[$i]}" -ne 0 ]; then
+			echo "Test ${tests[$i]} failed. exit code: ${failed[$i]}"
+		fi;
+	done
+
+	exit 1;
+fi;
+
+# success
+exit 0;

--- a/database-seeds/scripts/test/collections.test.ts
+++ b/database-seeds/scripts/test/collections.test.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
+import fs from "fs";
+import path from "path";
 import { SCHEMAS } from "tachi-common/lib/schemas";
 import { ReadCollection } from "../util";
 import { FormatFunctions } from "./test-utils";
-import fs from "fs";
-import path from "path";
 
 function FormatPrError(err, foreword = "Error") {
 	const receivedText =
@@ -15,7 +15,7 @@ function FormatPrError(err, foreword = "Error") {
 }
 
 let exitCode = 0;
-const suites = [];
+const suites: Array<{ name: string; good: boolean; report: unknown }> = [];
 
 const collections = fs
 	.readdirSync(path.join(__dirname, "../../collections"))
@@ -37,7 +37,13 @@ for (const collection of collections) {
 	let game = "";
 
 	if (collection.startsWith("songs-") || collection.startsWith("charts-")) {
-		game = collection.split("-")[1];
+		const maybeGame = collection.split("-")[1];
+
+		if (maybeGame === undefined) {
+			throw new Error(`Collection passed was literally ${collection}, why?`);
+		}
+
+		game = maybeGame;
 	}
 
 	for (const d of data) {

--- a/database-seeds/scripts/test/id.test.ts
+++ b/database-seeds/scripts/test/id.test.ts
@@ -35,22 +35,22 @@ const UniqueKeys: Partial<Record<keyof typeof SCHEMAS, DuplicateKeyDecl[]>> = {
 	...SongChartKeys,
 };
 
-UniqueKeys["charts-iidx"].push("data.arcChartID");
+UniqueKeys["charts-iidx"]!.push("data.arcChartID");
 
-UniqueKeys["charts-usc"].push(["data.hashSHA1", "playtype"]);
+UniqueKeys["charts-usc"]!.push(["data.hashSHA1", "playtype"]);
 
-UniqueKeys["charts-popn"].push("data.hashSHA256");
+UniqueKeys["charts-popn"]!.push("data.hashSHA256");
 
-UniqueKeys["charts-bms"].push("data.hashMD5");
-UniqueKeys["charts-bms"].push("data.hashSHA256");
+UniqueKeys["charts-bms"]!.push("data.hashMD5");
+UniqueKeys["charts-bms"]!.push("data.hashSHA256");
 
-UniqueKeys["charts-pms"].push(["data.hashMD5", "playtype"]);
-UniqueKeys["charts-pms"].push(["data.hashSHA256", "playtype"]);
+UniqueKeys["charts-pms"]!.push(["data.hashMD5", "playtype"]);
+UniqueKeys["charts-pms"]!.push(["data.hashSHA256", "playtype"]);
 
-UniqueKeys["charts-itg"].push("data.chartHash");
+UniqueKeys["charts-itg"]!.push("data.chartHash");
 
 let exitCode = 0;
-const suites = [];
+const suites: Array<{ name: string; good: boolean; report: unknown }> = [];
 
 for (const [collection, uniqueIDs] of Object.entries(UniqueKeys)) {
 	console.log(`[VALIDATING DUPES] ${collection}`);
@@ -66,7 +66,13 @@ for (const [collection, uniqueIDs] of Object.entries(UniqueKeys)) {
 	let game = "";
 
 	if (collection.startsWith("songs-") || collection.startsWith("charts-")) {
-		game = collection.split("-")[1];
+		const maybeGame = collection.split("-")[1];
+
+		if (maybeGame === undefined) {
+			throw new Error(`You passed ${collection} as a collection. Why?`);
+		}
+
+		game = maybeGame;
 	}
 
 	for (const uniqueID of uniqueIDs) {

--- a/database-seeds/scripts/test/test-utils.ts
+++ b/database-seeds/scripts/test/test-utils.ts
@@ -22,7 +22,7 @@ export const FormatFunctions: Partial<
 > = {
 	"bms-course-lookup": (d) => d.title,
 	folders: (d) => d.title,
-	tables: (d) => d.name,
+	tables: (d) => d.title,
 
 	"songs-bms": songFormat,
 	"songs-chunithm": songFormat,

--- a/database-seeds/scripts/tsconfig.json
+++ b/database-seeds/scripts/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"strict": false,
+		"strict": true,
 		"allowJs": true,
 		"lib": [
 			"ES2019",

--- a/database-seeds/scripts/tsconfig.json
+++ b/database-seeds/scripts/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"strict": true,
+		"noImplicitAny": false,
+		"strictNullChecks": true,
 		"allowJs": true,
 		"lib": [
 			"ES2019",


### PR DESCRIPTION
A script was written to add charts and songs to the corresponding json collections for Jubeat. Song titles and artists were manually fetched. The `chartID` strings were generated using `secrets.token_hex(20)`, and were not checked for duplicates. New additions were appended to the end of the array, with `songID` starting from `1080`. The 6 charts per song were added in difficulty order `ADV`, `BSC`, `EXT`, `HARD ADV`, `HARD BSC`, `HARD EXT`, per song. The `displayVersion` strings are derived from the first digit in the id. The `versions` list contains `qubell` for every chart which has appeared in Jubeat Qubell in the final version.