### PR TITLE
Adding alttitles for Resident CSV

### DIFF
--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -22419,7 +22419,7 @@
 	},
 	{
 		"altTitles": [
-		"ZENITH"
+			"ZENITH"
 		],
 		"artist": "Snail's House",
 		"data": {

--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -21744,7 +21744,8 @@
 	},
 	{
 		"altTitles": [
-			"POLKAMAИIA"
+			"POLKAMAИIA",
+			"POLKAMANIA"
 		],
 		"artist": "かめりあ feat. ななひら",
 		"data": {
@@ -22417,7 +22418,9 @@
 		"title": "BLACK or WHITE?"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+		"ZENITH"
+		],
 		"artist": "Snail's House",
 		"data": {
 			"displayVersion": "28",


### PR DESCRIPTION
Adds alttitles for Polkamania and Zenith. Something must've changed with eAM CSVs again.