### PR TITLE
Jubeat Versions List Assumes Final State for Festo.

### DIFF
--- a/database-seeds/collections/charts-jubeat.json
+++ b/database-seeds/collections/charts-jubeat.json
@@ -1455,8 +1455,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -1475,8 +1474,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -1495,8 +1493,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -1515,8 +1512,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -1535,8 +1531,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -1555,8 +1550,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -7935,8 +7929,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -7955,8 +7948,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -7975,8 +7967,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -7995,8 +7986,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -8015,8 +8005,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -8035,8 +8024,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -8055,8 +8043,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -8075,8 +8062,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -8095,8 +8081,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -8115,8 +8100,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -8135,8 +8119,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -8155,8 +8138,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9255,8 +9237,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9275,8 +9256,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9295,8 +9275,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9315,8 +9294,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9335,8 +9313,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9355,8 +9332,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9375,8 +9351,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9395,8 +9370,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9415,8 +9389,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9435,8 +9408,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9455,8 +9427,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9475,8 +9446,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9495,8 +9465,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9515,8 +9484,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9535,8 +9503,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9555,8 +9522,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9575,8 +9541,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9595,8 +9560,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9735,8 +9699,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9755,8 +9718,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9775,8 +9737,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9795,8 +9756,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9815,8 +9775,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9835,8 +9794,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9975,8 +9933,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -9995,8 +9952,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -10015,8 +9971,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -10035,8 +9990,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -10055,8 +10009,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -10075,8 +10028,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -10335,8 +10287,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -10355,8 +10306,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -10375,8 +10325,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -10395,8 +10344,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -10415,8 +10363,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -10435,8 +10382,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12495,8 +12441,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12515,8 +12460,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12535,8 +12479,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12555,8 +12498,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12575,8 +12517,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12595,8 +12536,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12615,8 +12555,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12635,8 +12574,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12655,8 +12593,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12675,8 +12612,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12695,8 +12631,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12715,8 +12650,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12735,8 +12669,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12755,8 +12688,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12775,8 +12707,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12795,8 +12726,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12815,8 +12745,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -12835,8 +12764,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -48735,8 +48663,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -48755,8 +48682,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -48775,8 +48701,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -48795,8 +48720,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -48815,8 +48739,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -48835,8 +48758,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58455,8 +58377,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58475,8 +58396,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58495,8 +58415,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58515,8 +58434,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58535,8 +58453,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58555,8 +58472,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58575,8 +58491,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58595,8 +58510,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58615,8 +58529,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58635,8 +58548,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58655,8 +58567,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -58675,8 +58586,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -63375,8 +63285,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -63395,8 +63304,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -63415,8 +63323,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -63435,8 +63342,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -63455,8 +63361,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -63475,8 +63380,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78332,8 +78236,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78351,8 +78254,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78370,8 +78272,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78389,8 +78290,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78408,8 +78308,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78427,8 +78326,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78446,8 +78344,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78465,8 +78362,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78484,8 +78380,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78503,8 +78398,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78522,8 +78416,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -78541,8 +78434,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -81866,8 +81758,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -81885,8 +81776,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -81904,8 +81794,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -81923,8 +81812,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -81942,8 +81830,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -81961,8 +81848,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82322,8 +82208,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82341,8 +82226,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82360,8 +82244,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82379,8 +82262,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82398,8 +82280,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82417,8 +82298,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82664,8 +82544,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82683,8 +82562,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82702,8 +82580,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82721,8 +82598,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82740,8 +82616,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82759,8 +82634,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82778,8 +82652,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82797,8 +82670,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82816,8 +82688,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82835,8 +82706,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82854,8 +82724,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -82873,8 +82742,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -83918,8 +83786,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -83937,8 +83804,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -83956,8 +83822,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -83975,8 +83840,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -83994,8 +83858,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84013,8 +83876,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84032,8 +83894,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84051,8 +83912,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84070,8 +83930,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84089,8 +83948,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84108,8 +83966,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84127,8 +83984,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84488,8 +84344,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84507,8 +84362,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84526,8 +84380,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84545,8 +84398,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84564,8 +84416,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84583,8 +84434,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84602,8 +84452,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84621,8 +84470,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84640,8 +84488,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84659,8 +84506,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84678,8 +84524,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -84697,8 +84542,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -90073,9 +89917,7 @@
 		"rgcID": null,
 		"songID": 762,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "0af4faa1a43a62e1447ab9d56e2eb32b02ae7947",
@@ -90091,9 +89933,7 @@
 		"rgcID": null,
 		"songID": 762,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "2d63e58660e24b842a31f467b1b9be945fc71624",
@@ -90109,9 +89949,7 @@
 		"rgcID": null,
 		"songID": 762,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "c761f6e3565085f8f2e8ac84bdcbb80520c97788",
@@ -90127,9 +89965,7 @@
 		"rgcID": null,
 		"songID": 762,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "65e4be18e5154052e460c77b81f8b08041b661b7",
@@ -90145,9 +89981,7 @@
 		"rgcID": null,
 		"songID": 762,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "f7d3bd48d3243beb6c976dd749bfaa15c3a0ba2a",
@@ -90163,9 +89997,7 @@
 		"rgcID": null,
 		"songID": 762,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "762a44ff380bb7d72e7778d543fb748668c86e3d",
@@ -90181,9 +90013,7 @@
 		"rgcID": null,
 		"songID": 763,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "20d804b126bc1c60627f5a5ab9ef0f650a58c4ed",
@@ -90199,9 +90029,7 @@
 		"rgcID": null,
 		"songID": 763,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "774d3b315f004d3f13600e06accadb3305f7bafb",
@@ -90217,9 +90045,7 @@
 		"rgcID": null,
 		"songID": 763,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "874a4dd35da6d3f9c8e5106a4666ab71836c7b4c",
