### PR TITLE
fix: make kai-type-apis not spontaneously fail to sync classes

### DIFF
--- a/server/src/lib/score-import/import-types/common/api-kai/iidx/class-handler.test.ts
+++ b/server/src/lib/score-import/import-types/common/api-kai/iidx/class-handler.test.ts
@@ -14,6 +14,10 @@ t.test("#CreateKaiIIDXClassHandler", async (t) => {
 	const fn = await CreateKaiIIDXClassHandler(
 		"FLO",
 		"token",
+		// eslint-disable-next-line @typescript-eslint/require-await
+		async () => {
+			throw new Error(`Unexpectedly called reauthFn?`);
+		},
 		MockJSONFetch({
 			[`${KaiTypeToBaseURL("FLO")}/api/iidx/v2/player_profile`]: {
 				_links: {},
@@ -45,6 +49,10 @@ t.test("#CreateKaiIIDXClassHandler", async (t) => {
 		const fn = await CreateKaiIIDXClassHandler(
 			"FLO",
 			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
 			MockJSONFetch({
 				[`${KaiTypeToBaseURL("FLO")}/api/iidx/v2/player_profile`]: {
 					_links: {},
@@ -69,6 +77,10 @@ t.test("#CreateKaiIIDXClassHandler", async (t) => {
 		const fn = await CreateKaiIIDXClassHandler(
 			"FLO",
 			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
 			MockJSONFetch({
 				[`${KaiTypeToBaseURL("FLO")}/api/iidx/v2/player_profile`]: {
 					_links: {},
@@ -93,6 +105,10 @@ t.test("#CreateKaiIIDXClassHandler", async (t) => {
 		const fn = await CreateKaiIIDXClassHandler(
 			"FLO",
 			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
 			MockJSONFetch({
 				[`${KaiTypeToBaseURL("FLO")}/api/iidx/v2/player_profile`]: {
 					_links: {},
@@ -114,7 +130,15 @@ t.test("#CreateKaiIIDXClassHandler", async (t) => {
 	});
 
 	t.test("Should gracefully handle negative API responses", async (t) => {
-		const fn = await CreateKaiIIDXClassHandler("FLO", "token", MockBasicFetch({ status: 500 }));
+		const fn = await CreateKaiIIDXClassHandler(
+			"FLO",
+			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
+			MockBasicFetch({ status: 500 })
+		);
 
 		const res = fn("iidx", "SP", 1, {}, logger);
 
@@ -123,10 +147,34 @@ t.test("#CreateKaiIIDXClassHandler", async (t) => {
 		t.end();
 	});
 
+	t.test("Should call reauthFn if statusCode is 401", async (t) => {
+		let pass = false;
+		const fn = await CreateKaiIIDXClassHandler(
+			"FLO",
+			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				pass = true;
+				return "";
+			},
+			MockBasicFetch({ status: 401 })
+		);
+
+		fn("iidx", "SP", 1, {}, logger);
+
+		t.equal(pass, true, "Should've called the reauth fn.");
+
+		t.end();
+	});
+
 	t.test("Should ignore null dans", async (t) => {
 		const fn = await CreateKaiIIDXClassHandler(
 			"FLO",
 			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
 			MockJSONFetch({
 				[`${KaiTypeToBaseURL("FLO")}/api/iidx/v2/player_profile`]: {
 					_links: {},
@@ -151,6 +199,10 @@ t.test("#CreateKaiIIDXClassHandler", async (t) => {
 		const fn = await CreateKaiIIDXClassHandler(
 			"FLO",
 			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
 			MockJSONFetch({
 				[`${KaiTypeToBaseURL("FLO")}/api/iidx/v2/player_profile`]: {
 					_links: {},

--- a/server/src/lib/score-import/import-types/common/api-kai/iidx/class-handler.ts
+++ b/server/src/lib/score-import/import-types/common/api-kai/iidx/class-handler.ts
@@ -2,11 +2,13 @@ import { KaiTypeToBaseURL } from "../utils";
 import { IIDXDans } from "lib/constants/classes";
 import nodeFetch from "utils/fetch";
 import { IsRecord } from "utils/misc";
+import type { KaiAPIReauthFunction } from "../traverse-api";
 import type { ClassHandler } from "lib/score-import/framework/user-game-stats/types";
 
 export async function CreateKaiIIDXClassHandler(
 	kaiType: "EAG" | "FLO",
 	token: string,
+	reauthFn: KaiAPIReauthFunction,
 	fetch = nodeFetch
 ): Promise<ClassHandler> {
 	let json: unknown;
@@ -16,12 +18,30 @@ export async function CreateKaiIIDXClassHandler(
 	// SP and DP dans are located in the same place,
 	// fetch once, then return a function that traverses this data.
 	try {
-		const res = await fetch(`${baseUrl}/api/iidx/v2/player_profile`, {
+		let res = await fetch(`${baseUrl}/api/iidx/v2/player_profile`, {
 			headers: {
 				Authorization: `Bearer ${token}`,
 				"Content-Type": "application/json",
 			},
 		});
+
+		// if we failed auth wise. Try reauthing.
+		if (res.status === 401 || res.status === 403) {
+			const newToken = await reauthFn();
+
+			res = await fetch(`${baseUrl}/api/sdvx/v1/player_profile`, {
+				headers: {
+					Authorization: `Bearer ${newToken}`,
+					"Content-Type": "application/json",
+				},
+			});
+		}
+
+		if (res.status !== 200) {
+			const text = await res.text();
+
+			throw new Error(`Got unexpected status from ${kaiType}: ${res.status}. Body: ${text}`);
+		}
 
 		json = (await res.json()) as unknown;
 	} catch (e: unknown) {

--- a/server/src/lib/score-import/import-types/common/api-kai/iidx/parser.ts
+++ b/server/src/lib/score-import/import-types/common/api-kai/iidx/parser.ts
@@ -16,19 +16,21 @@ export async function ParseKaiIIDX(
 ): Promise<ParserFunctionReturns<unknown, KaiContext>> {
 	const baseUrl = KaiTypeToBaseURL(service);
 
+	const reauthFn = CreateKaiReauthFunction(service, authDoc, logger, fetch);
+
 	return {
 		iterable: TraverseKaiAPI(
 			baseUrl,
 			"/api/iidx/v2/play_history",
 			authDoc.token,
 			logger,
-			CreateKaiReauthFunction(service, authDoc, logger, fetch),
+			reauthFn,
 			fetch
 		),
 		context: {
 			service,
 		},
-		classHandler: await CreateKaiIIDXClassHandler(service, authDoc.token, fetch),
+		classHandler: await CreateKaiIIDXClassHandler(service, authDoc.token, reauthFn, fetch),
 		game: "iidx",
 	};
 }

--- a/server/src/lib/score-import/import-types/common/api-kai/sdvx/class-handler.test.ts
+++ b/server/src/lib/score-import/import-types/common/api-kai/sdvx/class-handler.test.ts
@@ -14,6 +14,10 @@ t.test("#CreateKaiSDVXClassHandler", async (t) => {
 	const fn = await CreateKaiSDVXClassHandler(
 		"FLO",
 		"token",
+		// eslint-disable-next-line @typescript-eslint/require-await
+		async () => {
+			throw new Error(`Unexpectedly called reauthFn?`);
+		},
 		MockJSONFetch({
 			[`${KaiTypeToBaseURL("FLO")}/api/sdvx/v1/player_profile`]: {
 				_links: {},
@@ -44,6 +48,10 @@ t.test("#CreateKaiSDVXClassHandler", async (t) => {
 		const fn = await CreateKaiSDVXClassHandler(
 			"FLO",
 			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
 			MockJSONFetch({
 				[`${KaiTypeToBaseURL("FLO")}/api/sdvx/v1/player_profile`]: {
 					_links: {},
@@ -67,6 +75,10 @@ t.test("#CreateKaiSDVXClassHandler", async (t) => {
 		const fn = await CreateKaiSDVXClassHandler(
 			"FLO",
 			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
 			MockJSONFetch({
 				[`${KaiTypeToBaseURL("FLO")}/api/sdvx/v1/player_profile`]: {
 					_links: {},
@@ -90,6 +102,10 @@ t.test("#CreateKaiSDVXClassHandler", async (t) => {
 		const fn = await CreateKaiSDVXClassHandler(
 			"FLO",
 			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
 			MockJSONFetch({
 				[`${KaiTypeToBaseURL("FLO")}/api/sdvx/v1/player_profile`]: {
 					_links: {},
@@ -110,7 +126,15 @@ t.test("#CreateKaiSDVXClassHandler", async (t) => {
 	});
 
 	t.test("Should gracefully handle negative API responses", async (t) => {
-		const fn = await CreateKaiSDVXClassHandler("FLO", "token", MockBasicFetch({ status: 500 }));
+		const fn = await CreateKaiSDVXClassHandler(
+			"FLO",
+			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
+			MockBasicFetch({ status: 500 })
+		);
 
 		const res = fn("sdvx", "Single", 1, {}, logger);
 
@@ -119,10 +143,34 @@ t.test("#CreateKaiSDVXClassHandler", async (t) => {
 		t.end();
 	});
 
+	t.test("Should call reauthFn if statusCode is 401", async (t) => {
+		let pass = false;
+		const fn = await CreateKaiSDVXClassHandler(
+			"FLO",
+			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				pass = true;
+				return "";
+			},
+			MockBasicFetch({ status: 401 })
+		);
+
+		fn("sdvx", "Single", 1, {}, logger);
+
+		t.equal(pass, true, "Should've called the reauth fn.");
+
+		t.end();
+	});
+
 	t.test("Should ignore null dans", async (t) => {
 		const fn = await CreateKaiSDVXClassHandler(
 			"FLO",
 			"token",
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async () => {
+				throw new Error(`Unexpectedly called reauthFn?`);
+			},
 			MockJSONFetch({
 				[`${KaiTypeToBaseURL("FLO")}/api/sdvx/v1/player_profile`]: {
 					_links: {},

--- a/server/src/lib/score-import/import-types/common/api-kai/sdvx/parser.ts
+++ b/server/src/lib/score-import/import-types/common/api-kai/sdvx/parser.ts
@@ -16,19 +16,21 @@ export async function ParseKaiSDVX(
 ): Promise<ParserFunctionReturns<unknown, KaiContext>> {
 	const baseUrl = KaiTypeToBaseURL(service);
 
+	const reauthFn = CreateKaiReauthFunction(service, authDoc, logger, fetch);
+
 	return {
 		iterable: TraverseKaiAPI(
 			baseUrl,
 			"/api/sdvx/v1/play_history",
 			authDoc.token,
 			logger,
-			CreateKaiReauthFunction(service, authDoc, logger, fetch),
+			reauthFn,
 			fetch
 		),
 		context: {
 			service,
 		},
-		classHandler: await CreateKaiSDVXClassHandler(service, authDoc.token, fetch),
+		classHandler: await CreateKaiSDVXClassHandler(service, authDoc.token, reauthFn, fetch),
 		game: "sdvx",
 	};
 }


### PR DESCRIPTION
reauthing *did not* happen in the case where class-searching failed. It happened when the iterator is called,
which is after the classHandler is curried.