### PR TITLE
feat: a bunch of chunithm and maimai(dx) changes

### DIFF
--- a/client/src/lib/game-implementations.tsx
+++ b/client/src/lib/game-implementations.tsx
@@ -55,6 +55,22 @@ export const GPT_CLIENT_IMPLEMENTATIONS: GPTClientImplementations = {
 					color: "var(--bs-dark)",
 				},
 			},
+			dan: {
+				DAN_I: bgc("blue", "var(--bs-dark)"),
+				DAN_II: bgc("cyan", "var(--bs-dark)"),
+				DAN_III: bgc("var(--bs-warning)", "var(--bs-dark)"),
+				DAN_IV: bgc("red", "var(--bs-light)"),
+				DAN_V: bgc("purple", "var(--bs-light)"),
+				DAN_INFINITE: bgc("lightgoldenrodyellow", "var(--bs-dark)"),
+			},
+			emblem: {
+				DAN_I: bgc("blue", "var(--bs-dark)"),
+				DAN_II: bgc("cyan", "var(--bs-dark)"),
+				DAN_III: bgc("var(--bs-warning)", "var(--bs-dark)"),
+				DAN_IV: bgc("red", "var(--bs-light)"),
+				DAN_V: bgc("purple", "var(--bs-light)"),
+				DAN_INFINITE: bgc("lightgoldenrodyellow", "var(--bs-dark)"),
+			},
 		},
 		enumColours: {
 			grade: {

--- a/common/src/config/game-support/chunithm.ts
+++ b/common/src/config/game-support/chunithm.ts
@@ -15,16 +15,16 @@ export const CHUNITHM_CONF = {
 } as const satisfies INTERNAL_GAME_CONFIG;
 
 export const CHUNITHMColours = [
-	ClassValue("BLUE", "青", "Blue"),
-	ClassValue("GREEN", "緑", "Green"),
-	ClassValue("ORANGE", "橙", "Orange"),
-	ClassValue("RED", "赤", "Red"),
-	ClassValue("PURPLE", "紫", "Purple"),
-	ClassValue("COPPER", "銅", "Copper"),
-	ClassValue("SILVER", "銀", "Silver"),
-	ClassValue("GOLD", "金", "Gold"),
-	ClassValue("PLATINUM", "鉑", "Platinum"),
-	ClassValue("RAINBOW", "虹", "Rainbow"),
+	ClassValue("BLUE", "青", "Blue: 0 - 1.99 Rating"),
+	ClassValue("GREEN", "緑", "Green: 2 - 3.99 Rating"),
+	ClassValue("ORANGE", "橙", "Orange: 4 - 6.99 Rating"),
+	ClassValue("RED", "赤", "Red: 7 - 9.99 Rating"),
+	ClassValue("PURPLE", "紫", "Purple: 10 - 11.99 Rating"),
+	ClassValue("COPPER", "銅", "Copper: 12 - 13.24 Rating"),
+	ClassValue("SILVER", "銀", "Silver: 13.25 - 14.49 Rating"),
+	ClassValue("GOLD", "金", "Gold: 14.50 - 15.24 Rating"),
+	ClassValue("PLATINUM", "鉑", "Platinum: 15.25 - 15.99 Rating"),
+	ClassValue("RAINBOW", "虹", "Rainbow: >=16 Rating"),
 ];
 
 export const CHUNITHM_SINGLE_CONF = {

--- a/common/src/config/game-support/chunithm.ts
+++ b/common/src/config/game-support/chunithm.ts
@@ -27,6 +27,15 @@ export const CHUNITHMColours = [
 	ClassValue("RAINBOW", "虹", "Rainbow: >=16 Rating"),
 ];
 
+export const CHUNITHMClasses = [
+	ClassValue("DAN_I", "I", "Class I"),
+	ClassValue("DAN_II", "II", "Class II"),
+	ClassValue("DAN_III", "III", "Class III"),
+	ClassValue("DAN_IV", "IV", "Class IV"),
+	ClassValue("DAN_V", "V", "Class V"),
+	ClassValue("DAN_INFINITE", "∞", "Infinite Class"),
+]
+
 export const CHUNITHM_SINGLE_CONF = {
 	providedMetrics: {
 		score: {
@@ -115,6 +124,16 @@ export const CHUNITHM_SINGLE_CONF = {
 			type: "DERIVED",
 			values: CHUNITHMColours,
 		},
+
+		dan: {
+			type: "PROVIDED",
+			values: CHUNITHMClasses,
+		},
+
+		emblem: {
+			type: "PROVIDED",
+			values: CHUNITHMClasses,
+		}
 	},
 
 	orderedJudgements: ["jcrit", "justice", "attack", "miss"],

--- a/common/src/config/game-support/maimai-dx.ts
+++ b/common/src/config/game-support/maimai-dx.ts
@@ -26,7 +26,7 @@ const MaimaiDXDans = [
 	ClassValue("DAN_9", "九段", "9th Dan"),
 	ClassValue("DAN_10", "十段", "10th Dan"),
 
-	ClassValue("SHINDAN_1", "真初段", "Shinshodan"),
+	ClassValue("SHINDAN_1", "真初段", "1st Shindan"),
 	ClassValue("SHINDAN_2", "真二段", "2nd Shindan"),
 	ClassValue("SHINDAN_3", "真三段", "3rd Shindan"),
 	ClassValue("SHINDAN_4", "真四段", "4th Shindan"),

--- a/common/src/config/game-support/maimai-dx.ts
+++ b/common/src/config/game-support/maimai-dx.ts
@@ -43,17 +43,17 @@ const MaimaiDXDans = [
 ];
 
 const MaimaiDXColours = [
-	ClassValue("WHITE", "White"),
-	ClassValue("BLUE", "Blue"),
-	ClassValue("GREEN", "Green"),
-	ClassValue("YELLOW", "Yellow"),
-	ClassValue("RED", "Red"),
-	ClassValue("PURPLE", "Purple"),
-	ClassValue("BRONZE", "Bronze"),
-	ClassValue("SILVER", "Silver"),
-	ClassValue("GOLD", "Gold"),
-	ClassValue("PLATINUM", "Platinum"),
-	ClassValue("RAINBOW", "Rainbow"),
+	ClassValue("WHITE", "White", "0 - 999 Rating"),
+	ClassValue("BLUE", "Blue", "1000 - 1999 Rating"),
+	ClassValue("GREEN", "Green", "2000 - 3999 Rating"),
+	ClassValue("YELLOW", "Yellow", "4000 - 6999 Rating"),
+	ClassValue("RED", "Red", "7000 - 9999 Rating"),
+	ClassValue("PURPLE", "Purple", "10000 - 11999 Rating"),
+	ClassValue("BRONZE", "Bronze", "12000 - 12999 Rating"),
+	ClassValue("SILVER", "Silver", "13000 - 13999 Rating"),
+	ClassValue("GOLD", "Gold", "14000 - 14499 Rating"),
+	ClassValue("PLATINUM", "Platinum", "14500 - 14999 Rating"),
+	ClassValue("RAINBOW", "Rainbow", ">=15000 Rating"),
 ];
 
 const MaimaiDXMatchingClasses = [

--- a/common/src/config/game-support/maimai.ts
+++ b/common/src/config/game-support/maimai.ts
@@ -41,16 +41,16 @@ const MaimaiDans = [
 ];
 
 const MaimaiColours = [
-	ClassValue("WHITE", "White"),
-	ClassValue("BLUE", "Blue"),
-	ClassValue("GREEN", "Green"),
-	ClassValue("YELLOW", "Yellow"),
-	ClassValue("RED", "Red"),
-	ClassValue("PURPLE", "Purple"),
-	ClassValue("BRONZE", "Bronze"),
-	ClassValue("SILVER", "Silver"),
-	ClassValue("GOLD", "Gold"),
-	ClassValue("RAINBOW", "Rainbow"),
+	ClassValue("WHITE", "White", "0 - 1.99 Rating"),
+	ClassValue("BLUE", "Blue", "2 - 3.99 Rating"),
+	ClassValue("GREEN", "Green", "4 - 6.99 Rating"),
+	ClassValue("YELLOW", "Yellow", "7 - 9.99 Rating"),
+	ClassValue("RED", "Red", "10 - 11.99 Rating"),
+	ClassValue("PURPLE", "Purple", "12 - 12.99 Rating"),
+	ClassValue("BRONZE", "Bronze", "13 - 13.99 Rating"),
+	ClassValue("SILVER", "Silver", "14 - 14.49 Rating"),
+	ClassValue("GOLD", "Gold", "14.5 - 14.99 Rating"),
+	ClassValue("RAINBOW", "Rainbow", ">=15 Rating"),
 ];
 
 export const MAIMAI_SINGLE_CONF = {

--- a/common/src/config/game-support/maimai.ts
+++ b/common/src/config/game-support/maimai.ts
@@ -27,7 +27,7 @@ const MaimaiDans = [
 	ClassValue("DAN_10", "十段", "10th Dan"),
 	ClassValue("KAIDEN", "皆伝", "Kaiden"),
 
-	ClassValue("SHINDAN_1", "真初段", "Shinshodan"),
+	ClassValue("SHINDAN_1", "真初段", "1st Shindan"),
 	ClassValue("SHINDAN_2", "真二段", "2nd Shindan"),
 	ClassValue("SHINDAN_3", "真三段", "3rd Shindan"),
 	ClassValue("SHINDAN_4", "真四段", "4th Shindan"),


### PR DESCRIPTION
a joint PR with the chunithm sections from @beerpiss.

this adds hover text for the rating classes for all three games, and adds in dan support for chunithm. also renamed the 1st Shindan from "Shinshodan" to "1st Shindan" for consistency's sake. (i google translated the kanjis i'm sorry.)