@@ -90235,9 +90061,7 @@
 		"rgcID": null,
 		"songID": 763,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "61ce06b4d5ebd43cb0aee99fb0cddd01b553fe38",
@@ -90253,9 +90077,7 @@
 		"rgcID": null,
 		"songID": 763,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "3b256213a02d73e33653a26b98aa71d54141b9e1",
@@ -90271,9 +90093,7 @@
 		"rgcID": null,
 		"songID": 763,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "ce6e02e9e86f6d181bd77ed78aa90a718e7fc359",
@@ -90289,9 +90109,7 @@
 		"rgcID": null,
 		"songID": 764,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "f49a0a43d3e5900996c2d95fbb19bca4e6ac9ca6",
@@ -90307,9 +90125,7 @@
 		"rgcID": null,
 		"songID": 764,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "9ccac9d2672cccf43ea1556896a09cfee3b6f3e2",
@@ -90325,9 +90141,7 @@
 		"rgcID": null,
 		"songID": 764,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "ffaab7e01009b6b23aaaa3968a9ef38654bd7e9d",
@@ -90343,9 +90157,7 @@
 		"rgcID": null,
 		"songID": 764,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "044d78391403f95cdeffd3a14887c4ffd4899c97",
@@ -90361,9 +90173,7 @@
 		"rgcID": null,
 		"songID": 764,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "d13004095c348a2274fc2fad8db74b71a34c61d9",
@@ -90379,9 +90189,7 @@
 		"rgcID": null,
 		"songID": 764,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "71812909476d42fac323f620ab1d502d7fca374b",
@@ -90397,9 +90205,7 @@
 		"rgcID": null,
 		"songID": 765,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "42a4422828db9fa461662ae34f84e5e84abae5dc",
@@ -90415,9 +90221,7 @@
 		"rgcID": null,
 		"songID": 765,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "9ebe3049ecc87cab1c60b48b251342e46b2e3a87",
@@ -90433,9 +90237,7 @@
 		"rgcID": null,
 		"songID": 765,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "aec1d3fc6c4a752c50af5a8ed49c04a64affd5b0",
@@ -90451,9 +90253,7 @@
 		"rgcID": null,
 		"songID": 765,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "37cb1789abb01a7ef1bb86c69369fe480f37b08b",
@@ -90469,9 +90269,7 @@
 		"rgcID": null,
 		"songID": 765,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "0af12ed93b5370a1d7cd2bca04622629159f77e0",
@@ -90487,9 +90285,7 @@
 		"rgcID": null,
 		"songID": 765,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "637b43a24e3a67b046695ef8078e1ecafafe0cd4",
@@ -90613,9 +90409,7 @@
 		"rgcID": null,
 		"songID": 767,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "51f279098061b503287f848a29f83bd37f97b5a2",
@@ -90631,9 +90425,7 @@
 		"rgcID": null,
 		"songID": 767,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "cf53fd538ceaeacc18ba724fa340672a3fa5ab82",
@@ -90649,9 +90441,7 @@
 		"rgcID": null,
 		"songID": 767,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "3a45285d4ba65f2d6194c7db19548c24f47a0ba3",
@@ -90667,9 +90457,7 @@
 		"rgcID": null,
 		"songID": 767,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "5d98176ec4cb14535f29a8af4e910730f51a3658",
@@ -90685,9 +90473,7 @@
 		"rgcID": null,
 		"songID": 767,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "2691efcdcd3ecf68a4b8b6d2bfb2e0312e83a54e",
@@ -90703,9 +90489,7 @@
 		"rgcID": null,
 		"songID": 767,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "4fe439b8146bd0c53360668c95320792eca3fd7e",
@@ -90937,9 +90721,7 @@
 		"rgcID": null,
 		"songID": 770,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "9693748c54246e3b45da9d942ce7cd313494c1f2",
@@ -90955,9 +90737,7 @@
 		"rgcID": null,
 		"songID": 770,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "78eed219d004392ba49c292362d5485f0efcc412",
@@ -90973,9 +90753,7 @@
 		"rgcID": null,
 		"songID": 770,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "caa115390546d5ee5bb05db002b948194cf6aa73",
@@ -90991,9 +90769,7 @@
 		"rgcID": null,
 		"songID": 770,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "c46c23fea24fa9bedf9fedc1e6180092704f5bc3",
@@ -91009,9 +90785,7 @@
 		"rgcID": null,
 		"songID": 770,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "b73bb9495a09a83997730936a03e2be3e8292e6e",
@@ -91027,9 +90801,7 @@
 		"rgcID": null,
 		"songID": 770,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "f7782e0fb7b435278f9d02d96fbce7471bddf44b",
@@ -91153,9 +90925,7 @@
 		"rgcID": null,
 		"songID": 772,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "1e505c6704f682afdbd153f7c9d3e947ad910de9",
@@ -91171,9 +90941,7 @@
 		"rgcID": null,
 		"songID": 772,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a9f624e8fc4142b449825b59f0777bba52985c2a",
@@ -91189,9 +90957,7 @@
 		"rgcID": null,
 		"songID": 772,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "0edc1ccd4e88a83d5d7ec5efbea667d628a314a0",
@@ -91207,9 +90973,7 @@
 		"rgcID": null,
 		"songID": 772,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "043df0a00ba4609c2e59226d6b845c00a23c040a",
@@ -91225,9 +90989,7 @@
 		"rgcID": null,
 		"songID": 772,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a4b44362b0c4ee5e4e68e3b4731dc99086d42b7c",
@@ -91243,9 +91005,7 @@
 		"rgcID": null,
 		"songID": 772,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "fd8e9c5f814b2eff49e8809efa6b4ca84fe4dfd0",
