### PR TITLE
add exscore to sdvx eamuse csv imports

### DIFF
--- a/server/src/lib/score-import/import-types/file/eamusement-sdvx-csv/converter.test.ts
+++ b/server/src/lib/score-import/import-types/file/eamusement-sdvx-csv/converter.test.ts
@@ -52,6 +52,36 @@ t.test("#ConvertEamSDVXCSV", (t) => {
 		t.end();
 	});
 
+	t.test("Should include exScore if provided", async (t) => {
+		const res = await conv({ exscore: "5730" });
+
+		t.hasStrict(res, {
+			song: TestingSDVXAlbidaSong,
+			chart: TestingAlbidaADV,
+			dryScore: {
+				service: "e-amusement",
+				game: "sdvx",
+				scoreMeta: {},
+				timeAchieved: null,
+				comment: null,
+				importType: "file/eamusement-sdvx-csv",
+				scoreData: {
+					score: 9310699,
+					lamp: "EXCESSIVE CLEAR",
+
+					// percent: 93.10699, floating point
+					grade: "AA",
+					judgements: {},
+					hitMeta: {
+						exScore: 5730,
+					},
+				},
+			},
+		});
+
+		t.end();
+	});
+
 	t.test("Should reject invalid difficulty name", (t) => {
 		t.rejects(() => conv({ difficulty: "INVALID" }), {
 			message: /Invalid difficulty of INVALID\./u,

--- a/server/src/lib/score-import/import-types/file/eamusement-sdvx-csv/converter.ts
+++ b/server/src/lib/score-import/import-types/file/eamusement-sdvx-csv/converter.ts
@@ -85,6 +85,18 @@ const ConvertEamSDVXCSV: ConverterFunction<SDVXEamusementCSVData, EmptyObject> =
 		);
 	}
 
+	// n.b. "positive int" here means non-negative, 0 is allowed.
+	const exScoreOrZero = AssertStrAsPositiveInt(
+		data.exscore,
+		`${humanisedChartTitle} - Invalid EX score of ${data.score}.`
+	);
+
+	// It's theoretically possible to get an EX score of 0 on a legit play,
+	// but this is also the default value if the PB has no EX score (that is,
+	// this song has never been played with S-crit enabled). In this case,
+	// we should not set exScore.
+	const exScore = exScoreOrZero === 0 ? null : exScoreOrZero;
+
 	const lamp = LAMP_MAP.get(data.lamp);
 
 	if (!lamp) {
@@ -109,7 +121,9 @@ const ConvertEamSDVXCSV: ConverterFunction<SDVXEamusementCSVData, EmptyObject> =
 			percent,
 			grade,
 			judgements: {},
-			hitMeta: {},
+			hitMeta: {
+				exScore,
+			},
 		},
 	};
 

--- a/server/src/lib/score-import/import-types/file/eamusement-sdvx-csv/parser.ts
+++ b/server/src/lib/score-import/import-types/file/eamusement-sdvx-csv/parser.ts
@@ -56,9 +56,6 @@ export default function ParseEamusementSDVXCSV(
 		level: cells[2],
 		lamp: cells[3],
 		score: cells[5],
-
-		// @todo exscore is currently unused, but we should eventually store it.
-		// It is 0 if the score was played without S-criticals.
 		exscore: cells[6],
 
 		// The other columns (grade, # of different clears) are essentially useless.


### PR DESCRIPTION
This is not ideal at the moment because score dedup will prevent this from taking effect for any existing PBs, but it's better than nothing.