### PR TITLE
feat: store exScore from sv6c imports

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1136,6 +1136,7 @@ export interface HitMetaLookup {
 	};
 	"sdvx:Single": BASE_VALID_HIT_META & {
 		gauge: number | null;
+		exScore: number | null;
 	};
 	"usc:Controller": USCHitMeta;
 	"usc:Keyboard": USCHitMeta;

--- a/server/src/lib/score-import/import-types/ir/kshook-sv6c/converter.test.ts
+++ b/server/src/lib/score-import/import-types/ir/kshook-sv6c/converter.test.ts
@@ -39,6 +39,7 @@ t.test("#ConverterIRKsHookSV6C", (t) => {
 					},
 					hitMeta: {
 						maxCombo: 158,
+						exScore: 1334,
 					},
 				},
 				game: "sdvx",

--- a/server/src/lib/score-import/import-types/ir/kshook-sv6c/converter.ts
+++ b/server/src/lib/score-import/import-types/ir/kshook-sv6c/converter.ts
@@ -57,6 +57,7 @@ export const ConverterIRKsHookSV6C: ConverterFunction<KsHookSV6CScore, KsHookSV6
 			hitMeta: {
 				gauge: data.gauge / 100,
 				maxCombo: data.max_chain,
+				exScore: data.ex_score,
 			},
 		},
 		scoreMeta: {},

--- a/server/src/lib/score-import/worker/queue.ts
+++ b/server/src/lib/score-import/worker/queue.ts
@@ -6,7 +6,7 @@ const ScoreImportQueue = new Queue(`${TachiConfig.NAME} Score Import Queue`, {
 	defaultJobOptions: {
 		removeOnComplete: true,
 		removeOnFail: 10, // keep the last 10 failed jobs, but start pruning beyond that.
-	}
+	},
 });
 
 export default ScoreImportQueue;

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -265,20 +265,21 @@ export function IsRecord(maybeRecord: unknown): maybeRecord is Record<string, un
  * Wrap a promise in an error handler that exits the process safely, and logs
  * when it completes.
  */
-export async function WrapScriptPromise(promise: Promise<unknown>, logger: KtLogger) {
+export function WrapScriptPromise(promise: Promise<unknown>, logger: KtLogger) {
 	let code = 0;
 
-	try {
-		await promise;
+	void promise
+		.then(() => {
+			logger.info(`Finished executing.`);
+		})
+		.catch((err: Error) => {
+			logger.error(`Failed executing.`, { err });
 
-		logger.info(`Finished executing.`);
-	} catch (err) {
-		logger.error(`Failed executing.`, { err });
-
-		code = 1;
-	}
-
-	logger.end(() => {
-		process.exit(code);
-	});
+			code = 1;
+		})
+		.finally(() => {
+			logger.end(() => {
+				process.exit(code);
+			});
+		});
 }


### PR DESCRIPTION
this is a bandaid patch. we need to fix #395 properly at one point, by redefining what "scores" are valid for a game into GPT specific content.

This is painful as hell to do properly, so here's a temporary bandaid that sucks.