@@ -91369,9 +91129,7 @@
 		"rgcID": null,
 		"songID": 774,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "e208cc4d698768c19a29277d3edc969bce9301ea",
@@ -91387,9 +91145,7 @@
 		"rgcID": null,
 		"songID": 774,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "17bd44d9d0d973cb65e4a89b5c17edea326f5e84",
@@ -91405,9 +91161,7 @@
 		"rgcID": null,
 		"songID": 774,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a371b068dd96920e37e7724ecc40d69e673148f5",
@@ -91423,9 +91177,7 @@
 		"rgcID": null,
 		"songID": 774,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "fb7051df40481991bde714cf4663c533e5ec702d",
@@ -91441,9 +91193,7 @@
 		"rgcID": null,
 		"songID": 774,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "6f27377cc342dff56c95180c0b5282418d7b46a8",
@@ -91459,9 +91209,7 @@
 		"rgcID": null,
 		"songID": 774,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "55de37639e2fe5ab68f948eec4996db2349470ec",
@@ -91477,9 +91225,7 @@
 		"rgcID": null,
 		"songID": 775,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "d5a800a126892dac553d227d5e013256d351595c",
@@ -91495,9 +91241,7 @@
 		"rgcID": null,
 		"songID": 775,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "542c6b5777c10d2e7f93b3d04e48eee5821612d7",
@@ -91513,9 +91257,7 @@
 		"rgcID": null,
 		"songID": 775,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "55e542ae2a7724826a759d266a42ee8a913101a2",
@@ -91531,9 +91273,7 @@
 		"rgcID": null,
 		"songID": 775,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "89df41d9b1f7849976fbff1b804e8bff97e2b911",
@@ -91549,9 +91289,7 @@
 		"rgcID": null,
 		"songID": 775,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "018806cd1def571d9d165ae2e9dccd8767e72c7e",
@@ -91567,9 +91305,7 @@
 		"rgcID": null,
 		"songID": 775,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a63507121a784a831a4508dfa64b2d4fb7586137",
@@ -91585,9 +91321,7 @@
 		"rgcID": null,
 		"songID": 776,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "e8ec2226c66187aac4b08669cc2b8f222f52037b",
@@ -91603,9 +91337,7 @@
 		"rgcID": null,
 		"songID": 776,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a919a44cfe90e079c6f33316bc55908824090423",
@@ -91621,9 +91353,7 @@
 		"rgcID": null,
 		"songID": 776,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a42e248ad6ff349961857bc6c6b004c805364a4b",
@@ -91639,9 +91369,7 @@
 		"rgcID": null,
 		"songID": 776,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "ca815bf97dd68e29e3e3c42f23e6121e18279dcd",
@@ -91657,9 +91385,7 @@
 		"rgcID": null,
 		"songID": 776,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "8f9820212c0905ccd2cce16304b79e0c109a5b6d",
@@ -91675,9 +91401,7 @@
 		"rgcID": null,
 		"songID": 776,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "471fe94fa7303637bf30cb7f0688010b59b4cae8",
@@ -91693,9 +91417,7 @@
 		"rgcID": null,
 		"songID": 777,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "aff0ebe3117f03b76e8b7e601e28bfb6c910dbee",
@@ -91711,9 +91433,7 @@
 		"rgcID": null,
 		"songID": 777,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "7691c38b3ae355cd032f26bad2b8416608abdcc4",
@@ -91729,9 +91449,7 @@
 		"rgcID": null,
 		"songID": 777,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "644f7c741311ff2b2c1070c0ed6e0535c563ba5a",
@@ -91747,9 +91465,7 @@
 		"rgcID": null,
 		"songID": 777,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "860f7dd68957e696c2f855c9775a1cf0460f07e0",
@@ -91765,9 +91481,7 @@
 		"rgcID": null,
 		"songID": 777,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "4532d8bedd5eb17ddfd346e839bda994bc033018",
@@ -91783,9 +91497,7 @@
 		"rgcID": null,
 		"songID": 777,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "00b461320ec66ed7d967f1c306862ae479a0db85",
@@ -91801,9 +91513,7 @@
 		"rgcID": null,
 		"songID": 778,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "7e9138ceb0bed0313d580b1e7c6fe69f912fcf4f",
@@ -91819,9 +91529,7 @@
 		"rgcID": null,
 		"songID": 778,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "420745e71109e7d97c817f9accc8ae50f5ffaf2c",
@@ -91837,9 +91545,7 @@
 		"rgcID": null,
 		"songID": 778,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "e58031c46ec98cc5b717c3724e584b2fa9ca9dc2",
@@ -91855,9 +91561,7 @@
 		"rgcID": null,
 		"songID": 778,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "53f295822a0551ba34bc8db77690769ab58441a2",
@@ -91873,9 +91577,7 @@
 		"rgcID": null,
 		"songID": 778,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "df2277b051811c5268aa9e4d7ac0fa12e7fac90a",
@@ -91891,9 +91593,7 @@
 		"rgcID": null,
 		"songID": 778,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "2f3ec34cd544cdc9ad3496fcb503642ae94ab752",
@@ -91909,9 +91609,7 @@
 		"rgcID": null,
 		"songID": 779,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "09f850de21de234b45a9136007169928691a866d",
@@ -91927,9 +91625,7 @@
 		"rgcID": null,
 		"songID": 779,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "3013d8143008604720d01e1768181ab32e66e560",
@@ -91945,9 +91641,7 @@
 		"rgcID": null,
 		"songID": 779,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a1903de6e0f772f2960337fc8e2a3cbb997327cc",
@@ -91963,9 +91657,7 @@
 		"rgcID": null,
 		"songID": 779,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "eca0a2ddfb97acbcee0c6826aa7c7d1100973d7c",
