### PR TITLE
fix: remove all instances of isLoading

### DIFF
--- a/client/src/app/pages/ClientFileFlowPage.tsx
+++ b/client/src/app/pages/ClientFileFlowPage.tsx
@@ -17,7 +17,7 @@ export default function ClientFileFlowPage() {
 
 	const { user } = useContext(UserContext);
 
-	const { data, isLoading, error } = useApiQuery<Omit<TachiAPIClientDocument, "clientSecret">>(
+	const { data, error } = useApiQuery<Omit<TachiAPIClientDocument, "clientSecret">>(
 		`/clients/${clientID}`
 	);
 
@@ -33,7 +33,7 @@ export default function ClientFileFlowPage() {
 		);
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/OAuth2CallbackPage.tsx
+++ b/client/src/app/pages/OAuth2CallbackPage.tsx
@@ -20,7 +20,7 @@ export default function OAuth2CallbackPage({
 		return <ErrorPage statusCode={400} />;
 	}
 
-	const { data, isLoading, error } = useApiQuery(counterWeight, {
+	const { data, error } = useApiQuery(counterWeight, {
 		method: "POST",
 		body: JSON.stringify({ code }),
 		headers: {
@@ -32,7 +32,7 @@ export default function OAuth2CallbackPage({
 		<ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return (
 			<div>
 				We're checking up with this site to get your authentication sorted.

--- a/client/src/app/pages/OAuthRequestAuthPage.tsx
+++ b/client/src/app/pages/OAuthRequestAuthPage.tsx
@@ -32,7 +32,7 @@ export default function OAuthRequestAuthPage() {
 }
 
 function OAuthRequestAuthLoader({ clientID }: { clientID: string }) {
-	const { isLoading, error, data } = useApiQuery<Omit<TachiAPIClientDocument, "clientSecret">>(
+	const { error, data } = useApiQuery<Omit<TachiAPIClientDocument, "clientSecret">>(
 		`/clients/${clientID}`
 	);
 
@@ -40,7 +40,7 @@ function OAuthRequestAuthLoader({ clientID }: { clientID: string }) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/VerifyEmailPage.tsx
+++ b/client/src/app/pages/VerifyEmailPage.tsx
@@ -37,7 +37,7 @@ export default function VerifyEmailPage() {
 }
 
 function VerifyEmail({ code }: { code: string }) {
-	const { data, isLoading, error } = useApiQuery("/auth/verify-email", {
+	const { data, error } = useApiQuery("/auth/verify-email", {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
@@ -51,7 +51,7 @@ function VerifyEmail({ code }: { code: string }) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/DashboardPage.tsx
+++ b/client/src/app/pages/dashboard/DashboardPage.tsx
@@ -65,15 +65,13 @@ function DashboardLoggedIn({ user }: { user: PublicUserDocument }) {
 }
 
 function RecentInfo({ user }: { user: PublicUserDocument }) {
-	const { data, isLoading, error } = useApiQuery<UserRecentSummary>(
-		`/users/${user.id}/recent-summary`
-	);
+	const { data, error } = useApiQuery<UserRecentSummary>(`/users/${user.id}/recent-summary`);
 
 	if (error) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/games/_game/_playtype/GPTChartPage.tsx
+++ b/client/src/app/pages/dashboard/games/_game/_playtype/GPTChartPage.tsx
@@ -89,7 +89,7 @@ function InternalGPTChartPage({
 
 	const [mode, setMode] = useState<"leaderboard" | "adjacent">("leaderboard");
 
-	const { data, isLoading, error } = useQuery<ChartPBData, UnsuccessfulAPIFetchResponse>(
+	const { data, error } = useQuery<ChartPBData, UnsuccessfulAPIFetchResponse>(
 		["PBInfo", `${chart.chartID}`],
 		async () => {
 			const lRes = await APIFetchV1<ChartPBLeaderboardReturn>(
@@ -132,7 +132,7 @@ function InternalGPTChartPage({
 		return <ApiError error={error} />;
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/games/_game/_playtype/GPTLeaderboardsPage.tsx
+++ b/client/src/app/pages/dashboard/games/_game/_playtype/GPTLeaderboardsPage.tsx
@@ -78,7 +78,7 @@ function ProfileLeaderboard({ game, playtype }: GamePT) {
 			</Form.Control>
 		) : null;
 
-	const { data, isLoading, error } = useApiQuery<UserLeaderboardReturns>(
+	const { data, error } = useApiQuery<UserLeaderboardReturns>(
 		`/games/${game}/${playtype}/leaderboard?alg=${alg}&limit=500`
 	);
 
@@ -91,7 +91,7 @@ function ProfileLeaderboard({ game, playtype }: GamePT) {
 		);
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return (
 			<>
 				{SelectComponent}
@@ -187,7 +187,7 @@ function ScoreLeaderboard({ game, playtype }: GamePT) {
 			</Form.Control>
 		) : null;
 
-	const { data, isLoading, error } = useApiQuery<ScoreLeaderboardReturns>(
+	const { data, error } = useApiQuery<ScoreLeaderboardReturns>(
 		`/games/${game}/${playtype}/score-leaderboard?alg=${alg}`
 	);
 
@@ -200,7 +200,7 @@ function ScoreLeaderboard({ game, playtype }: GamePT) {
 		);
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return (
 			<>
 				{SelectComponent}

--- a/client/src/app/pages/dashboard/games/_game/_playtype/GPTMainPage.tsx
+++ b/client/src/app/pages/dashboard/games/_game/_playtype/GPTMainPage.tsx
@@ -74,7 +74,7 @@ export default function GPTMainPage({ game, playtype }: GamePT) {
 }
 
 function RecentAchievedGoalsComponent({ game, playtype }: GamePT) {
-	const { data, isLoading, error } = useApiQuery<{
+	const { data, error } = useApiQuery<{
 		users: PublicUserDocument[];
 		goals: GoalDocument[];
 		goalSubs: GoalSubscriptionDocument[];
@@ -84,7 +84,7 @@ function RecentAchievedGoalsComponent({ game, playtype }: GamePT) {
 		return <ApiError error={error} />;
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 
@@ -129,7 +129,7 @@ function RecentAchievedGoalsComponent({ game, playtype }: GamePT) {
 }
 
 function RecentHighlightedScoresComponent({ game, playtype }: GamePT) {
-	const { data, isLoading, error } = useApiQuery<{
+	const { data, error } = useApiQuery<{
 		scores: ScoreDocument[];
 		users: PublicUserDocument[];
 		charts: ChartDocument[];
@@ -140,7 +140,7 @@ function RecentHighlightedScoresComponent({ game, playtype }: GamePT) {
 		return <ApiError error={error} />;
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 
@@ -178,7 +178,7 @@ function RecentHighlightedScoresComponent({ game, playtype }: GamePT) {
 }
 
 function RecentClassesComponent({ game, playtype }: GamePT) {
-	const { data, isLoading, error } = useApiQuery<RecentClassesReturn>(
+	const { data, error } = useApiQuery<RecentClassesReturn>(
 		`/games/${game}/${playtype}/recent-classes`
 	);
 
@@ -186,7 +186,7 @@ function RecentClassesComponent({ game, playtype }: GamePT) {
 		return <ApiError error={error} />;
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/games/_game/_playtype/GPTSongsPage.tsx
+++ b/client/src/app/pages/dashboard/games/_game/_playtype/GPTSongsPage.tsx
@@ -50,7 +50,7 @@ export default function GPTSongsPage({ game, playtype }: GamePT) {
 function SearchSongsTable({ game, playtype, search }: { search: string } & GamePT) {
 	const params = new URLSearchParams({ search });
 
-	const { data, isLoading, error } = useApiQuery<{
+	const { data, error } = useApiQuery<{
 		charts: (ChartDocument & { __playcount: integer })[];
 		songs: SongDocument[];
 	}>(`/games/${game}/${playtype}/charts${search !== "" ? `?${params.toString()}` : ""}`);
@@ -59,7 +59,7 @@ function SearchSongsTable({ game, playtype, search }: { search: string } & GameP
 		return <ApiError error={error} />;
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/import/ImportPage.tsx
+++ b/client/src/app/pages/dashboard/import/ImportPage.tsx
@@ -71,7 +71,7 @@ function ShowRecentImports() {
 }
 
 function InnerShowRecentImports({ user }: { user: PublicUserDocument }) {
-	const { data, error, isLoading } = useApiQuery<{ importType: ImportTypes; count: integer }[]>(
+	const { data, error } = useApiQuery<{ importType: ImportTypes; count: integer }[]>(
 		`/users/${user.id}/recent-imports`
 	);
 
@@ -79,7 +79,7 @@ function InnerShowRecentImports({ user }: { user: PublicUserDocument }) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/users/ARCIntegrationPage.tsx
+++ b/client/src/app/pages/dashboard/users/ARCIntegrationPage.tsx
@@ -14,7 +14,7 @@ export default function ARCIntegrationPage({ reqUser }: { reqUser: PublicUserDoc
 	const [iidxID, setIIDXID] = useState("");
 	const [sdvxID, setSDVXID] = useState("");
 
-	const { data, isLoading, error } = useApiQuery<{
+	const { data, error } = useApiQuery<{
 		iidx: ARCSavedProfileDocument | null;
 		sdvx: ARCSavedProfileDocument | null;
 	}>(`/users/${reqUser.id}/integrations/arc`, undefined, true);
@@ -30,7 +30,7 @@ export default function ARCIntegrationPage({ reqUser }: { reqUser: PublicUserDoc
 		return <ApiError error={error} />;
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/users/FervidexIntegrationPage.tsx
+++ b/client/src/app/pages/dashboard/users/FervidexIntegrationPage.tsx
@@ -9,11 +9,7 @@ import { Link } from "react-router-dom";
 import { FervidexSettingsDocument, PublicUserDocument } from "tachi-common";
 
 export default function FervidexIntegrationPage({ reqUser }: { reqUser: PublicUserDocument }) {
-	const {
-		data: settings,
-		isLoading,
-		error,
-	} = useApiQuery<FervidexSettingsDocument | null>(
+	const { data: settings, error } = useApiQuery<FervidexSettingsDocument | null>(
 		`/users/${reqUser.id}/integrations/fervidex/settings`
 	);
 
@@ -21,7 +17,7 @@ export default function FervidexIntegrationPage({ reqUser }: { reqUser: PublicUs
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || settings === undefined) {
+	if (settings === undefined) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/users/UserIntegrationsPage.tsx
+++ b/client/src/app/pages/dashboard/users/UserIntegrationsPage.tsx
@@ -99,7 +99,7 @@ function OAuthClientPage() {
 }
 
 function OAuthClientInfo() {
-	const { data, isLoading, error } = useApiQuery<TachiAPIClientDocument[]>("/clients");
+	const { data, error } = useApiQuery<TachiAPIClientDocument[]>("/clients");
 
 	const [clients, setClients] = useState<TachiAPIClientDocument[]>([]);
 
@@ -111,7 +111,7 @@ function OAuthClientInfo() {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 
@@ -682,7 +682,7 @@ function KAIIntegrationStatus({
 	kaiType: "flo" | "eag" | "min";
 	userID: integer;
 }) {
-	const { data, isLoading, error } = useApiQuery<{ authStatus: boolean }>(
+	const { data, error } = useApiQuery<{ authStatus: boolean }>(
 		`/users/${userID}/integrations/kai/${kaiType}`
 	);
 
@@ -690,7 +690,7 @@ function KAIIntegrationStatus({
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 
@@ -720,7 +720,7 @@ function APIKeysPage({ reqUser }: { reqUser: PublicUserDocument }) {
 	const [apiKeys, setApiKeys] = useState<APITokenDocument[]>([]);
 	const [showModal, setShowModal] = useState(false);
 
-	const { data, isLoading, error } = useApiQuery<APITokenDocument[]>(
+	const { data, error } = useApiQuery<APITokenDocument[]>(
 		`/users/${reqUser.id}/api-tokens`
 	);
 
@@ -734,7 +734,7 @@ function APIKeysPage({ reqUser }: { reqUser: PublicUserDocument }) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/users/UserInvitesPage.tsx
+++ b/client/src/app/pages/dashboard/users/UserInvitesPage.tsx
@@ -20,7 +20,7 @@ export default function UserInvitesPage({ reqUser }: { reqUser: PublicUserDocume
 		`${reqUser.username}'s Invites`
 	);
 
-	const { data, isLoading, error } = useApiQuery<{ invites: integer; limit: integer }>(
+	const { data, error } = useApiQuery<{ invites: integer; limit: integer }>(
 		`/users/${reqUser.id}/invites/limit`
 	);
 
@@ -28,7 +28,7 @@ export default function UserInvitesPage({ reqUser }: { reqUser: PublicUserDocume
 		return <ApiError error={error} />;
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 
@@ -86,7 +86,7 @@ export default function UserInvitesPage({ reqUser }: { reqUser: PublicUserDocume
 }
 
 function InviteList({ reqUser }: { reqUser: PublicUserDocument }) {
-	const { data, isLoading, error } = useApiQuery<{
+	const { data, error } = useApiQuery<{
 		invites: InviteCodeDocument[];
 		consumers: PublicUserDocument[];
 	}>(`/users/${reqUser.id}/invites`);
@@ -95,7 +95,7 @@ function InviteList({ reqUser }: { reqUser: PublicUserDocument }) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/LeaderboardsPage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/LeaderboardsPage.tsx
@@ -48,7 +48,7 @@ export default function LeaderboardsPage({
 
 	const url = `/users/${reqUser.id}/games/${game}/${playtype}/leaderboard-adjacent?alg=${alg}`;
 
-	const { isLoading, error, data } = useQuery<LeaderboardsData, UnsuccessfulAPIFetchResponse>(
+	const { data, error } = useQuery<LeaderboardsData, UnsuccessfulAPIFetchResponse>(
 		url,
 		async () => {
 			const res = await APIFetchV1<UGPTLeaderboardAdjacent>(url);
@@ -73,7 +73,7 @@ export default function LeaderboardsPage({
 	);
 
 	return (
-		<LoadingWrapper {...{ dataset: data, isLoading, error }}>
+		<LoadingWrapper {...{ dataset: data, error }}>
 			<LeaderboardsPageContent {...{ reqUser, game, playtype, data: data!, alg, setAlg }} />
 		</LoadingWrapper>
 	);

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/ScoresPage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/ScoresPage.tsx
@@ -141,7 +141,7 @@ function AlgSelector({
 }
 
 function useFetchPBs(url: string, reqUser: PublicUserDocument) {
-	const { isLoading, error, data } = useQuery(url, async () => {
+	const { data, error } = useQuery(url, async () => {
 		const res = await APIFetchV1<{
 			pbs: PBScoreDocument<"iidx:SP">[];
 			charts: ChartDocument<"iidx:SP">[];
@@ -155,7 +155,7 @@ function useFetchPBs(url: string, reqUser: PublicUserDocument) {
 		return FormatData(res.body.pbs, res.body.songs, res.body.charts, reqUser);
 	});
 
-	return { isLoading, error: error as UnsuccessfulAPIResponse, data };
+	return { error: error as UnsuccessfulAPIResponse, data };
 }
 
 function PBsOverview({
@@ -175,7 +175,7 @@ function PBsOverview({
 } & GamePT) {
 	const [search, setSearch] = useState("");
 
-	const { isLoading, error, data } = useFetchPBs(url, reqUser);
+	const { data, error } = useFetchPBs(url, reqUser);
 
 	return (
 		<div className="row">
@@ -188,10 +188,7 @@ function PBsOverview({
 			</div>
 			<div className="col-12 mt-8">
 				{search === "" ? (
-					<LoadingWrapper
-						style={{ height: 500 }}
-						{...{ isLoading, error, dataset: data }}
-					>
+					<LoadingWrapper style={{ height: 500 }} {...{ error, dataset: data }}>
 						<PBTable
 							dataset={data!}
 							game={game}
@@ -239,7 +236,7 @@ function FormatData<
 }
 
 function useFetchScores(url: string, reqUser: PublicUserDocument) {
-	const { isLoading, error, data } = useQuery(url, async () => {
+	const { data, error } = useQuery(url, async () => {
 		const res = await APIFetchV1<{
 			scores: ScoreDocument[];
 			charts: ChartDocument[];
@@ -253,7 +250,7 @@ function useFetchScores(url: string, reqUser: PublicUserDocument) {
 		return FormatData(res.body.scores, res.body.songs, res.body.charts, reqUser);
 	});
 
-	return { isLoading, error: error as UnsuccessfulAPIResponse, data };
+	return { error: error as UnsuccessfulAPIResponse, data };
 }
 
 function PBsSearch({
@@ -267,13 +264,13 @@ function PBsSearch({
 	search: string;
 	alg?: ScoreCalculatedDataLookup[IDStrings];
 } & GamePT) {
-	const { isLoading, error, data } = useFetchPBs(
+	const { data, error } = useFetchPBs(
 		`/users/${reqUser.id}/games/${game}/${playtype}/pbs?search=${search}`,
 		reqUser
 	);
 
 	return (
-		<LoadingWrapper style={{ height: 500 }} {...{ isLoading, error, dataset: data }}>
+		<LoadingWrapper style={{ height: 500 }} {...{ error, dataset: data }}>
 			<PBTable
 				indexCol={false}
 				dataset={data!}
@@ -288,7 +285,7 @@ function PBsSearch({
 function ScoresOverview({ reqUser, game, playtype }: { reqUser: PublicUserDocument } & GamePT) {
 	const [search, setSearch] = useState("");
 
-	const { isLoading, error, data } = useFetchScores(
+	const { data, error } = useFetchScores(
 		`/users/${reqUser.id}/games/${game}/${playtype}/scores/recent`,
 		reqUser
 	);
@@ -304,10 +301,7 @@ function ScoresOverview({ reqUser, game, playtype }: { reqUser: PublicUserDocume
 			</div>
 			<div className="col-12 mt-8">
 				{search === "" ? (
-					<LoadingWrapper
-						style={{ height: 500 }}
-						{...{ isLoading, dataset: data, error }}
-					>
+					<LoadingWrapper style={{ height: 500 }} {...{ dataset: data, error }}>
 						<ScoreTable dataset={data!} game={game} playtype={playtype as any} />
 					</LoadingWrapper>
 				) : (
@@ -324,13 +318,13 @@ function ScoresSearch({
 	playtype,
 	search,
 }: { reqUser: PublicUserDocument; search: string } & GamePT) {
-	const { isLoading, error, data } = useFetchScores(
+	const { data, error } = useFetchScores(
 		`/users/${reqUser.id}/games/${game}/${playtype}/scores?search=${search}`,
 		reqUser
 	);
 
 	return (
-		<LoadingWrapper style={{ height: 500 }} {...{ isLoading, error, dataset: data }}>
+		<LoadingWrapper style={{ height: 500 }} {...{ error, dataset: data }}>
 			<ScoreTable dataset={data!} game={game} playtype={playtype as any} />
 		</LoadingWrapper>
 	);

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/SessionsPage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/SessionsPage.tsx
@@ -42,7 +42,7 @@ export default function SessionsPage({
 
 	const rating = useSessionRatingAlg(game, playtype);
 
-	const { isLoading, error, data } = useQuery<SessionDataset, UnsuccessfulAPIResponse>(
+	const { data, error } = useQuery<SessionDataset, UnsuccessfulAPIResponse>(
 		`${baseUrl}/${sessionSet}`,
 		async () => {
 			const res = await APIFetchV1<SessionDocument[]>(`${baseUrl}/${sessionSet}`);
@@ -93,7 +93,7 @@ export default function SessionsPage({
 			</div>
 			<div className="col-12 mt-4">
 				{search === "" ? (
-					<LoadingWrapper {...{ isLoading, error, dataset: data }}>
+					<LoadingWrapper {...{ error, dataset: data }}>
 						<GenericSessionTable
 							indexCol={sessionSet === "best"}
 							dataset={data!}
@@ -117,7 +117,7 @@ function SearchSessionsTable({
 	reqUser,
 	baseUrl,
 }: { search: string; baseUrl: string; reqUser: PublicUserDocument } & GamePT) {
-	const { isLoading, error, data } = useQuery<SessionDataset, UnsuccessfulAPIResponse>(
+	const { data, error } = useQuery<SessionDataset, UnsuccessfulAPIResponse>(
 		`${baseUrl}?search=${search}`,
 		async () => {
 			const res = await APIFetchV1<SessionDocument[]>(`${baseUrl}?search=${search}`);
@@ -136,7 +136,7 @@ function SearchSessionsTable({
 	);
 
 	return (
-		<LoadingWrapper {...{ isLoading, error, dataset: data }}>
+		<LoadingWrapper {...{ error, dataset: data }}>
 			<GenericSessionTable
 				reqUser={reqUser}
 				dataset={data!}

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/SpecificSessionPage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/SpecificSessionPage.tsx
@@ -24,13 +24,13 @@ type Props = { reqUser: PublicUserDocument } & GamePT;
 export default function SpecificSessionPage({ reqUser, game, playtype }: Props) {
 	const { sessionID } = useParams<{ sessionID: string }>();
 
-	const { data, isLoading, error } = useApiQuery<SessionReturns>(`/sessions/${sessionID}`);
+	const { data, error } = useApiQuery<SessionReturns>(`/sessions/${sessionID}`);
 
 	if (error) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/UGPTSettingsPage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/UGPTSettingsPage.tsx
@@ -113,17 +113,15 @@ function PreferencesForm({ reqUser, game, playtype }: Props) {
 		},
 	});
 
-	const {
-		data: tables,
-		isLoading,
-		error,
-	} = useApiQuery<TableDocument[]>(`/games/${game}/${playtype}/tables?showInactive=true`);
+	const { data: tables, error } = useApiQuery<TableDocument[]>(
+		`/games/${game}/${playtype}/tables?showInactive=true`
+	);
 
 	if (error) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !tables) {
+	if (!tables) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/folders/FolderSelectPage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/folders/FolderSelectPage.tsx
@@ -24,7 +24,7 @@ export default function FoldersSearch({ reqUser, game, playtype }: Props) {
 
 	const params = useMemo(() => new URLSearchParams({ search }), [search]);
 
-	const { data, isLoading, error } = useApiQuery<UGPTFolderSearch>(
+	const { data, error } = useApiQuery<UGPTFolderSearch>(
 		`/users/${reqUser.id}/games/${game}/${playtype}/folders?${params.toString()}`
 	);
 
@@ -32,7 +32,7 @@ export default function FoldersSearch({ reqUser, game, playtype }: Props) {
 
 	if (error) {
 		body = <>{error.description}</>;
-	} else if (isLoading || !data) {
+	} else if (!data) {
 		body = <Loading />;
 	} else {
 		const statMap = new Map();

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/folders/FolderTablePage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/folders/FolderTablePage.tsx
@@ -38,7 +38,7 @@ interface Props {
 }
 
 export default function FolderTablePage({ reqUser, game, playtype }: Props) {
-	const { data, isLoading, error } = useApiQuery<TableDocument[]>(
+	const { data, error } = useApiQuery<TableDocument[]>(
 		`/games/${game}/${playtype}/tables?showInactive=true`
 	);
 
@@ -84,7 +84,7 @@ export default function FolderTablePage({ reqUser, game, playtype }: Props) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 
@@ -125,7 +125,7 @@ interface UGPTFolderStats {
 }
 
 function TableFolderViewer({ reqUser, game, playtype, table }: Props & { table: TableDocument }) {
-	const { data, isLoading, error } = useApiQuery<UGPTTableReturns>(
+	const { data, error } = useApiQuery<UGPTTableReturns>(
 		`/users/${reqUser.id}/games/${game}/${playtype}/tables/${table.tableID}`
 	);
 
@@ -153,7 +153,7 @@ function TableFolderViewer({ reqUser, game, playtype, table }: Props & { table: 
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data || !hasLoadedFolderMap) {
+	if (!data || !hasLoadedFolderMap) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/folders/RecentFoldersPage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/folders/RecentFoldersPage.tsx
@@ -21,7 +21,7 @@ export default function RecentFoldersPage({
 		return <>Hey, you're not logged in. How did you get here!</>;
 	}
 
-	const { data, isLoading, error } = useApiQuery<{
+	const { data, error } = useApiQuery<{
 		folders: FolderDocument[];
 		views: RecentlyViewedFolderDocument[];
 		stats: FolderStatsInfo[];
@@ -31,7 +31,7 @@ export default function RecentFoldersPage({
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/folders/SpecificFolderPage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/folders/SpecificFolderPage.tsx
@@ -47,7 +47,7 @@ interface Props {
 export default function SpecificFolderPage({ reqUser, game, playtype }: Props) {
 	const { folderID } = useParams<{ folderID: string }>();
 
-	const { data, isLoading, error } = useApiQuery<UGPTFolderReturns>(
+	const { data, error } = useApiQuery<UGPTFolderReturns>(
 		`/users/${reqUser.id}/games/${game}/${playtype}/folders/${folderID}`
 	);
 
@@ -101,7 +101,7 @@ export default function SpecificFolderPage({ reqUser, game, playtype }: Props) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data || !folderDataset) {
+	if (!data || !folderDataset) {
 		return <Loading />;
 	}
 
@@ -227,7 +227,7 @@ function TimelineMain({
 	type: "grade" | "lamp";
 	value: integer;
 }) {
-	const { data, isLoading, error } = useApiQuery<{
+	const { data, error } = useApiQuery<{
 		scores: ScoreDocument[];
 		songs: SongDocument[];
 		charts: ChartDocument[];
@@ -239,7 +239,7 @@ function TimelineMain({
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/rivals/RivalsOverviewPage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/rivals/RivalsOverviewPage.tsx
@@ -23,7 +23,7 @@ export default function RivalsOverviewWrapper({
 	game: Game;
 	playtype: Playtype;
 }) {
-	const { data, isLoading, error } = useApiQuery<PublicUserDocument[]>(
+	const { data, error } = useApiQuery<PublicUserDocument[]>(
 		`/users/${reqUser.id}/games/${game}/${playtype}/rivals`
 	);
 
@@ -39,7 +39,7 @@ export default function RivalsOverviewWrapper({
 		<ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/routes/GameRoutes.tsx
+++ b/client/src/app/routes/GameRoutes.tsx
@@ -154,7 +154,7 @@ function GamePlaytypeRoutes({ game }: { game: Game }) {
 function SongChartRoutes({ game, playtype }: GamePT) {
 	const { songID } = useParams<{ songID: string }>();
 
-	const { data, isLoading, error } = useApiQuery<SongsReturn>(
+	const { data, error } = useApiQuery<SongsReturn>(
 		`/games/${game}/${playtype}/songs/${songID}`
 	);
 
@@ -172,7 +172,7 @@ function SongChartRoutes({ game, playtype }: GamePT) {
 		return <ErrorPage statusCode={error.statusCode} customMessage={error.description} />;
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/app/routes/UserRoutes.tsx
+++ b/client/src/app/routes/UserRoutes.tsx
@@ -44,11 +44,7 @@ export default function UserRoutes() {
 	const { userID } = useParams<{ userID: string }>();
 	const history = useHistory();
 
-	const {
-		data: reqUser,
-		isLoading,
-		error,
-	} = useApiQuery<PublicUserDocument>(`/users/${params.userID}`);
+	const { data: reqUser, error } = useApiQuery<PublicUserDocument>(`/users/${params.userID}`);
 
 	const { setBackground } = useContext(BackgroundContext);
 	useEffect(() => {
@@ -69,7 +65,7 @@ export default function UserRoutes() {
 		return <ErrorPage statusCode={error.statusCode} customMessage={error.description} />;
 	}
 
-	if (isLoading || !reqUser) {
+	if (!reqUser) {
 		return null;
 	}
 
@@ -221,7 +217,7 @@ function UserGamePlaytypeRoutes({ reqUser, game }: { reqUser: PublicUserDocument
 		};
 	}, [user, game, playtype]);
 
-	const { isLoading, error, data } = useQuery<UGPTStatsReturn, APIFetchV1Return<UserGameStats>>(
+	const { data, error } = useQuery<UGPTStatsReturn, APIFetchV1Return<UserGameStats>>(
 		[reqUser.id, game, playtype],
 		async () => {
 			const res = await APIFetchV1<UGPTStatsReturn>(
@@ -246,7 +242,7 @@ function UserGamePlaytypeRoutes({ reqUser, game }: { reqUser: PublicUserDocument
 		return <ErrorPage statusCode={error.statusCode} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/components/game/charts/ChartInfoFormat.tsx
+++ b/client/src/components/game/charts/ChartInfoFormat.tsx
@@ -23,7 +23,7 @@ export default function ChartInfoFormat({
 
 	const withTierlists = gptConfig.tierlists.filter((e) => chart.tierlistInfo[e]);
 
-	const { data, isLoading, error } = useApiQuery<FolderDocument[]>(
+	const { data, error } = useApiQuery<FolderDocument[]>(
 		`/games/${game}/${playtype}/charts/${chart.chartID}/folders`
 	);
 
@@ -34,7 +34,7 @@ export default function ChartInfoFormat({
 		<ApiError error={error} />;
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/components/imports/ARCImportPage.tsx
+++ b/client/src/components/imports/ARCImportPage.tsx
@@ -31,7 +31,7 @@ export default function ARCImportPage({ game }: { game: "sdvx" | "iidx" }) {
 		return <>No user? How did you get here!</>;
 	}
 
-	const { data, isLoading, error } = useApiQuery<{
+	const { data, error } = useApiQuery<{
 		iidx: ARCSavedProfileDocument | null;
 		sdvx: ARCSavedProfileDocument | null;
 	}>(`/users/${user.id}/integrations/arc`);
@@ -40,7 +40,7 @@ export default function ARCImportPage({ game }: { game: "sdvx" | "iidx" }) {
 		return <ApiError error={error} />;
 	}
 
-	if (!data || isLoading) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/components/imports/ImportInfo.tsx
+++ b/client/src/components/imports/ImportInfo.tsx
@@ -37,7 +37,7 @@ interface Data {
 }
 
 export default function ImportInfo({ importID }: { importID: string }) {
-	const { data, isLoading, error } = useApiQuery<Data>(`/imports/${importID}`);
+	const { data, error } = useApiQuery<Data>(`/imports/${importID}`);
 
 	const { setUGS } = useContext(UserGameStatsContext);
 	const { user } = useContext(UserContext);
@@ -70,7 +70,7 @@ export default function ImportInfo({ importID }: { importID: string }) {
 		);
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return (
 			<>
 				<Loading />

--- a/client/src/components/imports/KAIIntegrationPage.tsx
+++ b/client/src/components/imports/KAIIntegrationPage.tsx
@@ -36,7 +36,7 @@ export default function KAIIntegrationPage({ clientID, hash, kaiType, redirectUr
 		return <ErrorPage statusCode={401} />;
 	}
 
-	const { isLoading, error, data } = useApiQuery<{ authStatus: boolean }>(
+	const { data, error } = useApiQuery<{ authStatus: boolean }>(
 		`/users/${user.id}/integrations/kai/${kaiType}`
 	);
 
@@ -44,7 +44,7 @@ export default function KAIIntegrationPage({ clientID, hash, kaiType, redirectUr
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/components/sessions/SessionCard.tsx
+++ b/client/src/components/sessions/SessionCard.tsx
@@ -22,7 +22,7 @@ import { ScoreDataset } from "types/tables";
 export default function SessionCard({ sessionID }: { sessionID: string }) {
 	const { user } = useContext(UserContext);
 
-	const { data, isLoading, error } = useApiQuery<SessionReturns>(`/sessions/${sessionID}`);
+	const { data, error } = useApiQuery<SessionReturns>(`/sessions/${sessionID}`);
 
 	const [highlight, setHighlight] = useState(false);
 
@@ -34,7 +34,7 @@ export default function SessionCard({ sessionID }: { sessionID: string }) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/components/sessions/SessionRaiseBreakdown.tsx
+++ b/client/src/components/sessions/SessionRaiseBreakdown.tsx
@@ -89,7 +89,7 @@ export default function SessionRaiseBreakdown({
 		});
 	}, [folder, tableID, filter]);
 
-	const { isLoading, error, data } = useQuery(`/games/${game}/${playtype}/tables`, async () => {
+	const { data, error } = useQuery(`/games/${game}/${playtype}/tables`, async () => {
 		const res = await APIFetchV1<TableDocument[]>(`/games/${game}/${playtype}/tables`);
 
 		if (!res.success) {
@@ -110,7 +110,7 @@ export default function SessionRaiseBreakdown({
 		return <>{(error as Error).message}</>;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/components/tables/dropdowns/PBDropdown.tsx
+++ b/client/src/components/tables/dropdowns/PBDropdown.tsx
@@ -44,15 +44,11 @@ export default function PBDropdown<I extends IDStrings = IDStrings>({
 
 	const [view, setView] = useState(defaultView);
 
-	const { isLoading, error, data } = useApiQuery<UGPTChartPBComposition<I>>(
+	const { data, error } = useApiQuery<UGPTChartPBComposition<I>>(
 		`/users/${userID}/games/${game}/${playtype}/pbs/${chart.chartID}?getComposition=true`
 	);
 
-	const {
-		isLoading: histIsLoading,
-		error: histError,
-		data: histData,
-	} = useApiQuery<ScoreDocument<I>[]>(
+	const { error: histError, data: histData } = useApiQuery<ScoreDocument<I>[]>(
 		`/users/${userID}/games/${game}/${playtype}/scores/${chart.chartID}`
 	);
 
@@ -88,7 +84,7 @@ export default function PBDropdown<I extends IDStrings = IDStrings>({
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return (
 			<div style={{ height: "200px" }} className="d-flex align-items-center">
 				<Loading />
@@ -106,7 +102,6 @@ export default function PBDropdown<I extends IDStrings = IDStrings>({
 			<PlayHistory
 				data={histData}
 				error={histError}
-				isLoading={histIsLoading}
 				game={game}
 				playtype={playtype}
 				chart={chart}

--- a/client/src/components/tables/dropdowns/ScoreDropdown.tsx
+++ b/client/src/components/tables/dropdowns/ScoreDropdown.tsx
@@ -59,15 +59,11 @@ export default function ScoreDropdown<I extends IDStrings = IDStrings>({
 	const { user: currentUser } = useContext(UserContext);
 	const { settings } = useContext(UserSettingsContext);
 
-	const { isLoading, error, data } = useApiQuery<UGPTChartPBComposition<I>>(
+	const { data, error } = useApiQuery<UGPTChartPBComposition<I>>(
 		`/users/${user.id}/games/${game}/${playtype}/pbs/${chart.chartID}?getComposition=true`
 	);
 
-	const {
-		isLoading: histIsLoading,
-		error: histError,
-		data: histData,
-	} = useApiQuery<ScoreDocument<I>[]>(
+	const { error: histError, data: histData } = useApiQuery<ScoreDocument<I>[]>(
 		`/users/${user.id}/games/${game}/${playtype}/scores/${chart.chartID}`
 	);
 
@@ -75,7 +71,7 @@ export default function ScoreDropdown<I extends IDStrings = IDStrings>({
 		return <>An error has occured. Whoops.</>;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return (
 			<div style={{ height: "200px" }} className="d-flex align-items-center">
 				<Loading />
@@ -89,7 +85,6 @@ export default function ScoreDropdown<I extends IDStrings = IDStrings>({
 		body = (
 			<PlayHistory
 				error={histError}
-				isLoading={histIsLoading}
 				game={game}
 				playtype={playtype}
 				data={histData}

--- a/client/src/components/tables/dropdowns/components/PlayHistory.tsx
+++ b/client/src/components/tables/dropdowns/components/PlayHistory.tsx
@@ -7,14 +7,12 @@ import { GamePT } from "types/react";
 
 export default function PlayHistory({
 	data,
-	isLoading,
 	error,
 	game,
 	playtype,
 	chart,
 }: {
 	data?: ScoreDocument[];
-	isLoading: boolean;
 	error: UnsuccessfulAPIFetchResponse | null;
 	chart: ChartDocument;
 } & GamePT) {
@@ -22,7 +20,7 @@ export default function PlayHistory({
 		return <>{error.description}</>;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/components/user/UGPTStatContainer.tsx
+++ b/client/src/components/user/UGPTStatContainer.tsx
@@ -33,7 +33,7 @@ export default function UGPTStatContainer({
 		searchParams.set("gte", stat.gte.toString());
 	}
 
-	const { data, isLoading, error } = useQuery(
+	const { data, error } = useQuery(
 		`/users/${reqUser.id}/games/${game}/${playtype}/showcase/custom?${searchParams.toString()}`,
 		async () => {
 			const res = await APIFetchV1<UGPTPreferenceStatsReturn>(
@@ -66,7 +66,7 @@ export default function UGPTStatContainer({
 		return <>{(error as any).description}</>;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 

--- a/client/src/components/util/LoadingWrapper.tsx
+++ b/client/src/components/util/LoadingWrapper.tsx
@@ -4,13 +4,11 @@ import { UnsuccessfulAPIResponse } from "tachi-common";
 
 export default function LoadingWrapper({
 	dataset,
-	isLoading,
 	error,
 	children,
 	style,
 }: {
 	dataset: unknown | null | undefined;
-	isLoading: boolean;
 	error: UnsuccessfulAPIResponse | null;
 	children: JSX.Element | JSX.Element[];
 	style?: CSSProperties;
@@ -19,7 +17,7 @@ export default function LoadingWrapper({
 		return <h3>An error has occured. {error.description}</h3>;
 	}
 
-	if (isLoading || !dataset) {
+	if (!dataset) {
 		return <Loading style={style} />;
 	}
 

--- a/client/src/components/util/OAuthMoreInfo.tsx
+++ b/client/src/components/util/OAuthMoreInfo.tsx
@@ -10,13 +10,13 @@ export default function OAuthMoreInfo({
 }: {
 	client: Omit<TachiAPIClientDocument, "clientSecret">;
 }) {
-	const { data, isLoading, error } = useApiQuery<PublicUserDocument>(`/users/${client.author}`);
+	const { data, error } = useApiQuery<PublicUserDocument>(`/users/${client.author}`);
 
 	if (error) {
 		return <ApiError error={error} />;
 	}
 
-	if (isLoading || !data) {
+	if (!data) {
 		return <Loading />;
 	}
 


### PR DESCRIPTION
Fixes #654.

We were holding react-query wrong. This stops rapid flashes of loading icons when tabbing back into the site.