### PR TITLE
Fix the Notifications link in profile dropdown

### DIFF
--- a/client/src/components/layout/header/UserProfileDropdown.tsx
+++ b/client/src/components/layout/header/UserProfileDropdown.tsx
@@ -48,7 +48,7 @@ export function UserProfileDropdown({ user }: { user: UserDocument }) {
 							</div>
 						</div>
 					</Link>
-					<Link to={`/u/${user.username}`} className="navi-item px-8 cursor-pointer">
+					<Link to={`/notifications`} className="navi-item px-8 cursor-pointer">
 						<div className="navi-link">
 							<div className="navi-icon mr-2">
 								<Icon type="envelope" colour="success" />


### PR DESCRIPTION
Diff should be fairly obvious.

Food for thought: Why is this link even here? It's duplicating the function of the message icon that's perpetually on the header. Personal suggestion would be to remove that icon either always (and just show a `(1)` tag on the profile picture), or remove it when there are no unread notifications, cus it's a bit redundant and feels weird to have something like that that's barely used promoted hard by the UI.