@@ -91981,9 +91673,7 @@
 		"rgcID": null,
 		"songID": 779,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "ca535adc348c290a53b04bfb760dfd33163bf17e",
@@ -91999,9 +91689,7 @@
 		"rgcID": null,
 		"songID": 779,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "d76bb788876ed90012101ffb603ed290bb05b75c",
@@ -92017,9 +91705,7 @@
 		"rgcID": null,
 		"songID": 780,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "e1d7c8d4fb067db29cb52d2a4caa7f56bfbe2bcf",
@@ -92035,9 +91721,7 @@
 		"rgcID": null,
 		"songID": 780,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "45626a4a4978e8ff3249d773d38d4b00eaa369b5",
@@ -92053,9 +91737,7 @@
 		"rgcID": null,
 		"songID": 780,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "8c4655bdb30a5e646eba4414d263d9d15dcf551b",
@@ -92071,9 +91753,7 @@
 		"rgcID": null,
 		"songID": 780,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "9fde9c36f02d7b5c518d4890d38dfd521a746cca",
@@ -92089,9 +91769,7 @@
 		"rgcID": null,
 		"songID": 780,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "16e46af1c99cb7a8ddde39fdf7f1e0386411e3f9",
@@ -92107,9 +91785,7 @@
 		"rgcID": null,
 		"songID": 780,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "f9066a284535b62749269819ce4984f534c80030",
@@ -95257,9 +94933,7 @@
 		"rgcID": null,
 		"songID": 810,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "c0a4781050eb11fce7481349907c6483c8520d1d",
@@ -95275,9 +94949,7 @@
 		"rgcID": null,
 		"songID": 810,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "468578167587d249e8162b12ffff8a40fa48977f",
@@ -95293,9 +94965,7 @@
 		"rgcID": null,
 		"songID": 810,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "95fabba769d87683c49d8047ddfff7df7de5cd32",
@@ -95311,9 +94981,7 @@
 		"rgcID": null,
 		"songID": 810,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "176a8f1548955240d4580eaed2925b0a7a6acf8c",
@@ -95329,9 +94997,7 @@
 		"rgcID": null,
 		"songID": 810,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "0f5713f945a9c1f18e1016f04524943f1db63aa1",
@@ -95347,9 +95013,7 @@
 		"rgcID": null,
 		"songID": 810,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "6576c231b0f5b1f94ba0153e37ea25bcb209a082",
@@ -95797,9 +95461,7 @@
 		"rgcID": null,
 		"songID": 815,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "952adead397a143f11453d37e5ecfb9bba488d03",
@@ -95815,9 +95477,7 @@
 		"rgcID": null,
 		"songID": 815,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "8b7f65e3455e1da47daf6564f64426a6bbd63656",
@@ -95833,9 +95493,7 @@
 		"rgcID": null,
 		"songID": 815,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a978d65f7ba020e011949d0f7b61ea47fce0117a",
@@ -95851,9 +95509,7 @@
 		"rgcID": null,
 		"songID": 815,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "d60939ad9dc46e89de8c2c81ad13f8c3a6084e12",
@@ -95869,9 +95525,7 @@
 		"rgcID": null,
 		"songID": 815,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "51887eade3477e792e6bd87a3e26215f6e3e043e",
@@ -95887,9 +95541,7 @@
 		"rgcID": null,
 		"songID": 815,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "13f6b0ffe0ce292f68478943266fffeb7f13527f",
@@ -95905,9 +95557,7 @@
 		"rgcID": null,
 		"songID": 816,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "84438bf1444994151fb2aba20d892ce249c26053",
@@ -95923,9 +95573,7 @@
 		"rgcID": null,
 		"songID": 816,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "4b863a19ff0d1ec35263ca4f0763de8f0cc8709c",
@@ -95941,9 +95589,7 @@
 		"rgcID": null,
 		"songID": 816,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "519f23950e63bdee8b15d461e5817c0c788e068e",
@@ -95959,9 +95605,7 @@
 		"rgcID": null,
 		"songID": 816,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "50c4247cb3e17d36f95a12b653acd14c27339df2",
@@ -95977,9 +95621,7 @@
 		"rgcID": null,
 		"songID": 816,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "c6ab9b751f4d311c3cdd94cfc0d8fcfa7c4d280f",
@@ -95995,9 +95637,7 @@
 		"rgcID": null,
 		"songID": 816,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "6e1e566ae7b7b1295dd2007a851854f1e40c5bdf",
@@ -96013,9 +95653,7 @@
 		"rgcID": null,
 		"songID": 817,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "78890fbbabbcd29f3bdd76a6970591312ae8db43",
@@ -96031,9 +95669,7 @@
 		"rgcID": null,
 		"songID": 817,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "4229b62483d0ec92c99a9717ae9c80d949028561",
@@ -96049,9 +95685,7 @@
 		"rgcID": null,
 		"songID": 817,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "79602f319249adc7c4da6a3bf56b5a1a01690c77",
@@ -96067,9 +95701,7 @@
 		"rgcID": null,
 		"songID": 817,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "f459f65f44534078accdfb644707b6b3a23bc39a",
@@ -96085,9 +95717,7 @@
 		"rgcID": null,
 		"songID": 817,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "178bdb6597ddda3153794c26df2ac46cf2d94a30",
@@ -96103,9 +95733,7 @@
 		"rgcID": null,
 		"songID": 817,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a0b02f386ce2031ca00dae5248dcf14d26925e82",
@@ -96121,9 +95749,7 @@
 		"rgcID": null,
 		"songID": 818,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "d12012ce1cbdb1c87e9e90d0161d79e8e203b872",
@@ -96139,9 +95765,7 @@
 		"rgcID": null,
 		"songID": 818,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "7c343a5085d14d6a7a1b7ac4330f5a4d362c5d4b",
