### PR TITLE
update sdvx konaste

### DIFF
--- a/database-seeds/collections/charts-sdvx.json
+++ b/database-seeds/collections/charts-sdvx.json
@@ -739,7 +739,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -762,7 +763,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -785,7 +787,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -15966,7 +15969,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -15988,7 +15992,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -16010,7 +16015,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -30645,7 +30651,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -30673,7 +30680,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -30695,7 +30703,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -38850,7 +38859,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -38871,7 +38881,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -38892,7 +38903,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -135009,7 +135021,8 @@
 		"songID": 1711,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -135027,7 +135040,8 @@
 		"songID": 1711,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -135051,7 +135065,8 @@
 			}
 		},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -135069,7 +135084,8 @@
 		"songID": 1711,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -143248,6 +143264,798 @@
 		]
 	},
 	{
+		"chartID": "a16d5bf23df82d0c870ab853cc8a9beb273a1565",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1856
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1856,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "960243c25f19db4f3b8a35e62d3df312c70f0582",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1856
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1856,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "bfa4f5189c4bec7804dc541e30b78f9b5bfebd68",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1856
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1856,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "97d3d381bd99ea663a42093bf9f825916f11e307",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1856
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1856,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "f5b16d6851b91e7c140f3ffcbfd64565593cb8f2",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1857
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1857,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "76c7e382679a0b4b60216647149aa48c55f8aa55",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1857
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1857,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "3364c22b0a80d57ee90056988957b9ae1a1d94e9",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1857
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1857,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "b61c08e76dc8854f4474de355e54427a4ac55ef6",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1857
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1857,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "da9210627f6690d05ee627b5888211f3c9d98a45",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1858
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "11",
+		"levelNum": 11,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1858,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "9949fff91db422b24cbc3e02d96e15176d8e1635",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1858
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1858,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "57fc0f109c8a66407cb1f557d4daa8b4ce0b52bf",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1858
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1858,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "79248171a37d796c91aa5b649fcf7a280f91d0e5",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1858
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1858,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "509c03805529c0bd44b121ffd33aeac63824078d",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1859
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "11",
+		"levelNum": 11,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1859,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "aef74948738e4981e5fcf118777dd4fa45008b1f",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1859
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1859,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "3b8788c5d5d4f081112ddded6f8ec6d43449b150",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1859
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1859,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "b0c9f4968d812a2477a9bdacbae932eec05c66a6",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1859
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1859,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "c237a95d780e6f186ccc91ab34cb51e931dd8026",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1860
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1860,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "44b4531c9c7f2d6b8494222a457b509a3a038db8",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1860
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1860,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "f5570a74b915932641393a2d675edd7118a84b4e",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1860
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1860,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "579bcf85f509bfd0f69da7da0cd47a027b54ccbf",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1860
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1860,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "08be1df0cf34d4b7f764bf2a421b5639190e7436",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1861
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1861,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "5eee8a1c2152bd3653115fdbd673f7e99be2e47f",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1861
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1861,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "fafeac43769665956dd1256a29fa19723a39d29a",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1861
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1861,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "af41aa94c83500c461c1d1cf8e81f1a1bf243bb1",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1861
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1861,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "4a5b0fd67c345807d3d61db8ed4059eb0431db06",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1862
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1862,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "46a7808497c59dc5c892aa85f38924c4fa54fd34",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1862
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1862,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "6453ee7edf31b2b5fdb5a93736295370120790b0",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1862
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1862,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "0fe8b90d034a73ad8cad1de991142075095c54ca",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1862
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1862,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "3dc17e082db3200e613a879f5beb0f9bd696a55a",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1863
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1863,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "84cb35998a0c76d51d5215c59c03e3545599b920",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1863
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1863,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "0767f8dcf7f64091729a567bcd9635cd87c41604",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1863
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1863,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "767ff8a2ccc3956d438987fc22d91e3037c10d7a",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1863
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1863,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "e004862e804cf0185cbabc4f7b7db4506c0908af",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1864
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1864,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "8be61233d5cd5a5216d55cc3ebf1dec8539cf221",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1864
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1864,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "7fa6c44b27f7a3c7d0775e6fb27b69a89db88d46",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1864
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1864,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "f72d9ff319e9a7402b6970abb2de44c968d68f35",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1864
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1864,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "e01a06c89194fc385e0f1b6236297757ff63d782",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1865
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1865,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "86ee3f8ee4565f773ade02d3bad40d4bd829586e",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1865
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1865,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "e069639a1107282d3752ebcb2b05f02764672ce8",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1865
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1865,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "998e121d9ecfba385bb998b89085df5f6f5bc32e",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1865
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1865,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "46e7e386052ceb86138497aa31959dc7efc67bd3",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1866
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1866,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "ff1c9022223ef5a03a8a678a0ec9ab7a863e0566",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1866
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1866,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "da0028af98f836ca49c7be216c0f380178a033c8",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1866
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1866,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "07562f5cea1ed3d667c9ad83c6ff2d8df93056d7",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1866
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1866,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
 		"chartID": "432a40dd834f35481c0875a136657eb4d082aab8",
 		"data": {
 			"arcChartID": null,
@@ -143530,6 +144338,150 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1886,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "5103a036ae6dd8ef47f4629a34143221c1c112f3",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1903
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1903,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "08c4ee0093080c140cf92e975843ced05e70f51a",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1903
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1903,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "9a131e4fa138b8cb9570c7ca3a7aaba6b241fcd6",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1903
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1903,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "a3ba5454c9237d0dbaa7aec4fd18fe259468a6ee",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1903
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1903,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "4d9cb3c575aea6a108f7ec801c76c9c9babf4cce",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1904
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1904,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "14fb10c7c96c9f92e60fd837ddff052a955c9493",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1904
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1904,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "5209574ad826b32f1b449ef7e649266b8cb018dd",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1904
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1904,
+		"tierlistInfo": {},
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "070d4c58d046aee0a8d7746b0291acff26541799",
+		"data": {
+			"arcChartID": null,
+			"inGameID": 1904
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1904,
 		"tierlistInfo": {},
 		"versions": [
 			"konaste"

--- a/database-seeds/collections/charts-sdvx.json
+++ b/database-seeds/collections/charts-sdvx.json
@@ -2877,8 +2877,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "18C",
-				"value": 18.5
+				"text": "18D",
+				"value": 18.3
 			}
 		},
 		"versions": [
@@ -17628,8 +17628,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "19A",
-				"value": 19.7
+				"text": "19B",
+				"value": 19.5
 			}
 		},
 		"versions": [
@@ -19661,8 +19661,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "19A+",
-				"value": 19.9
+				"text": "19A",
+				"value": 19.7
 			}
 		},
 		"versions": [
@@ -20622,8 +20622,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "16A/B",
-				"value": 16.5
+				"text": "16A+",
+				"value": 16.7
 			}
 		},
 		"versions": [
@@ -22507,8 +22507,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": true,
-				"text": "18A",
-				"value": 18.7
+				"text": "18A+",
+				"value": 18.8
 			}
 		},
 		"versions": [
@@ -27300,8 +27300,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": true,
-				"text": "17B+",
-				"value": 17.6
+				"text": "17A",
+				"value": 17.7
 			}
 		},
 		"versions": [
@@ -37737,8 +37737,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17B+",
-				"value": 17.6
+				"text": "17A",
+				"value": 17.7
 			}
 		},
 		"versions": [
@@ -41000,8 +41000,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": true,
-				"text": "19B - 17C",
-				"value": 18
+				"text": "18E",
+				"value": 18.1
 			}
 		},
 		"versions": [
@@ -43796,8 +43796,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "18D",
-				"value": 18.3
+				"text": "18C",
+				"value": 18.5
 			}
 		},
 		"versions": [
@@ -44765,8 +44765,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "16A+",
-				"value": 16.7
+				"text": "16S",
+				"value": 16.9
 			}
 		},
 		"versions": [
@@ -45401,8 +45401,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17A",
-				"value": 17.7
+				"text": "17A+",
+				"value": 17.8
 			}
 		},
 		"versions": [
@@ -46692,8 +46692,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": true,
-				"text": "18B",
-				"value": 18.6
+				"text": "18A",
+				"value": 18.7
 			}
 		},
 		"versions": [
@@ -48370,8 +48370,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17A",
-				"value": 17.7
+				"text": "17A+",
+				"value": 17.8
 			}
 		},
 		"versions": [
@@ -49230,7 +49230,7 @@
 		"songID": 670,
 		"tierlistInfo": {
 			"clear": {
-				"individualDifference": true,
+				"individualDifference": false,
 				"text": "17A+",
 				"value": 17.8
 			}
@@ -57286,8 +57286,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17E",
-				"value": 17.2
+				"text": "17D",
+				"value": 17.3
 			}
 		},
 		"versions": [
@@ -57632,8 +57632,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17A",
-				"value": 17.7
+				"text": "17A+",
+				"value": 17.8
 			}
 		},
 		"versions": [
@@ -61449,8 +61449,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17B",
-				"value": 17.5
+				"text": "17B+",
+				"value": 17.6
 			}
 		},
 		"versions": [
@@ -78176,8 +78176,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17B+",
-				"value": 17.6
+				"text": "17A",
+				"value": 17.7
 			}
 		},
 		"versions": [
@@ -78664,9 +78664,9 @@
 		"songID": 1041,
 		"tierlistInfo": {
 			"clear": {
-				"individualDifference": true,
-				"text": "17B",
-				"value": 17.5
+				"individualDifference": false,
+				"text": "17B+",
+				"value": 17.6
 			}
 		},
 		"versions": [
@@ -81449,7 +81449,7 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": true,
-				"text": "18A - 18E",
+				"text": "18A - 18D",
 				"value": 18
 			}
 		},
