### PR TITLE
Permit empty "about me"s

### DIFF
--- a/client/src/app/pages/dashboard/users/UserPage.tsx
+++ b/client/src/app/pages/dashboard/users/UserPage.tsx
@@ -34,7 +34,7 @@ function AboutMeCard({ reqUser }: Props) {
 				headers: {
 					"Content-Type": "application/json",
 				},
-				body: JSON.stringify({ about: content.length === 0 ? null : content }),
+				body: JSON.stringify({ about: content }),
 			},
 			true,
 			true

--- a/server/src/server/router/api/v1/users/_userID/router.test.ts
+++ b/server/src/server/router/api/v1/users/_userID/router.test.ts
@@ -120,6 +120,20 @@ t.test("PATCH /api/v1/users/:userID", async (t) => {
 		t.end();
 	});
 
+	t.test("Shouldn't allow empty strings for about me.", async (t) => {
+		const res = await mockApi.patch("/api/v1/users/1").set("Cookie", cookie).send({
+			about: "",
+		});
+
+		t.equal(res.statusCode, 200);
+
+		const dbUser = await db.users.findOne({ id: 1 });
+
+		t.equal(dbUser?.about, "");
+
+		t.end();
+	});
+
 	t.test("Shouldn't allow about me to be set to null.", async (t) => {
 		const res = await mockApi.patch("/api/v1/users/1").set("Cookie", cookie).send({
 			about: null,

--- a/server/src/server/router/api/v1/users/_userID/router.test.ts
+++ b/server/src/server/router/api/v1/users/_userID/router.test.ts
@@ -120,7 +120,7 @@ t.test("PATCH /api/v1/users/:userID", async (t) => {
 		t.end();
 	});
 
-	t.test("Shouldn't allow empty strings for about me.", async (t) => {
+	t.test("Should allow empty strings for about me.", async (t) => {
 		const res = await mockApi.patch("/api/v1/users/1").set("Cookie", cookie).send({
 			about: "",
 		});


### PR DESCRIPTION
Amends the react code to not pass null and adds a server test for this case (though the server was already accepting zero-length strings).