### PR TITLE
Update setup.md

### DIFF
--- a/docs/docs/contributing/setup.md
+++ b/docs/docs/contributing/setup.md
@@ -171,7 +171,7 @@ There's a remarkably easy way to do this, using GitHub's `gh` tool.
 
 === "Debian, Ubuntu, WSL Ubuntu"
 	```sh
-	sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+	sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 23F3D4EA75716059
 	sudo apt-add-repository https://cli.github.com/packages
 	sudo apt update
 	sudo apt install gh


### PR DESCRIPTION
Doc update for setting up the dev enviroment.

The key "C99B11DEB97541F0" that is used to to add the github repository itself and be able to run apt update, has expired. I changed it to the new one. for more info, see this link https://github.com/cli/cli/issues/6175#issuecomment-1242737335