### PR TITLE
iidx 29 update

### DIFF
--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -23246,5 +23246,555 @@
 		"id": 2099,
 		"searchTerms": [],
 		"title": "24h Endurance Race"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"L.E.D.\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "NEUROFUNK"
+		},
+		"id": 2100,
+		"searchTerms": [],
+		"title": "GRAVITON"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"L.E.D.\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "LIGHTNING EUROBEAT"
+		},
+		"id": 2101,
+		"searchTerms": [],
+		"title": "PLASMA SOUL NIGHT feat. Nana Takahashi / 709sec."
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"dj Hellix\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "IRREGULAR OMNIBUS HARDCORE"
+		},
+		"id": 2102,
+		"searchTerms": [],
+		"title": "ALTERNATOR"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"HuΣeR × Yvya\" feat.紫村 花澄",
+		"data": {
+			"displayVersion": "29",
+			"genre": "EMOTIONAL J-POP"
+		},
+		"id": 2103,
+		"searchTerms": [],
+		"title": "ANEMONE"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"D.J.Amuro\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "BLACK OUT"
+		},
+		"id": 2104,
+		"searchTerms": [],
+		"title": "Binary Black Hole"
+	},
+	{
+		"altTitles": [],
+		"artist": "Absolute The 4th",
+		"data": {
+			"displayVersion": "29",
+			"genre": "BIG ANTHEM"
+		},
+		"id": 2105,
+		"searchTerms": [],
+		"title": "Divine Heaven"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Sota F.\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "FUTURE POP"
+		},
+		"id": 2106,
+		"searchTerms": [],
+		"title": "AMICABLE"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"L.E.D.-G\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "EUPHORIC HARDSTYLE"
+		},
+		"id": 2107,
+		"searchTerms": [],
+		"title": "SPARK IN THE NIGHT"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Virkato Wakhmaninov\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "THRENODY"
+		},
+		"id": 2108,
+		"searchTerms": [],
+		"title": "ピアノ独奏無言歌 \"灰燼\""
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"SYUNN\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "FUTURE BASS"
+		},
+		"id": 2109,
+		"searchTerms": [],
+		"title": "Pout"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"劇団レコード\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "ADVENTURE TRIP"
+		},
+		"id": 2110,
+		"searchTerms": [],
+		"title": "Legendary Treasures"
+	},
+	{
+		"altTitles": [],
+		"artist": "kors k",
+		"data": {
+			"displayVersion": "29",
+			"genre": "CHANNEL K"
+		},
+		"id": 2111,
+		"searchTerms": [],
+		"title": "kors k's How to make OTOGE CORE"
+	},
+	{
+		"altTitles": [],
+		"artist": "kors k vs Yooh",
+		"data": {
+			"displayVersion": "29",
+			"genre": "HARDCORE"
+		},
+		"id": 2112,
+		"searchTerms": [],
+		"title": "2 Beasts Unchained"
+	},
+	{
+		"altTitles": [],
+		"artist": "Ujico*",
+		"data": {
+			"displayVersion": "29",
+			"genre": "AQUARIUM QUARTERSTEP"
+		},
+		"id": 2113,
+		"searchTerms": [],
+		"title": "青の洞窟"
+	},
+	{
+		"altTitles": [],
+		"artist": "nora2r",
+		"data": {
+			"displayVersion": "29",
+			"genre": "EARLY RAVE"
+		},
+		"id": 2114,
+		"searchTerms": [],
+		"title": "Banger Banger Banger Banger"
+	},
+	{
+		"altTitles": [],
+		"artist": "MK",
+		"data": {
+			"displayVersion": "29",
+			"genre": "FUTURE BOUNCE"
+		},
+		"id": 2115,
+		"searchTerms": [],
+		"title": "Get set, Go! feat.Kanae Asaba"
+	},
+	{
+		"altTitles": [],
+		"artist": "Qlarabelle",
+		"data": {
+			"displayVersion": "29",
+			"genre": "HARD DANCE"
+		},
+		"id": 2116,
+		"searchTerms": [],
+		"title": "天邪鬼"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ Mass MAD Izm*",
+		"data": {
+			"displayVersion": "29",
+			"genre": "MIXTURE"
+		},
+		"id": 2117,
+		"searchTerms": [],
+		"title": "RAGE feat.H14 of LEONAIR"
+	},
+	{
+		"altTitles": [],
+		"artist": "Nhato",
+		"data": {
+			"displayVersion": "29",
+			"genre": "HARD PSY TRANCE"
+		},
+		"id": 2118,
+		"searchTerms": [],
+		"title": "禊"
+	},
+	{
+		"altTitles": [],
+		"artist": "Dirty Androids",
+		"data": {
+			"displayVersion": "29",
+			"genre": "DARKSYNTH"
+		},
+		"id": 2119,
+		"searchTerms": [],
+		"title": "Nocturnal 2097"
+	},
+	{
+		"altTitles": [],
+		"artist": "lapix",
+		"data": {
+			"displayVersion": "29",
+			"genre": "COLOUR CORE"
+		},
+		"id": 2120,
+		"searchTerms": [],
+		"title": "Flying Castle"
+	},
+	{
+		"altTitles": [],
+		"artist": "かめりあ involving ななひら",
+		"data": {
+			"displayVersion": "29",
+			"genre": "CROSSO-WHA-R"
+		},
+		"id": 2121,
+		"searchTerms": [],
+		"title": "WHA"
+	},
+	{
+		"altTitles": [],
+		"artist": "OSTER project",
+		"data": {
+			"displayVersion": "29",
+			"genre": "CYBER TAIGA"
+		},
+		"id": 2122,
+		"searchTerms": [],
+		"title": "烽火連天の刃"
+	},
+	{
+		"altTitles": [],
+		"artist": "REMO-CON",
+		"data": {
+			"displayVersion": "29",
+			"genre": "TECH DANCE"
+		},
+		"id": 2123,
+		"searchTerms": [],
+		"title": "Smalt #28598F"
+	},
+	{
+		"altTitles": [],
+		"artist": "TOMOSUKE",
+		"data": {
+			"displayVersion": "29",
+			"genre": "亜空間ジャズ"
+		},
+		"id": 2124,
+		"searchTerms": [],
+		"title": "Ergosphere"
+	},
+	{
+		"altTitles": [],
+		"artist": "sky_delta",
+		"data": {
+			"displayVersion": "29",
+			"genre": "ELECTRIC POP"
+		},
+		"id": 2125,
+		"searchTerms": [],
+		"title": "EMOTiON TRiPPER"
+	},
+	{
+		"altTitles": [],
+		"artist": "AJURIKA",
+		"data": {
+			"displayVersion": "29",
+			"genre": "DRUMSTEP"
+		},
+		"id": 2126,
+		"searchTerms": [],
+		"title": "10000 MILES AWAY"
+	},
+	{
+		"altTitles": [],
+		"artist": "Blacklolita",
+		"data": {
+			"displayVersion": "29",
+			"genre": "SYMPHONIC DUBSTEP"
+		},
+		"id": 2127,
+		"searchTerms": [],
+		"title": "n/a"
+	},
+	{
+		"altTitles": [],
+		"artist": "中山真斗 feat. CHAN",
+		"data": {
+			"displayVersion": "29",
+			"genre": "ALTERNATIVE"
+		},
+		"id": 2128,
+		"searchTerms": [],
+		"title": "ナイトフィクション"
+	},
+	{
+		"altTitles": [],
+		"artist": "Yuta Imai ≡ Blacklolita",
+		"data": {
+			"displayVersion": "29",
+			"genre": "HIDEOUT"
+		},
+		"id": 2129,
+		"searchTerms": [],
+		"title": "hard-wired"
+	},
+	{
+		"altTitles": [],
+		"artist": "Des-ROW・組",
+		"data": {
+			"displayVersion": "29",
+			"genre": "HIP ROCK3"
+		},
+		"id": 2130,
+		"searchTerms": [],
+		"title": "雪上断火"
+	},
+	{
+		"altTitles": [],
+		"artist": "Hommarju ft. Mayumi Morinaga",
+		"data": {
+			"displayVersion": "29",
+			"genre": "FREEFORM HARDCORE"
+		},
+		"id": 2131,
+		"searchTerms": [],
+		"title": "Arkadia"
+	},
+	{
+		"altTitles": [],
+		"artist": "Pizuya's Cell",
+		"data": {
+			"displayVersion": "29",
+			"genre": "ROCK"
+		},
+		"id": 2132,
+		"searchTerms": [],
+		"title": "アクマフカ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Yuta Imai",
+		"data": {
+			"displayVersion": "29",
+			"genre": "EUPHORIC FRENCHCORE"
+		},
+		"id": 2133,
+		"searchTerms": [],
+		"title": "ABSOLUTE EVIL"
+	},
+	{
+		"altTitles": [],
+		"artist": "TORIENA",
+		"data": {
+			"displayVersion": "29",
+			"genre": "ハッピースピードコア"
+		},
+		"id": 2134,
+		"searchTerms": [],
+		"title": "めでてえ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by Nhato feat. ricono",
+		"data": {
+			"displayVersion": "29",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2135,
+		"searchTerms": [],
+		"title": "怪物"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by BEMANI Sound Team \"PON\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2136,
+		"searchTerms": [],
+		"title": "ミュージック・アワー"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by Xceon feat. Marcia(幽閉サテライト)",
+		"data": {
+			"displayVersion": "29",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2137,
+		"searchTerms": [],
+		"title": "ぐだふわエブリデー"
+	},
+	{
+		"altTitles": [],
+		"artist": "xi",
+		"data": {
+			"displayVersion": "29",
+			"genre": "PIANO CONCERTINO + JAZZ FUSION"
+		},
+		"id": 2138,
+		"searchTerms": [],
+		"title": "Silver Bullet"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"猫叉Master & あさき & Yvya\"",
+		"data": {
+			"displayVersion": "29",
+			"genre": "ROCK"
+		},
+		"id": 2139,
+		"searchTerms": [],
+		"title": "Aftermath"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"HuΣeR\" feat.Fernweh",
+		"data": {
+			"displayVersion": "29",
+			"genre": "JAPANESQUE"
+		},
+		"id": 2140,
+		"searchTerms": [],
+		"title": "逆月"
+	},
+	{
+		"altTitles": [],
+		"artist": "しーけー",
+		"data": {
+			"displayVersion": "29",
+			"genre": "ALCHEMY POP"
+		},
+		"id": 2141,
+		"searchTerms": [],
+		"title": "Souhait bleu"
+	},
+	{
+		"altTitles": [],
+		"artist": "ATSUMI UEDA",
+		"data": {
+			"displayVersion": "29",
+			"genre": "NU PRELUDE"
+		},
+		"id": 2142,
+		"searchTerms": [],
+		"title": "Harmonia"
+	},
+	{
+		"altTitles": [],
+		"artist": "PSYQUI",
+		"data": {
+			"displayVersion": "29",
+			"genre": "DANCE MUSIC"
+		},
+		"id": 2143,
+		"searchTerms": [],
+		"title": "Stepper"
+	},
+	{
+		"altTitles": [],
+		"artist": "MOSAIC.WAV",
+		"data": {
+			"displayVersion": "29",
+			"genre": "AKIBA-POP"
+		},
+		"id": 2144,
+		"searchTerms": [],
+		"title": "Push on Beats!～音ゲの国のeX-ストリーマー～"
+	},
+	{
+		"altTitles": [],
+		"artist": "猫叉Master feat.霜月はるか",
+		"data": {
+			"displayVersion": "29",
+			"genre": "SHOWA RETRO"
+		},
+		"id": 2145,
+		"searchTerms": [],
+		"title": "黒紅掬い"
+	},
+	{
+		"altTitles": [],
+		"artist": "PON",
+		"data": {
+			"displayVersion": "29",
+			"genre": "EDM STYLE"
+		},
+		"id": 2146,
+		"searchTerms": [],
+		"title": "Emera"
+	},
+	{
+		"altTitles": [],
+		"artist": "KMNZ",
+		"data": {
+			"displayVersion": "29",
+			"genre": "DANCE MUSIC"
+		},
+		"id": 2147,
+		"searchTerms": [],
+		"title": "VR - Virtual Reality (prod.by Snail's House)"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by uno(IOSYS) & Liqo feat. Chiyoko",
+		"data": {
+			"displayVersion": "29",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2148,
+		"searchTerms": [],
+		"title": "グッバイ宣言"
+	},
+	{
+		"altTitles": [],
+		"artist": "ずっと真夜中でいいのに。",
+		"data": {
+			"displayVersion": "29",
+			"genre": "J-POP"
+		},
+		"id": 2149,
+		"searchTerms": [],
+		"title": "あいつら全員同窓会"
 	}
 ]

--- a/database-seeds/scripts/rerunners/add-new-primary-iidx-charts.js
+++ b/database-seeds/scripts/rerunners/add-new-primary-iidx-charts.js
@@ -1,0 +1,48 @@
+const { MutateCollection, CreateChartID } = require("../util");
+
+const inGameID = 19017;
+const tachiSongID = 1014;
+
+const newCharts = [
+	["SP", "NORMAL", 297, 3],
+	["DP", "NORMAL", 316, 3],
+	["DP", "ANOTHER", 1068, 10],
+];
+
+const shouldBeDeprimaried = (c) =>
+	newCharts.map((e) => `${e[0]}-${e[1]}`).includes(`${c.playtype}-${c.difficulty}`);
+
+MutateCollection("charts-iidx.json", (charts) => {
+	for (const chart of charts) {
+		if (chart.data.inGameID === inGameID && shouldBeDeprimaried(chart)) {
+			chart.isPrimary = false;
+		}
+	}
+
+	for (const [playtype, difficulty, notecount, level] of newCharts) {
+		charts.push({
+			chartID: CreateChartID(),
+			data: {
+				"2dxtraSet": null,
+				arcChartID: null,
+				hashSHA256: null,
+				inGameID,
+				bpiCoefficient: null,
+				kaidenAverage: null,
+				worldRecord: null,
+				notecount,
+			},
+			difficulty,
+			playtype,
+			isPrimary: true,
+			level: level.toString(),
+			levelNum: level,
+			rgcID: null,
+			songID: tachiSongID,
+			tierlistInfo: {},
+			versions: ["29"],
+		});
+	}
+
+	return charts;
+});


### PR DESCRIPTION
This updates seed data for iidx 29 vanilla.

Revivals with modified charts still need to be dealt with, listed below.  I assume new charts need to be added for these?  Additionally the ascii titles should probably be added to `searchTerms` for songs with Japanese titles.

New charts:

7031 Somebody Like You
SP-NORMAL  OLD: 453 -> NEW: 376.
SP-HYPER  OLD: 678 -> NEW: 606.
SP-ANOTHER  OLD: 761 -> NEW: 933.
DP-NORMAL  OLD: 560 -> NEW: 375.
DP-HYPER  OLD: 609 -> NEW: 603.
DP-ANOTHER  OLD: 741 -> NEW: 937.

10031 SCORE
SP-NORMAL  OLD: 601 -> NEW: 595.
SP-HYPER  OLD: 829 -> NEW: 812.
DP-NORMAL  OLD: 597 -> NEW: 591.
DP-HYPER  OLD: 828 -> NEW: 806.
DP-ANOTHER  OLD: 1100 -> NEW: 1105.

12046 mind the gap
DP-NORMAL  OLD: 380 -> NEW: 378.
DP-HYPER  OLD: 550 -> NEW: 564.

17042 Do Back Burn
SP-NORMAL  OLD: 342 -> NEW: 364.
SP-HYPER  OLD: 711 -> NEW: 728.
SP-ANOTHER  OLD: 1000 -> NEW: 1078.
DP-NORMAL  OLD: 417 -> NEW: 456.
DP-HYPER  OLD: 807 -> NEW: 788.
DP-ANOTHER  OLD: 1085 -> NEW: 1096.

19017 GIGANT
SP-NORMAL  OLD: 295 -> NEW: 297.
DP-NORMAL  OLD: 315 -> NEW: 316.
DP-ANOTHER  OLD: 1067 -> NEW: 1068.
