### PR TITLE
fix: players with less than 60 scores should still have jubility calculate

### DIFF
--- a/client/src/app/pages/dashboard/import/ImportPage.tsx
+++ b/client/src/app/pages/dashboard/import/ImportPage.tsx
@@ -10,6 +10,7 @@ import useApiQuery from "components/util/query/useApiQuery";
 import { UserContext } from "context/UserContext";
 import { TachiConfig } from "lib/config";
 import React, { useContext, useState } from "react";
+import { Row } from "react-bootstrap";
 import {
 	APIImportTypes,
 	FileUploadImportTypes,
@@ -91,14 +92,18 @@ function InnerShowRecentImports({ user }: { user: PublicUserDocument }) {
 		<>
 			<h4>Recently Used Import Methods</h4>
 			<Divider />
-			{data
-				.filter((e) => e.importType.startsWith("file/") || e.importType.startsWith("api/"))
-				.map((e) => (
-					<ImportTypeInfoCard
-						key={e.importType}
-						importType={e.importType as FileUploadImportTypes | APIImportTypes}
-					/>
-				))}
+			<Row>
+				{data
+					.filter(
+						(e) => e.importType.startsWith("file/") || e.importType.startsWith("api/")
+					)
+					.map((e) => (
+						<ImportTypeInfoCard
+							key={e.importType}
+							importType={e.importType as FileUploadImportTypes | APIImportTypes}
+						/>
+					))}
+			</Row>
 		</>
 	);
 }

--- a/server/src/lib/score-import/framework/user-game-stats/rating.test.ts
+++ b/server/src/lib/score-import/framework/user-game-stats/rating.test.ts
@@ -1,6 +1,8 @@
 import { CalculateRatings } from "./rating";
+import db from "external/mongo/db";
 import CreateLogCtx from "lib/logger/logger";
 import t from "tap";
+import { mkFakePBIIDXSP, mkFakePBJubeat } from "test-utils/misc";
 import ResetDBState from "test-utils/resets";
 
 const logger = CreateLogCtx(__filename);
@@ -65,9 +67,19 @@ t.test("#CalculateRatings", (t) => {
 
 		t.strictSame(res, { skill: null, naiveSkill: null }, "Should return skill keys.");
 
-		const resDP = await CalculateRatings("gitadora", "Gita", 1, logger);
+		const res2 = await CalculateRatings("gitadora", "Gita", 1, logger);
 
-		t.strictSame(resDP, { skill: null, naiveSkill: null }, "Should return skill keys.");
+		t.strictSame(res2, { skill: null, naiveSkill: null }, "Should return skill keys.");
+
+		t.end();
+	});
+
+	t.test("Should calculate jubility for Jubeat", async (t) => {
+		await db["personal-bests"].insert(mkFakePBJubeat());
+
+		const res = await CalculateRatings("jubeat", "Single", 1, logger);
+
+		t.strictSame(res, { jubility: 5, naiveJubility: 5 }, "Should return jubility keys.");
 
 		t.end();
 	});

--- a/server/src/lib/score-import/framework/user-game-stats/update-ugs.ts
+++ b/server/src/lib/score-import/framework/user-game-stats/update-ugs.ts
@@ -10,9 +10,6 @@ import type { ClassHandler } from "./types";
 import type { KtLogger } from "lib/logger/logger";
 import type { ClassDelta, Game, integer, Playtype, UserGameStats } from "tachi-common";
 
-/**
- * @param allowDowngrades - If passed, this will allow metrics to be downgraded.
- */
 export async function UpdateUsersGamePlaytypeStats(
 	game: Game,
 	playtype: Playtype,

--- a/server/src/test-utils/misc.ts
+++ b/server/src/test-utils/misc.ts
@@ -7,6 +7,7 @@ import {
 	HC511UserGoal,
 	TestingIIDXSPScore,
 	TestingIIDXSPScorePB,
+	TestingJubeatPB,
 	TestingSDVXAlbidaChart,
 	TestingSDVXPB,
 	TestingSDVXScore,
@@ -94,6 +95,10 @@ export function mkFakeScoreSDVX(modifant: Partial<ScoreDocument<"sdvx:Single">> 
 
 export function mkFakePBIIDXSP(modifant: Partial<PBScoreDocument<"iidx:SP">> = {}) {
 	return dmf(TestingIIDXSPScorePB, modifant);
+}
+
+export function mkFakePBJubeat(modifant: Partial<PBScoreDocument<"jubeat:Single">> = {}) {
+	return dmf(TestingJubeatPB, modifant);
 }
 
 export function mkFakeNotification(modifant: Partial<NotificationDocument> = {}) {

--- a/server/src/test-utils/test-data.ts
+++ b/server/src/test-utils/test-data.ts
@@ -104,6 +104,40 @@ export const TestingIIDXSPScorePB: PBScoreDocument<"iidx:SP"> = {
 	timeAchieved: 10000,
 };
 
+export const TestingJubeatPB: PBScoreDocument<"jubeat:Single"> = {
+	chartID: "b90a319f18d1a746b330b8f4cd6f74874f664421",
+	userID: 1,
+	calculatedData: {
+		jubility: 5,
+	},
+	composedFrom: {
+		scorePB: "TESTING_SCORE_ID",
+		lampPB: "TESTING_SCORE_ID",
+	},
+	highlight: false,
+	isPrimary: true,
+	scoreData: {
+		score: 986_000,
+		percent: 94.11,
+		grade: "A",
+		gradeIndex: 7,
+		lamp: "CLEAR",
+		lampIndex: 6,
+		judgements: {},
+		hitMeta: {},
+		esd: null,
+	},
+	rankingData: {
+		rank: 1,
+		outOf: 2,
+		rivalRank: null,
+	},
+	songID: 1,
+	game: "jubeat",
+	playtype: "Single",
+	timeAchieved: 10000,
+};
+
 export const TestingIIDXSPScore: ScoreDocument<"iidx:SP"> = {
 	service: "foo (DIRECT-MANUAL)",
 	game: "iidx",


### PR DESCRIPTION
This is one of the craziest bugs in the codebase, and it's built upon just absolutely *completely* incorrect logic in our jubility calc.

It was fetching only on *songID*, with no regard to what `game` that `songID` belonged to.
As such, the bug manifested in this awkward way:

Because the query only returned 30 results, if the user had less than 30 scores on `jubeat` **AND** happened to have scores on another game **WHERE** that songID was involved, `undefined` would seep into the reducer, resulting in NaN.

`NaN`, of course, can be stored perfectly fine in MongoDB, but **does not exist at all** in JSON, so it becomes `null`, manifesting in an insane bug where a function that CANNOT return null, seems like it's returning null.

Insane.