@@ -96157,9 +95781,7 @@
 		"rgcID": null,
 		"songID": 818,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a836d1951a3b08678fceae44d02c01ede71fc3bd",
@@ -96175,9 +95797,7 @@
 		"rgcID": null,
 		"songID": 818,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "e06ca570dbe3b9a5019cfbdfd203d4fb6b70b4c3",
@@ -96193,9 +95813,7 @@
 		"rgcID": null,
 		"songID": 818,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "1aebf629a3420a7a9146ef45c7bbc0427e32639e",
@@ -96211,9 +95829,7 @@
 		"rgcID": null,
 		"songID": 818,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "453a3c84499b9eeba5623bb1729f85f576b637a4",
@@ -96337,9 +95953,7 @@
 		"rgcID": null,
 		"songID": 820,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "4006d44667a47ebf78c350bb31204af4e2e54c89",
@@ -96355,9 +95969,7 @@
 		"rgcID": null,
 		"songID": 820,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "2c285d125c0982e0467e2ff63411501550fa7c10",
@@ -96373,9 +95985,7 @@
 		"rgcID": null,
 		"songID": 820,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "9881fc96481dabfb8e33f6d3a3a548db9b11fc47",
@@ -96391,9 +96001,7 @@
 		"rgcID": null,
 		"songID": 820,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "20d2798378ed9c8db0a8892f95795fb8986f0d83",
@@ -96409,9 +96017,7 @@
 		"rgcID": null,
 		"songID": 820,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "634752f806a69d49a1658cdcfcc3aa9311f17375",
@@ -96427,9 +96033,7 @@
 		"rgcID": null,
 		"songID": 820,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "fa0b3a24ebc4ad7b7dd6bf2ce08507d8392a55ac",
@@ -96445,9 +96049,7 @@
 		"rgcID": null,
 		"songID": 821,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "fb038e2729556298bb95a65e999efd5a65886cd8",
@@ -96463,9 +96065,7 @@
 		"rgcID": null,
 		"songID": 821,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a3cae6374c16e0163d6a971a2e88535580c9d756",
@@ -96481,9 +96081,7 @@
 		"rgcID": null,
 		"songID": 821,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "9fde3d34ac0ba0999fdcbc4510860c3bd97f4540",
@@ -96499,9 +96097,7 @@
 		"rgcID": null,
 		"songID": 821,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "e7a902c55899cccf36f72dac4eb3fe27c181eebe",
@@ -96517,9 +96113,7 @@
 		"rgcID": null,
 		"songID": 821,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "c84aa27ae9368bec915adb716ed1394f448e9e75",
@@ -96535,9 +96129,7 @@
 		"rgcID": null,
 		"songID": 821,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "a365e737092746ea708087123ccbb6ac43115503",
@@ -96553,9 +96145,7 @@
 		"rgcID": null,
 		"songID": 822,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "2f81470bee956ee1071a540b8d6c2ea2a7b951e2",
@@ -96571,9 +96161,7 @@
 		"rgcID": null,
 		"songID": 822,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "43a818417d48ebd6d0d9eb4aa326c28ce0e85d1e",
@@ -96589,9 +96177,7 @@
 		"rgcID": null,
 		"songID": 822,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "d113f86deb1f7b2ffc42eacdbead2db36e543b58",
@@ -96607,9 +96193,7 @@
 		"rgcID": null,
 		"songID": 822,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "ae5d4b608090b818daa33e5838fff26488633dc4",
@@ -96625,9 +96209,7 @@
 		"rgcID": null,
 		"songID": 822,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "1c40054ba7dc498831b17c0effe0bc6123039f22",
@@ -96643,9 +96225,7 @@
 		"rgcID": null,
 		"songID": 822,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "7d43b4ae5d5207e1f0a2456ffb7991f8b0f2bbd0",
@@ -96661,9 +96241,7 @@
 		"rgcID": null,
 		"songID": 823,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "eaf7c165b43e773f366592f7982e6d1b0edd4f98",
@@ -96679,9 +96257,7 @@
 		"rgcID": null,
 		"songID": 823,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "064619d141e531da6e149bf320729d9bbe98bb5a",
@@ -96697,9 +96273,7 @@
 		"rgcID": null,
 		"songID": 823,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "2a9ee44830cb957109f3c4ab5146b98cd5a2b231",
@@ -96715,9 +96289,7 @@
 		"rgcID": null,
 		"songID": 823,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "5b36bd9d5aa94e9cd573548617f0f80dcaa07318",
@@ -96733,9 +96305,7 @@
 		"rgcID": null,
 		"songID": 823,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "51add2d7eda05e4d3c02a7ad5fdb39b76a5facc6",
@@ -96751,9 +96321,7 @@
 		"rgcID": null,
 		"songID": 823,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "523488ce5790ef0e97b9edadcf505f5278b9575e",
@@ -96769,9 +96337,7 @@
 		"rgcID": null,
 		"songID": 824,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "356430699e540895d464dcaafd4834a0b3330bd2",
@@ -96787,9 +96353,7 @@
 		"rgcID": null,
 		"songID": 824,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "92092eedf245135fd8b6de73d8081936cd9f3c0e",
@@ -96805,9 +96369,7 @@
 		"rgcID": null,
 		"songID": 824,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "f1bd1f61b55572458c87b085466dd4e490b38f47",
@@ -96823,9 +96385,7 @@
 		"rgcID": null,
 		"songID": 824,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "662ebabeaaaa29134d2663b7ffcb76d2882d614c",
@@ -96841,9 +96401,7 @@
 		"rgcID": null,
 		"songID": 824,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "dfa27f4dacf5610e4e3ed59b2a107c13344a7440",
@@ -96859,9 +96417,7 @@
 		"rgcID": null,
 		"songID": 824,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "9dceb204124e42768083fdf6d00611b50511dd01",
