### PR TITLE
Use overflow:auto not overflow:scroll

### DIFF
--- a/client/src/components/layout/header/SearchBar.tsx
+++ b/client/src/components/layout/header/SearchBar.tsx
@@ -289,7 +289,7 @@ export default function SearchBar() {
 						className="quick-search quick-search-dropdown quick-search-has-result"
 					>
 						<div
-							style={{ maxHeight: "325px", overflowY: "scroll" }}
+							style={{ maxHeight: "325px", overflowY: "auto" }}
 							className="quick-search-wrapper"
 						>
 							{results ? <SearchResults results={results} /> : <Loading />}

--- a/client/src/components/sessions/SessionCalendar.tsx
+++ b/client/src/components/sessions/SessionCalendar.tsx
@@ -151,7 +151,7 @@ function SessionTooltip({ sessionID, game, playtype, reqUser }: { sessionID: str
 				{data.session.desc && <Muted>{data.session.desc}</Muted>}
 				<Divider />
 			</div>
-			<Row className="w-100" style={{ maxHeight: "500px", overflowY: "scroll" }}>
+			<Row className="w-100" style={{ maxHeight: "500px", overflowY: "auto" }}>
 				<SessionRaiseBreakdown noHeader sessionData={data} />
 			</Row>
 			<div className="w-100 text-center">

--- a/client/src/components/tables/cells/SeedsDiffCell.tsx
+++ b/client/src/components/tables/cells/SeedsDiffCell.tsx
@@ -8,7 +8,7 @@ export default function SeedsDiffCell({ diffs }: { diffs: JSONAttributeDiff[] })
 				style={{
 					maxHeight: "200px",
 					maxWidth: "600px",
-					overflow: "scroll",
+					overflow: "auto",
 					textAlign: "left",
 				}}
 			>

--- a/client/src/components/tables/seeds/SeedsQuestTable.tsx
+++ b/client/src/components/tables/seeds/SeedsQuestTable.tsx
@@ -40,7 +40,7 @@ export const SeedsQuestCells: CellsRenderFN<QuestWithRelated> = ({
 		</td>
 		<td>{FormatGame(data.game, data.playtype)}</td>
 		<td>
-			<div style={{ maxHeight: "200px", overflowY: "scroll" }}>
+			<div style={{ maxHeight: "200px", overflowY: "auto" }}>
 				{data.questData.map((section) => (
 					<>
 						<h6>{section.title}</h6>

--- a/client/src/components/tables/seeds/SeedsQuestlineTable.tsx
+++ b/client/src/components/tables/seeds/SeedsQuestlineTable.tsx
@@ -39,7 +39,7 @@ export const SeedsQuestlineCells: CellsRenderFN<QuestlineWithRelated> = ({ data 
 		</td>
 		<td>{FormatGame(data.game, data.playtype)}</td>
 		<td className="text-left">
-			<div style={{ maxHeight: "200px", overflowY: "scroll" }}>
+			<div style={{ maxHeight: "200px", overflowY: "auto" }}>
 				{data.quests.map((e) => {
 					const quest = data.__related.quests[e];
 

--- a/client/src/components/tables/seeds/SeedsTableTable.tsx
+++ b/client/src/components/tables/seeds/SeedsTableTable.tsx
@@ -45,7 +45,7 @@ export const SeedsTableCells: CellsRenderFN<TableWithRelated> = ({ data }) => (
 		</td>
 		<td>{FormatGame(data.game, data.playtype)}</td>
 		<td className="text-left">
-			<div style={{ maxHeight: "200px", overflowY: "scroll" }}>
+			<div style={{ maxHeight: "200px", overflowY: "auto" }}>
 				{data.folders.map((e) => {
 					const folder = data.__related.folders[e];
 


### PR DESCRIPTION
`overflow: scroll` instructs the browser to **ALWAYS** show a scrollbar. This is almost certainly not what intended. Attached is an example of this. `overflow: auto` says "we want scrollbars, but only when we actually need them". Of the `scroll` occurrences none of them appeared to be a situation where this former situation was actually the required case.

![image](https://user-images.githubusercontent.com/7524553/226541654-ef8f082f-4006-422d-a951-dd47210e1169.png)