@@ -83219,8 +83219,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "16A+",
-				"value": 16.7
+				"text": "16A/B",
+				"value": 16.5
 			}
 		},
 		"versions": [
@@ -89536,7 +89536,7 @@
 		"songID": 1162,
 		"tierlistInfo": {
 			"clear": {
-				"individualDifference": true,
+				"individualDifference": false,
 				"text": "17A",
 				"value": 17.7
 			}
@@ -92014,9 +92014,9 @@
 		"songID": 1190,
 		"tierlistInfo": {
 			"clear": {
-				"individualDifference": true,
-				"text": "18A+ - 18D",
-				"value": 18
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.7
 			}
 		},
 		"versions": [
@@ -98262,8 +98262,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "18C",
-				"value": 18.5
+				"text": "18D",
+				"value": 18.3
 			}
 		},
 		"versions": [
@@ -105740,8 +105740,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "18F",
-				"value": 18
+				"text": "18E",
+				"value": 18.1
 			}
 		},
 		"versions": [
@@ -106092,8 +106092,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": true,
-				"text": "18A+ - 18D",
-				"value": 18
+				"text": "18B",
+				"value": 18.6
 			}
 		},
 		"versions": [
@@ -107854,8 +107854,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "19B",
-				"value": 19.5
+				"text": "19C",
+				"value": 19.4
 			}
 		},
 		"versions": [
@@ -108118,8 +108118,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17A",
-				"value": 17.7
+				"text": "17B+",
+				"value": 17.6
 			}
 		},
 		"versions": [
@@ -110591,9 +110591,9 @@
 		"songID": 1400,
 		"tierlistInfo": {
 			"clear": {
-				"individualDifference": true,
-				"text": "18A - 18E",
-				"value": 18
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.5
 			}
 		},
 		"versions": [
@@ -116207,9 +116207,9 @@
 		"songID": 1466,
 		"tierlistInfo": {
 			"clear": {
-				"individualDifference": true,
-				"text": "18A+ - 18D",
-				"value": 18
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.6
 			}
 		},
 		"versions": [
@@ -118602,8 +118602,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "18A",
-				"value": 18.7
+				"text": "18A+",
+				"value": 18.8
 			}
 		},
 		"versions": [
@@ -120664,8 +120664,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "18E",
-				"value": 18.1
+				"text": "18F",
+				"value": 18
 			}
 		},
 		"versions": [
@@ -123532,8 +123532,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "18D",
-				"value": 18.3
+				"text": "18E",
+				"value": 18.1
 			}
 		},
 		"versions": [
@@ -125051,9 +125051,9 @@
 		"songID": 1580,
 		"tierlistInfo": {
 			"clear": {
-				"individualDifference": true,
-				"text": "18A+ - 18C",
-				"value": 18
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.7
 			}
 		},
 		"versions": [
@@ -126440,8 +126440,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17B",
-				"value": 17.5
+				"text": "17C",
+				"value": 17.4
 			}
 		},
 		"versions": [
@@ -127404,8 +127404,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17B+",
-				"value": 17.6
+				"text": "17B",
+				"value": 17.5
 			}
 		},
 		"versions": [
@@ -131045,7 +131045,7 @@
 		"songID": 1651,
 		"tierlistInfo": {
 			"clear": {
-				"individualDifference": false,
+				"individualDifference": true,
 				"text": "18D",
 				"value": 18.3
 			}
@@ -131674,8 +131674,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "18B",
-				"value": 18.6
+				"text": "18C",
+				"value": 18.5
 			}
 		},
 		"versions": [
@@ -133732,8 +133732,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "17B+",
-				"value": 17.6
+				"text": "17A",
+				"value": 17.7
 			}
 		},
 		"versions": [
@@ -136978,8 +136978,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "18B",
-				"value": 18.6
+				"text": "18C",
+				"value": 18.5
 			}
 		},
 		"versions": [
@@ -142425,8 +142425,8 @@
 		"tierlistInfo": {
 			"clear": {
 				"individualDifference": false,
-				"text": "18B",
-				"value": 18.6
+				"text": "18A",
+				"value": 18.7
 			}
 		},
 		"versions": [
@@ -143384,7 +143384,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1857,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -143456,7 +143462,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1858,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -143600,7 +143612,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1860,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -143672,7 +143690,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1861,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -143726,7 +143750,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1862,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -143744,7 +143774,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1862,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -144014,7 +144050,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1866,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -144032,7 +144074,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1866,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -144374,7 +144422,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1903,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -144464,7 +144518,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1904,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]

--- a/database-seeds/collections/charts-sdvx.json
+++ b/database-seeds/collections/charts-sdvx.json
@@ -6253,7 +6253,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -6276,7 +6277,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -6299,7 +6301,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -6322,7 +6325,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -6345,7 +6349,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -6374,7 +6379,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -6397,7 +6403,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -8647,7 +8654,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -8670,7 +8678,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -8693,7 +8702,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -9158,7 +9168,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -9181,7 +9192,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -9204,7 +9216,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -23735,7 +23748,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -23757,7 +23771,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -23779,7 +23794,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -24005,7 +24021,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -24033,7 +24050,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -24061,7 +24079,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -24083,7 +24102,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -32075,7 +32095,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -32103,7 +32124,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -32125,7 +32147,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -34656,7 +34679,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -34683,7 +34707,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -34704,7 +34729,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -34726,7 +34752,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -34754,7 +34781,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -34776,7 +34804,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -51682,7 +51711,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -51709,7 +51739,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -51730,7 +51761,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137267,7 +137299,8 @@
 		"songID": 1739,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137285,7 +137318,8 @@
 		"songID": 1739,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137309,7 +137343,8 @@
 			}
 		},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137327,7 +137362,8 @@
 		"songID": 1739,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137345,7 +137381,8 @@
 		"songID": 1740,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137363,7 +137400,8 @@
 		"songID": 1740,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137387,7 +137425,8 @@
 			}
 		},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137405,7 +137444,8 @@
 		"songID": 1740,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137423,7 +137463,8 @@
 		"songID": 1741,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137441,7 +137482,8 @@
 		"songID": 1741,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137465,7 +137507,8 @@
 			}
 		},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -137483,7 +137526,8 @@
 		"songID": 1741,
 		"tierlistInfo": {},
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{

--- a/database-seeds/collections/songs-sdvx.json
+++ b/database-seeds/collections/songs-sdvx.json
@@ -22805,6 +22805,149 @@
 	},
 	{
 		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1856,
+		"searchTerms": [
+			"heartache tobyfox",
+			"ﾊｰﾄｴｲｸｺｺﾛﾉｲﾀﾐ"
+		],
+		"title": "Heartache / 心の痛み"
+	},
+	{
+		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1857,
+		"searchTerms": [
+			"bonetrousle tobyfox",
+			"ﾎﾞｰﾝﾄﾗｳｽﾙ"
+		],
+		"title": "Bonetrousle"
+	},
+	{
+		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1858,
+		"searchTerms": [
+			"spearofjustice tobyfox",
+			"ｽﾋﾟｱｵﾌﾞｼﾞｬｽﾃｨｽｾｲｷﾞﾉﾔﾘ"
+		],
+		"title": "Spear of Justice / 正義の槍"
+	},
+	{
+		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1859,
+		"searchTerms": [
+			"spiderdance tobyfox",
+			"ｽﾊﾟｲﾀﾞｰﾀﾞﾝｽ"
+		],
+		"title": "Spider Dance / スパイダーダンス"
+	},
+	{
+		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1860,
+		"searchTerms": [
+			"deathby tobyfox",
+			"ﾃﾞｽﾊﾞｲｸﾞﾗﾏｰｶﾚｲﾅﾙｼﾄｳ"
+		],
+		"title": "Death by Glamour / 華麗なる死闘"
+	},
+	{
+		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1861,
+		"searchTerms": [
+			"asgore tobyfox",
+			"ｱｽﾞｺﾞｱ"
+		],
+		"title": "ASGORE / アズゴア"
+	},
+	{
+		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1862,
+		"searchTerms": [
+			"finale tobyfox",
+			"ﾌｨﾅｰﾚ"
+		],
+		"title": "Finale / フィナーレ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1863,
+		"searchTerms": [
+			"savetheworld tobyfox",
+			"ｾｲﾌﾞｻﾞﾜｰﾙﾄﾞ"
+		],
+		"title": "SAVE the World"
+	},
+	{
+		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1864,
+		"searchTerms": [
+			"truehero tobyfox",
+			"ﾊﾞﾄﾙｱｹﾞﾝｽﾄｱﾄｩﾙｰﾋｰﾛｰﾎﾝﾓﾉﾉﾋｰﾛｰﾄﾉﾀﾀｶｲ"
+		],
+		"title": "Battle Against a True Hero / 本物のヒーローとの戦い"
+	},
+	{
+		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1865,
+		"searchTerms": [
+			"megalovania tobyfox",
+			"ﾒｶﾞﾛﾊﾞﾆｱ"
+		],
+		"title": "MEGALOVANIA"
+	},
+	{
+		"altTitles": [],
+		"artist": "Toby Fox",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1866,
+		"searchTerms": [
+			"worldrevolving tobyfox",
+			"ｻﾞﾜｰﾙﾄﾞﾘﾎﾞﾙﾋﾞﾝｸﾞ"
+		],
+		"title": "THE WORLD REVOLVING"
+	},
+	{
+		"altTitles": [],
 		"artist": "常盤ゆう",
 		"data": {
 			"displayVersion": "exceed"
@@ -22854,5 +22997,31 @@
 			"ｳｪﾙｶﾑﾄｩｻﾞﾓｯｼｭﾋﾟｯﾄ"
 		],
 		"title": "Welcome to the Mosh Pit"
+	},
+	{
+		"altTitles": [],
+		"artist": "周防パトラ",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1903,
+		"searchTerms": [
+			"iamnumberone suoupatra",
+			"ｱｲｱﾑﾅﾝﾊﾞｰﾜﾝﾊﾟﾄﾗﾁｬﾝｻﾏ"
+		],
+		"title": "あいあむなんばーわんパトラちゃん様"
+	},
+	{
+		"altTitles": [],
+		"artist": "周防パトラ",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 1904,
+		"searchTerms": [
+			"vtubbanouta suoupatra",
+			"ﾌﾞｲﾁｭｯﾊﾞﾉｳﾀ"
+		],
+		"title": "ぶいちゅっばの歌"
 	}
 ]