@@ -105087,8 +104643,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105107,8 +104662,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105127,8 +104681,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105147,8 +104700,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105167,8 +104719,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105187,8 +104738,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105207,8 +104757,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105227,8 +104776,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105247,8 +104795,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105267,8 +104814,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105287,8 +104833,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105307,8 +104852,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105327,8 +104871,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105347,8 +104890,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105367,8 +104909,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105387,8 +104928,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105407,8 +104947,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105427,8 +104966,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105447,8 +104985,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105467,8 +105004,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105487,8 +105023,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105507,8 +105042,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105527,8 +105061,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105547,8 +105080,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105567,8 +105099,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105587,8 +105118,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105607,8 +105137,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105627,8 +105156,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105647,8 +105175,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105667,8 +105194,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105687,8 +105213,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105707,8 +105232,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105727,8 +105251,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105747,8 +105270,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105767,8 +105289,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105787,8 +105308,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105807,8 +105327,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105827,8 +105346,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105847,8 +105365,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105867,8 +105384,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105887,8 +105403,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105907,8 +105422,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105927,8 +105441,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105947,8 +105460,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105967,8 +105479,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -105987,8 +105498,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106007,8 +105517,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106027,8 +105536,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106275,8 +105783,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106295,8 +105802,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106315,8 +105821,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106335,8 +105840,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106355,8 +105859,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106375,8 +105878,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106395,8 +105897,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106415,8 +105916,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106435,8 +105935,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106455,8 +105954,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106475,8 +105973,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106495,8 +105992,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106515,8 +106011,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106535,8 +106030,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106555,8 +106049,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106575,8 +106068,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106595,8 +106087,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106615,8 +106106,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106635,8 +106125,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106655,8 +106144,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106675,8 +106163,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106695,8 +106182,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106715,8 +106201,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106735,8 +106220,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106755,8 +106239,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106775,8 +106258,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106795,8 +106277,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106815,8 +106296,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106835,8 +106315,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106855,8 +106334,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106875,8 +106353,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106895,8 +106372,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106915,8 +106391,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106935,8 +106410,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106955,8 +106429,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106975,8 +106448,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -106995,8 +106467,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107015,8 +106486,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107035,8 +106505,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107055,8 +106524,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107075,8 +106543,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107095,8 +106562,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107115,8 +106581,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107135,8 +106600,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107155,8 +106619,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107175,8 +106638,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107195,8 +106657,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107215,8 +106676,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107235,8 +106695,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107255,8 +106714,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107275,8 +106733,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107295,8 +106752,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107315,8 +106771,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107335,8 +106790,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107355,8 +106809,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107375,8 +106828,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107395,8 +106847,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107415,8 +106866,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107435,8 +106885,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107455,8 +106904,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107475,8 +106923,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107495,8 +106942,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107515,8 +106961,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107535,8 +106980,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107555,8 +106999,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107575,8 +107018,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107595,8 +107037,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107615,8 +107056,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107635,8 +107075,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107655,8 +107094,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107675,8 +107113,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107695,8 +107132,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107715,8 +107151,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107735,8 +107170,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107755,8 +107189,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107775,8 +107208,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107795,8 +107227,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107815,8 +107246,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107835,8 +107265,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107855,8 +107284,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107875,8 +107303,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107895,8 +107322,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107915,8 +107341,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107935,8 +107360,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107955,8 +107379,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107975,8 +107398,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -107995,8 +107417,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108015,8 +107436,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108035,8 +107455,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108055,8 +107474,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108075,8 +107493,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108095,8 +107512,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108115,8 +107531,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108135,8 +107550,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108155,8 +107569,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108175,8 +107588,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108195,8 +107607,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108215,8 +107626,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108235,8 +107645,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108255,8 +107664,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108275,8 +107683,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108295,8 +107702,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108315,8 +107721,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108335,8 +107740,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108355,8 +107759,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108375,8 +107778,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108395,8 +107797,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108415,8 +107816,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108435,8 +107835,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108455,8 +107854,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108475,8 +107873,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108495,8 +107892,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108515,8 +107911,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108535,8 +107930,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108555,8 +107949,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108575,8 +107968,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108595,8 +107987,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108615,8 +108006,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108635,8 +108025,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108655,8 +108044,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108675,8 +108063,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108695,8 +108082,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108715,8 +108101,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108735,8 +108120,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108755,8 +108139,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108775,8 +108158,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108795,8 +108177,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108815,8 +108196,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108835,8 +108215,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108855,8 +108234,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108875,8 +108253,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108895,8 +108272,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108915,8 +108291,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108935,8 +108310,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108955,8 +108329,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108975,8 +108348,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -108995,8 +108367,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109015,8 +108386,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109035,8 +108405,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109055,8 +108424,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109075,8 +108443,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109095,8 +108462,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109115,8 +108481,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109135,8 +108500,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109155,8 +108519,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109175,8 +108538,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109195,8 +108557,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109215,8 +108576,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109235,8 +108595,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109255,8 +108614,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109275,8 +108633,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109295,8 +108652,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109315,8 +108671,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109335,8 +108690,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109355,8 +108709,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -109375,8 +108728,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110421,8 +109773,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110441,8 +109792,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110461,8 +109811,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110481,8 +109830,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110501,8 +109849,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110521,8 +109868,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110541,8 +109887,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110561,8 +109906,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110581,8 +109925,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110601,8 +109944,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110621,8 +109963,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110641,8 +109982,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110661,8 +110001,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110681,8 +110020,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110701,8 +110039,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110721,8 +110058,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110741,8 +110077,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110761,8 +110096,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110781,8 +110115,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110801,8 +110134,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110821,8 +110153,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110841,8 +110172,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110861,8 +110191,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110881,8 +110210,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110901,8 +110229,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110921,8 +110248,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110941,8 +110267,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110961,8 +110286,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -110981,8 +110305,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111001,8 +110324,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111021,8 +110343,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111041,8 +110362,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111061,8 +110381,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111081,8 +110400,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111101,8 +110419,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111121,8 +110438,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111141,8 +110457,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111161,8 +110476,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111181,8 +110495,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111201,8 +110514,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111221,8 +110533,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111241,8 +110552,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111261,8 +110571,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111281,8 +110590,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111301,8 +110609,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111321,8 +110628,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111341,8 +110647,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111361,8 +110666,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111381,8 +110685,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111401,8 +110704,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111421,8 +110723,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111441,8 +110742,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111461,8 +110761,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111481,8 +110780,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111501,8 +110799,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111521,8 +110818,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111541,8 +110837,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111561,8 +110856,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111581,8 +110875,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111601,8 +110894,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111621,8 +110913,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111641,8 +110932,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111661,8 +110951,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111681,8 +110970,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111701,8 +110989,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111721,8 +111008,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111741,8 +111027,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111761,8 +111046,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111781,8 +111065,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111801,8 +111084,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111821,8 +111103,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111841,8 +111122,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111861,8 +111141,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111881,8 +111160,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111901,8 +111179,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111921,8 +111198,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111941,8 +111217,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111961,8 +111236,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -111981,8 +111255,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112001,8 +111274,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112021,8 +111293,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112041,8 +111312,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112061,8 +111331,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112081,8 +111350,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112101,8 +111369,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112121,8 +111388,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112141,8 +111407,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112161,8 +111426,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112181,8 +111445,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112201,8 +111464,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112221,8 +111483,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112241,8 +111502,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112261,8 +111521,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112281,8 +111540,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112301,8 +111559,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112321,8 +111578,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112341,8 +111597,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112361,8 +111616,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112381,8 +111635,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112401,8 +111654,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112421,8 +111673,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112441,8 +111692,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112461,8 +111711,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112481,8 +111730,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112501,8 +111749,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112521,8 +111768,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112541,8 +111787,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112561,8 +111806,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112581,8 +111825,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112601,8 +111844,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112621,8 +111863,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112641,8 +111882,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112661,8 +111901,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112681,8 +111920,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112701,8 +111939,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112721,8 +111958,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112741,8 +111977,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112761,8 +111996,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112781,8 +112015,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112801,8 +112034,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112821,8 +112053,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112841,8 +112072,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112861,8 +112091,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112881,8 +112110,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112901,8 +112129,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112921,8 +112148,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112941,8 +112167,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112961,8 +112186,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -112981,8 +112205,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113001,8 +112224,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113021,8 +112243,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113041,8 +112262,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113061,8 +112281,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113081,8 +112300,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113101,8 +112319,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113121,8 +112338,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113141,8 +112357,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113161,8 +112376,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113181,8 +112395,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113201,8 +112414,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113221,8 +112433,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113241,8 +112452,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113261,8 +112471,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113281,8 +112490,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113301,8 +112509,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113321,8 +112528,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113341,8 +112547,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113361,8 +112566,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113381,8 +112585,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113401,8 +112604,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113421,8 +112623,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113441,8 +112642,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113461,8 +112661,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113481,8 +112680,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113501,8 +112699,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113521,8 +112718,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113541,8 +112737,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113561,8 +112756,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113581,8 +112775,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113601,8 +112794,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113621,8 +112813,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113641,8 +112832,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113661,8 +112851,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113681,8 +112870,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113701,8 +112889,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113721,8 +112908,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113741,8 +112927,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113761,8 +112946,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113781,8 +112965,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113801,8 +112984,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113821,8 +113003,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113841,8 +113022,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113861,8 +113041,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113881,8 +113060,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113901,8 +113079,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113921,8 +113098,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113941,8 +113117,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113961,8 +113136,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -113981,8 +113155,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114001,8 +113174,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114021,8 +113193,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114041,8 +113212,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114061,8 +113231,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114081,8 +113250,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114101,8 +113269,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114121,8 +113288,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114141,8 +113307,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114161,8 +113326,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114181,8 +113345,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114201,8 +113364,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114221,8 +113383,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114241,8 +113402,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114261,8 +113421,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114281,8 +113440,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114301,8 +113459,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114321,8 +113478,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114341,8 +113497,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114361,8 +113516,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114381,8 +113535,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114401,8 +113554,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114421,8 +113573,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114441,8 +113592,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114461,8 +113611,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114481,8 +113630,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114501,8 +113649,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114521,8 +113668,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114541,8 +113687,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114561,8 +113706,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114581,8 +113725,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114601,8 +113744,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114621,8 +113763,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114641,8 +113782,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114661,8 +113801,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114681,8 +113820,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114701,8 +113839,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114721,8 +113858,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114741,8 +113877,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114761,8 +113896,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114781,8 +113915,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114801,8 +113934,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114821,8 +113953,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114841,8 +113972,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114861,8 +113991,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114881,8 +114010,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114901,8 +114029,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114921,8 +114048,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114941,8 +114067,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114961,8 +114086,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -114981,8 +114105,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115001,8 +114124,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115021,8 +114143,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115041,8 +114162,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115061,8 +114181,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115081,8 +114200,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115101,8 +114219,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115121,8 +114238,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115141,8 +114257,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115161,8 +114276,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115181,8 +114295,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115201,8 +114314,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115221,8 +114333,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115241,8 +114352,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115261,8 +114371,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115281,8 +114390,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115301,8 +114409,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115321,8 +114428,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115341,8 +114447,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115361,8 +114466,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115381,8 +114485,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115401,8 +114504,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115421,8 +114523,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115441,8 +114542,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115461,8 +114561,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115481,8 +114580,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115501,8 +114599,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115521,8 +114618,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115541,8 +114637,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115561,8 +114656,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115581,8 +114675,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115601,8 +114694,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115621,8 +114713,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115641,8 +114732,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115661,8 +114751,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115681,8 +114770,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115701,8 +114789,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115721,8 +114808,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115741,8 +114827,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115761,8 +114846,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115781,8 +114865,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115801,8 +114884,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115821,8 +114903,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115841,8 +114922,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115861,8 +114941,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115881,8 +114960,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115901,8 +114979,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115921,8 +114998,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115941,8 +115017,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115961,8 +115036,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -115981,8 +115055,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116001,8 +115074,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116021,8 +115093,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116041,8 +115112,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116061,8 +115131,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116081,8 +115150,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116101,8 +115169,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116121,8 +115188,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116141,8 +115207,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116161,8 +115226,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116181,8 +115245,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116201,8 +115264,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116221,8 +115283,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116241,8 +115302,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116261,8 +115321,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116281,8 +115340,7 @@
 		"tierlistInfo": {},
 		"versions": [
 			"qubell",
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116300,8 +115358,7 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116319,8 +115376,7 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116338,8 +115394,7 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116357,8 +115412,7 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116376,8 +115430,7 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116395,8 +115448,7 @@
 		"songID": 995,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116414,8 +115466,7 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116433,8 +115484,7 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116452,8 +115502,7 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116471,8 +115520,7 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116490,8 +115538,7 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116509,8 +115556,7 @@
 		"songID": 996,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116528,8 +115574,7 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116547,8 +115592,7 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116566,8 +115610,7 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116585,8 +115628,7 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116604,8 +115646,7 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116623,8 +115664,7 @@
 		"songID": 997,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116642,8 +115682,7 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116661,8 +115700,7 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116680,8 +115718,7 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116699,8 +115736,7 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116718,8 +115754,7 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116737,8 +115772,7 @@
 		"songID": 998,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116756,8 +115790,7 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116775,8 +115808,7 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116794,8 +115826,7 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116813,8 +115844,7 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116832,8 +115862,7 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116851,8 +115880,7 @@
 		"songID": 999,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116870,8 +115898,7 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116889,8 +115916,7 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116908,8 +115934,7 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116927,8 +115952,7 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116946,8 +115970,7 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116965,8 +115988,7 @@
 		"songID": 1000,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -116984,8 +116006,7 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117003,8 +116024,7 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117022,8 +116042,7 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117041,8 +116060,7 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117060,8 +116078,7 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117079,8 +116096,7 @@
 		"songID": 1001,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117098,8 +116114,7 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117117,8 +116132,7 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117136,8 +116150,7 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117155,8 +116168,7 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117174,8 +116186,7 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117193,8 +116204,7 @@
 		"songID": 1002,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117212,8 +116222,7 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117231,8 +116240,7 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117250,8 +116258,7 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117269,8 +116276,7 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117288,8 +116294,7 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117307,8 +116312,7 @@
 		"songID": 1003,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117326,8 +116330,7 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117345,8 +116348,7 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117364,8 +116366,7 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117383,8 +116384,7 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117402,8 +116402,7 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117421,8 +116420,7 @@
 		"songID": 1050,
 		"tierlistInfo": {},
 		"versions": [
-			"clan",
-			"festo"
+			"clan"
 		]
 	},
 	{
@@ -117439,9 +116437,7 @@
 		"rgcID": null,
 		"songID": 1051,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "0e89a84a8628856db1a9fa157e5a8e0b1b8862e3",
@@ -117457,9 +116453,7 @@
 		"rgcID": null,
 		"songID": 1051,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "73dc2eb5eea8457e453a49f0ff145c2e16accfd8",
@@ -117475,9 +116469,7 @@
 		"rgcID": null,
 		"songID": 1051,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "f4267c5eeb4d3d47f1beb0f262007043527413e3",
@@ -117493,9 +116485,7 @@
 		"rgcID": null,
 		"songID": 1051,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "aa859c5319997f80a032d96845d2b14eb42ef6b5",
@@ -117511,9 +116501,7 @@
 		"rgcID": null,
 		"songID": 1051,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "0e8ab89c7b0d7c5550667a61d4d00b94feb2e897",
@@ -117529,9 +116517,7 @@
 		"rgcID": null,
 		"songID": 1051,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "7fe0efc554ec4944e5a37d520d76057ea61ed9ab",
@@ -117547,9 +116533,7 @@
 		"rgcID": null,
 		"songID": 1052,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "96c9fedad7da54406ba829cc1c6a8193dc5f7574",
@@ -117565,9 +116549,7 @@
 		"rgcID": null,
 		"songID": 1052,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "655246f86632bdc0c10d4b41f63e50553de15c72",
@@ -117583,9 +116565,7 @@
 		"rgcID": null,
 		"songID": 1052,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "49d65c12dbcd8346a219d610a65b168a6dbb080a",
@@ -117601,9 +116581,7 @@
 		"rgcID": null,
 		"songID": 1052,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "f6e3df28672cc430e656a64790530fb150da5e16",
@@ -117619,9 +116597,7 @@
 		"rgcID": null,
 		"songID": 1052,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "39d3ee0ece5f5187da458fd79395ef05bf785064",
@@ -117637,9 +116613,7 @@
 		"rgcID": null,
 		"songID": 1052,
 		"tierlistInfo": {},
-		"versions": [
-			"festo"
-		]
+		"versions": []
 	},
 	{
 		"chartID": "b3a53428ed44c203182c64a4c96e1966319214b5",


### PR DESCRIPTION
Fixes issue #658.

`festo` tag was removed from `versions` list if the chart was not present in Festo Final. 