### PR TITLE
feat: add matching class to maimai DX

### DIFF
--- a/client/src/lib/game-implementations.tsx
+++ b/client/src/lib/game-implementations.tsx
@@ -343,6 +343,38 @@ export const GPT_CLIENT_IMPLEMENTATIONS: GPTClientImplementations = {
 					color: "var(--bs-dark)",
 				},
 			},
+			class: {
+				B5: bgc("green", "var(--bs-light)"),
+				B4: bgc("green", "var(--bs-light)"),
+				B3: bgc("green", "var(--bs-light)"),
+				B2: bgc("green", "var(--bs-light)"),
+				B1: bgc("green", "var(--bs-light)"),
+				A5: bgc("red", "var(--bs-light)"),
+				A4: bgc("red", "var(--bs-light)"),
+				A3: bgc("red", "var(--bs-light)"),
+				A2: bgc("red", "var(--bs-light)"),
+				A1: bgc("red", "var(--bs-light)"),
+				S5: bgc("brown", "var(--bs-light)"),
+				S4: bgc("brown", "var(--bs-light)"),
+				S3: bgc("brown", "var(--bs-light)"),
+				S2: bgc("brown", "var(--bs-light)"),
+				S1: bgc("brown", "var(--bs-light)"),
+				SS5: bgc("gray", "var(--bs-light)"),
+				SS4: bgc("gray", "var(--bs-light)"),
+				SS3: bgc("gray", "var(--bs-light)"),
+				SS2: bgc("gray", "var(--bs-light)"),
+				SS1: bgc("gray", "var(--bs-light)"),
+				SSS5: bgc("var(--bs-warning)", "var(--bs-dark)"),
+				SSS4: bgc("var(--bs-warning)", "var(--bs-dark)"),
+				SSS3: bgc("var(--bs-warning)", "var(--bs-dark)"),
+				SSS2: bgc("var(--bs-warning)", "var(--bs-dark)"),
+				SSS1: bgc("var(--bs-warning)", "var(--bs-dark)"),
+				LEGEND: {
+					background:
+						"linear-gradient(-45deg, #f0788a, #f48fb1, #9174c2, #79bcf2, #70a173, #f7ff99, #faca7d, #ff9d80, #f0788a)",
+					color: "var(--bs-dark)",
+				}
+			}
 		},
 		difficultyColours: {
 			Basic: COLOUR_SET.green,
@@ -658,8 +690,8 @@ export const GPT_CLIENT_IMPLEMENTATIONS: GPTClientImplementations = {
 							{chart.data.rankedLevel === null
 								? "Unranked Chart."
 								: sc.calculatedData.blockRating === null
-								? "Failed"
-								: sc.calculatedData.blockRating}
+									? "Failed"
+									: sc.calculatedData.blockRating}
 						</strong>
 					</td>
 				) : (

--- a/common/src/config/game-support/maimai-dx.ts
+++ b/common/src/config/game-support/maimai-dx.ts
@@ -56,6 +56,41 @@ const MaimaiDXColours = [
 	ClassValue("RAINBOW", "Rainbow"),
 ];
 
+const MaimaiDXClasses = [
+	ClassValue("B5", "B5"),
+	ClassValue("B4", "B4"),
+	ClassValue("B3", "B3"),
+	ClassValue("B2", "B2"),
+	ClassValue("B1", "B1"),
+
+	ClassValue("A5", "A5"),
+	ClassValue("A5", "A5"),
+	ClassValue("A4", "A4"),
+	ClassValue("A3", "A3"),
+	ClassValue("A2", "A2"),
+	ClassValue("A1", "A1"),
+
+	ClassValue("S5", "S5"),
+	ClassValue("S4", "S4"),
+	ClassValue("S3", "S3"),
+	ClassValue("S2", "S2"),
+	ClassValue("S1", "S1"),
+
+	ClassValue("SS5", "SS5"),
+	ClassValue("SS4", "SS4"),
+	ClassValue("SS3", "SS3"),
+	ClassValue("SS2", "SS2"),
+	ClassValue("SS1", "SS1"),
+
+	ClassValue("SSS5", "SSS5"),
+	ClassValue("SSS4", "SSS4"),
+	ClassValue("SSS3", "SSS3"),
+	ClassValue("SSS2", "SSS2"),
+	ClassValue("SSS1", "SSS1"),
+
+	ClassValue("LEGEND", "Legend"),
+]
+
 export const MAIMAI_DX_SINGLE_CONF = {
 	providedMetrics: {
 		percent: {
@@ -165,6 +200,10 @@ export const MAIMAI_DX_SINGLE_CONF = {
 			type: "PROVIDED",
 			values: MaimaiDXDans,
 		},
+		class: {
+			type: "PROVIDED",
+			values: MaimaiDXClasses,
+		}
 	},
 
 	orderedJudgements: ["pcrit", "perfect", "great", "good", "miss"],

--- a/common/src/constants/game.ts
+++ b/common/src/constants/game.ts
@@ -459,6 +459,7 @@ export enum MAIMAIDX_DANS {
 	SHINDAN_10 = 19,
 
 	SHINKAIDEN = 20,
+	URAKAIDEN = 21,
 }
 
 export enum MAIMAIDX_GRADES {
@@ -476,4 +477,38 @@ export enum MAIMAIDX_GRADES {
 	SS_PLUS = 11,
 	SSS = 12,
 	SSS_PLUS = 13,
+}
+
+export enum MAIMAIDX_CLASSES {
+	B5 = 0,
+	B4 = 1,
+	B3 = 2,
+	B2 = 3,
+	B1 = 4,
+
+	A5 = 5,
+	A4 = 6,
+	A3 = 7,
+	A2 = 8,
+	A1 = 9,
+
+	S5 = 10,
+	S4 = 11,
+	S3 = 12,
+	S2 = 13,
+	S1 = 14,
+
+	SS5 = 15,
+	SS4 = 16,
+	SS3 = 17,
+	SS2 = 18,
+	SS1 = 19,
+
+	SSS5 = 20,
+	SSS4 = 21,
+	SSS3 = 22,
+	SSS2 = 23,
+	SSS1 = 24,
+
+	LEGEND = 25,
 }


### PR DESCRIPTION
this PR adds matching classes in maimai DX to Tachi - sort of a ranking system that's available during normal play - players will try to beat other players' scores on randomly chosen charts, with the requirements increasing as their class increases. this system goes from B5-B1, A5-A1, S5-S1, SS5-SS1, SSS5-SSS1 then Legend.

i honestly don't know why i left this out in the first place, but as i start to play more i realize that grinding this kinda helps with consistency and everything and i'd like this to be tracked as well.

the tracking mechanic is probably the same as dans - displaying your peak class.