### PR TITLE
Fix auth cookies on newer chromium builds

### DIFF
--- a/server/src/server/router/api/v1/auth/auth.ts
+++ b/server/src/server/router/api/v1/auth/auth.ts
@@ -178,5 +178,4 @@ export function MountAuthCookie(
 	};
 
 	req.session.cookie.maxAge = 3.154e10;
-	req.session.cookie.secure = Environment.nodeEnv === "production";
 }

--- a/server/src/server/server.ts
+++ b/server/src/server/server.ts
@@ -43,10 +43,12 @@ const userSessionMiddleware = expressSession({
 	resave: true,
 	saveUninitialized: false,
 	cookie: {
+		// the absence of Secure in combination with SameSite=None will cause issues on non-https
+		// instances in newer versions of chromium. there is no workaround for this.
 		secure: Environment.nodeEnv === "production" || ServerConfig.ENABLE_SERVER_HTTPS,
 
 		// Very important. Without this, we're vulnerable to CSRF!
-		sameSite: "strict",
+		sameSite: Environment.nodeEnv === "production" ? "strict" : "none",
 	},
 });
 


### PR DESCRIPTION
In newer versions of chromium (91+), `SameSite` defaults to `Lax`. The client and server run on different origins in dev, and as such `SameSite` must be explicitly set to `None`.

A `SameSite` of `None` is only permissible if the cookie is `Secure`. This therefore mandates that development in these situations is either performed with `ENABLE_SERVER_HTTPS` enabled (the default) or behind a local reverse proxy ensuring both are on a shared origin.