### PR TITLE
fix profile pics from stretching

### DIFF
--- a/client/src/components/layout/header/UserProfileDropdown.tsx
+++ b/client/src/components/layout/header/UserProfileDropdown.tsx
@@ -37,8 +37,13 @@ export function UserProfileDropdown({ user }: { user: UserDocument }) {
 							</>
 						)}
 					</span>
-					<span className="symbol symbol-35">
-						<img alt="Pic" className="hidden" src={ToAPIURL("/users/me/pfp")} />
+					<span className="symbol symbol-35 symbol-fixed">
+						<img
+							alt={"Pic"}
+							className="hidden"
+							style={{objectFit:"cover"}}
+							src={ToAPIURL("/users/me/pfp")}
+						/>
 					</span>
 				</div>
 			</Dropdown.Toggle>

--- a/client/src/components/user/ProfilePicture.tsx
+++ b/client/src/components/user/ProfilePicture.tsx
@@ -26,6 +26,7 @@ export default function ProfilePicture({
 					style={{
 						width: "128px",
 						height: "128px",
+						objectFit: "cover",
 						boxShadow: "0px 0px 10px 0px #000000",
 					}}
 				/>
@@ -42,6 +43,7 @@ export default function ProfilePicture({
 				style={{
 					width: "128px",
 					height: "128px",
+					objectFit: "cover",
 					boxShadow: "0px 0px 10px 0px #000000",
 				}}
 			/>
@@ -72,6 +74,7 @@ export function ProfilePictureSmall({
 					style={{
 						width: "32px",
 						height: "32px",
+						objectFit: "cover",
 						boxShadow: "0px 0px 10px 0px #000000",
 					}}
 				/>
@@ -88,6 +91,7 @@ export function ProfilePictureSmall({
 				style={{
 					width: "32px",
 					height: "32px",
+					objectFit: "cover",
 					boxShadow: "0px 0px 10px 0px #000000",
 				}}
 			/>


### PR DESCRIPTION
Use `object-fit: "cover"` to retain the image's aspect ratio and create a crop effect rather than filling the container by stretching. Also append `symbol-fixed` to the profile dropdown component to fix the size of the image to 35x35px. Previous behaviour made the max width 35px and the height 100%; this isn't very nice to vertical images since the container shrinks if the width is less than 35px. We add `object-fit: "cover"` to style to prevent stretching and create the same crop effect as everywhere else.