### PR TITLE
Modify database-seeds/repo.ts to not use cd

### DIFF
--- a/server/src/lib/database-seeds/repo.ts
+++ b/server/src/lib/database-seeds/repo.ts
@@ -111,6 +111,7 @@ export class DatabaseSeedsRepo {
 		return asyncExec(`git config user.name "${ServerConfig.SEEDS_CONFIG.USER_NAME}"`)
 			.then(() => asyncExec(`git config user.email "${email}"`))
 			.then(() =>
+				// eslint-disable-next-line lines-around-comment
 				// @ereti is insistent that this sleep 1 is fine, so, whatever.
 				asyncExec(
 					`git config credential.helper '!f() { sleep 1; echo "username=\${GIT_USER}"; echo "password=\${GIT_PASSWORD}"; }; f'`

--- a/server/src/lib/database-seeds/repo.ts
+++ b/server/src/lib/database-seeds/repo.ts
@@ -95,7 +95,7 @@ export class DatabaseSeedsRepo {
 	 */
 	#AuthenticateWithGitServer() {
 		if (!ServerConfig.SEEDS_CONFIG) {
-			// Shouldn't be possible. Ever, since SEEDS_CONFIG must be deffed in order
+			// Shouldn't be possible. Ever, since SEEDS_CONFIG must be defined in order
 			// to run PullDBSeeds
 			throw new Error(`Cannot commit changes back. SEEDS_CONFIG is not set.`);
 		}
@@ -106,17 +106,21 @@ export class DatabaseSeedsRepo {
 			);
 		}
 
-		const email = ServerConfig.SEEDS_CONFIG.USER_EMAIL; // Ensure this is still defined by the second exec
+		// TS complains that SEEDS_CONFIG.USER_EMAIL might not still be a string by the time the second
+		// callback is called, so lets just define it to a local variable.
+		const email = ServerConfig.SEEDS_CONFIG.USER_EMAIL;
 
-		return asyncExec(`git config user.name "${ServerConfig.SEEDS_CONFIG.USER_NAME}"`)
-			.then(() => asyncExec(`git config user.email "${email}"`))
-			.then(() =>
-				// eslint-disable-next-line lines-around-comment
+		return (
+			asyncExec(`git config user.name "${ServerConfig.SEEDS_CONFIG.USER_NAME}"`)
+				.then(() => asyncExec(`git config user.email "${email}"`))
+
 				// @ereti is insistent that this sleep 1 is fine, so, whatever.
-				asyncExec(
-					`git config credential.helper '!f() { sleep 1; echo "username=\${GIT_USER}"; echo "password=\${GIT_PASSWORD}"; }; f'`
+				.then(() =>
+					asyncExec(
+						`git config credential.helper '!f() { sleep 1; echo "username=\${GIT_USER}"; echo "password=\${GIT_PASSWORD}"; }; f'`
+					)
 				)
-			);
+		);
 	}
 
 	/**

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -181,9 +181,9 @@ export function OmitUndefinedKeys<T>(obj: Partial<T>): Partial<T> {
  * @param command A bash command to execute on the system.
  * @returns stdout and stderr as strings.
  */
-export function asyncExec(command: string) {
+export function asyncExec(command: string, cwd?: string) {
 	return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
-		exec(command, (err, stdout, stderr) => {
+		exec(command, { cwd }, (err, stdout, stderr) => {
 			if (err) {
 				// eslint-disable-next-line prefer-promise-reject-errors
 				reject({ err, stdout, stderr });


### PR DESCRIPTION
Rather than chaining a `cd` command within `asyncExec`, we can instead utilise the `cwd` option within `child_process.exec`. This is slightly cleaner, and is also the magic sauce to make `repo.ts` run on windows (I'm so sorry). This PR splits up all the conjoined commands within `repo.ts` and instead lets typescript handle sequential execution of commands.