--- a/database-seeds/scripts/rerunners/sdvx/add-sdvx-clear-tierlist.js
+++ b/database-seeds/scripts/rerunners/sdvx/add-sdvx-clear-tierlist.js
@@ -17,18 +17,38 @@ const TIERS = {
 			text: "16F",
 			value: 16.0,
 		},
-		"16弱(16EとF)": {
-			text: "16E",
-			value: 16.1,
-		},
-		"16中(16CとD)": {
-			text: "16C/D",
-			value: 16.3,
-		},
-		"16強(16AとB)": {
-			text: "16A/B",
-			value: 16.5,
-		},
+		...(Object.fromEntries(
+			[
+				"16弱(16EとF) 地力　記号・A〜Z",
+				"16弱(16EとF) 地力　あ〜わ",
+				"16弱(16EとF)鍵盤・つまみ",
+			].map(key => [
+				key, {
+					text: "16E",
+					value: 16.1,
+				},
+			])
+		)),
+		...(Object.fromEntries(
+			[
+				"16中(16CとD)地力　記号・A〜Z",
+				"16中(16CとD)地力　あ〜わ",
+				"16中(16CとD)鍵盤・つまみ",
+			].map(key => [
+				key, {
+					text: "16C/D",
+					value: 16.3,
+				},
+			])
+		)),
+		...(Object.fromEntries(
+			["16強(16AとB) 地力", "16強(16AとB) 鍵盤・つまみ"].map(key => [
+				key, {
+					text: "16A/B",
+					value: 16.5,
+				},
+			])
+		)),
 		"16強+(16A以上S未満)": {
 			text: "16A+",
 			value: 16.7,
@@ -218,6 +238,7 @@ const MANUAL_TITLE_MAP = {
 	"VALKYRIE ASAULT": "VALKYRIE ASSAULT",
 	SuperMiracleEmsemble: "SuperMiracleEnsemble",
 	"仔羊のナヴァラン・クリシェを添えて": "～仔羊のナヴァラン・クリシェを添えて～",
+	"あいあむなんばーわんぱとらちゃん様": "あいあむなんばーわんパトラちゃん様", // hirigana/katakana
 
 	// 17s
 	"Emperors divide": "Emperor's Divide",
@@ -419,7 +440,7 @@ function addTiers(levelNum, csvData, headerRow, leftOffset, simple) {
 				const [_, title, difficulty] = chartString.match(/^(.*?)(?:\[([A-Z]{3})\])?$/);
 				if (
 					difficulty &&
-					!["NOV", "ADV", "EXH", "MXM", "INF", "GRV", "HVN", "VVD"].includes(difficulty)
+					!["NOV", "ADV", "EXH", "MXM", "INF", "GRV", "HVN", "VVD", "XCD"].includes(difficulty)
 				) {
 					console.log(`Unknown difficulty ${difficulty} for ${title}.`);
 				}


### PR DESCRIPTION
sorry this is hella old by this point

some songs seem like they're still missing from the tierlist spreadsheet, either still being voted on or idk. these songs are konaste only, so they won't be there:
* `少年リップルズ`
* `アガット`
* `[E]`
* `Welcome to the Mosh Pit`

I don't know why the other charts are missing:
```
The following lv16 charts are still missing a tier:
1856: Heartache / 心の痛み [MXM] (displayVersion: exceed)
1865: MEGALOVANIA [EXH] (displayVersion: exceed)
1883: 少年リップルズ [EXH] (displayVersion: exceed)
1885: アガット [EXH] (displayVersion: exceed)
The following lv17 charts are still missing a tier:
1859: Spider Dance / スパイダーダンス [MXM] (displayVersion: exceed)
1884: [E] [MXM] (displayVersion: exceed)
The following lv18 charts are still missing a tier:
1863: SAVE the World [MXM] (displayVersion: exceed)
1864: Battle Against a True Hero / 本物のヒーローとの戦い [MXM] (displayVersion: exceed)
1865: MEGALOVANIA [MXM] (displayVersion: exceed)
1883: 少年リップルズ [MXM] (displayVersion: exceed)
1885: アガット [MXM] (displayVersion: exceed)
1886: Welcome to the Mosh Pit [MXM] (displayVersion: exceed)
1903: あいあむなんばーわんパトラちゃん様 [MXM] (displayVersion: exceed)
```