### PR TITLE
New match type: `inGameStrID`

### DIFF
--- a/common/src/config/game-support/arcaea.ts
+++ b/common/src/config/game-support/arcaea.ts
@@ -125,12 +125,12 @@ export const ARCAEA_TOUCH_CONF = {
 	},
 
 	chartData: z.strictObject({
-		inGameID: z.string(),
+		inGameStrID: z.string(),
 		notecount: zodNonNegativeInt,
 	}),
 
 	preferences: z.strictObject({}),
 	scoreMeta: z.strictObject({}),
 
-	supportedMatchTypes: ["inGameID", "songTitle", "tachiSongID"],
+	supportedMatchTypes: ["inGameStrID", "songTitle", "tachiSongID"],
 } as const satisfies INTERNAL_GAME_PT_CONFIG;

--- a/common/src/config/game-support/maimai.ts
+++ b/common/src/config/game-support/maimai.ts
@@ -164,5 +164,5 @@ export const MAIMAI_SINGLE_CONF = {
 	preferences: z.strictObject({}),
 	scoreMeta: z.strictObject({}),
 
-	supportedMatchTypes: ["songTitle", "tachiSongID", "inGameID"],
+	supportedMatchTypes: ["songTitle", "tachiSongID", "inGameID", "inGameStrID"],
 } as const satisfies INTERNAL_GAME_PT_CONFIG;

--- a/common/src/lib/schemas.ts
+++ b/common/src/lib/schemas.ts
@@ -842,6 +842,7 @@ const PR_BATCH_MANUAL_SCORE = (game: Game, playtype: Playtype): PrudenceSchema =
 			"itgChartHash",
 			"sdvxInGameID",
 			"inGameID",
+			"inGameStrID",
 			"uscChartHash",
 			"popnChartHash"
 		),

--- a/common/src/types/batch-manual.ts
+++ b/common/src/types/batch-manual.ts
@@ -18,7 +18,12 @@ import type { AllFieldsNullableOptional } from "./utils";
 type MatchTypesNoDifficulty = "bmsChartHash" | "itgChartHash" | "popnChartHash" | "uscChartHash";
 
 // These MatchTypes need `difficulty` set in the batch manual.
-type MatchTypesWithDifficulty = "inGameID" | "sdvxInGameID" | "songTitle" | "tachiSongID";
+type MatchTypesWithDifficulty =
+	| "inGameID"
+	| "inGameStrID"
+	| "sdvxInGameID"
+	| "songTitle"
+	| "tachiSongID";
 
 export type MatchTypes = MatchTypesNoDifficulty | MatchTypesWithDifficulty;
 

--- a/database-seeds/collections/charts-arcaea.json
+++ b/database-seeds/collections/charts-arcaea.json
@@ -2,7 +2,7 @@
 	{
 		"chartID": "94197cdd2d3a002dbfa0e8e66e700da9e88adef4",
 		"data": {
-			"inGameID": "sayonarahatsukoi",
+			"inGameStrID": "sayonarahatsukoi",
 			"notecount": 666
 		},
 		"difficulty": "Future",
@@ -18,7 +18,7 @@
 	{
 		"chartID": "cb4112524b2299deb500a098dadf8fddb506b164",
 		"data": {
-			"inGameID": "sayonarahatsukoi",
+			"inGameStrID": "sayonarahatsukoi",
 			"notecount": 205
 		},
 		"difficulty": "Past",
@@ -34,7 +34,7 @@
 	{
 		"chartID": "9d95f9890664e3b3d5276431316c9ce1f4daa144",
 		"data": {
-			"inGameID": "sayonarahatsukoi",
+			"inGameStrID": "sayonarahatsukoi",
 			"notecount": 305
 		},
 		"difficulty": "Present",
@@ -50,7 +50,7 @@
 	{
 		"chartID": "f0becc8367f0e0131941f6cc6da431b5fcdd0aa3",
 		"data": {
-			"inGameID": "lostcivilization",
+			"inGameStrID": "lostcivilization",
 			"notecount": 1061
 		},
 		"difficulty": "Beyond",
@@ -66,7 +66,7 @@
 	{
 		"chartID": "5e2a983c5aefdebef10a51c66225f9c49913c142",
 		"data": {
-			"inGameID": "lostcivilization",
+			"inGameStrID": "lostcivilization",
 			"notecount": 986
 		},
 		"difficulty": "Future",
@@ -82,7 +82,7 @@
 	{
 		"chartID": "fd9e4423cd0b178d524f25fccb2259c1166b8ef5",
 		"data": {
-			"inGameID": "lostcivilization",
+			"inGameStrID": "lostcivilization",
 			"notecount": 462
 		},
 		"difficulty": "Past",
@@ -98,7 +98,7 @@
 	{
 		"chartID": "349a0c81b8bf60162e3e9b20e5414165d88cb8da",
 		"data": {
-			"inGameID": "lostcivilization",
+			"inGameStrID": "lostcivilization",
 			"notecount": 690
 		},
 		"difficulty": "Present",
@@ -114,7 +114,7 @@
 	{
 		"chartID": "292b26b425e26fef07355223476aac9b620b29df",
 		"data": {
-			"inGameID": "goodtek",
+			"inGameStrID": "goodtek",
 			"notecount": 1103
 		},
 		"difficulty": "Beyond",
@@ -130,7 +130,7 @@
 	{
 		"chartID": "a45b50ff0fbe91d232e051bfd7050a8799586b7e",
 		"data": {
-			"inGameID": "goodtek",
+			"inGameStrID": "goodtek",
 			"notecount": 968
 		},
 		"difficulty": "Future",
@@ -146,7 +146,7 @@
 	{
 		"chartID": "c8be97e5cf2ce25040c18025176074163b473b79",
 		"data": {
-			"inGameID": "goodtek",
+			"inGameStrID": "goodtek",
 			"notecount": 449
 		},
 		"difficulty": "Past",
@@ -162,7 +162,7 @@
 	{
 		"chartID": "d7bcc705c2e91185208384e587c08dd1fc442913",
 		"data": {
-			"inGameID": "goodtek",
+			"inGameStrID": "goodtek",
 			"notecount": 632
 		},
 		"difficulty": "Present",
@@ -178,7 +178,7 @@
 	{
 		"chartID": "5160d836dd58ac4f6b7f5b4782e15e61b9710db6",
 		"data": {
-			"inGameID": "viyella",
+			"inGameStrID": "viyella",
 			"notecount": 791
 		},
 		"difficulty": "Future",
@@ -194,7 +194,7 @@
 	{
 		"chartID": "284ca5ba8a584a5aa7436bfe9c221a67fe763397",
 		"data": {
-			"inGameID": "viyella",
+			"inGameStrID": "viyella",
 			"notecount": 414
 		},
 		"difficulty": "Past",
@@ -210,7 +210,7 @@
 	{
 		"chartID": "1eb8852f0d834c718ffb8c922ade59123e433aa5",
 		"data": {
-			"inGameID": "viyella",
+			"inGameStrID": "viyella",
 			"notecount": 492
 		},
 		"difficulty": "Present",
@@ -226,7 +226,7 @@
 	{
 		"chartID": "29412ffab50654f49d9eb60d76ca1bba05d20930",
 		"data": {
-			"inGameID": "rise",
+			"inGameStrID": "rise",
 			"notecount": 788
 		},
 		"difficulty": "Future",
@@ -242,7 +242,7 @@
 	{
 		"chartID": "842ac5f86cd7ca87be1dd69887ba30b5a075ee0a",
 		"data": {
-			"inGameID": "rise",
+			"inGameStrID": "rise",
 			"notecount": 322
 		},
 		"difficulty": "Past",
@@ -258,7 +258,7 @@
 	{
 		"chartID": "c0b245f12ea08e8b917db890b5f8c19fb72aa9b8",
 		"data": {
-			"inGameID": "rise",
+			"inGameStrID": "rise",
 			"notecount": 599
 		},
 		"difficulty": "Present",
@@ -274,7 +274,7 @@
 	{
 		"chartID": "f0f1d18e2f81dd9df26afe379aac18374f306772",
 		"data": {
-			"inGameID": "lucifer",
+			"inGameStrID": "lucifer",
 			"notecount": 861
 		},
 		"difficulty": "Future",
@@ -290,7 +290,7 @@
 	{
 		"chartID": "4ed66271cb31b4bc4004acd200f1c991e2fd3dbc",
 		"data": {
-			"inGameID": "lucifer",
+			"inGameStrID": "lucifer",
 			"notecount": 424
 		},
 		"difficulty": "Past",
@@ -306,7 +306,7 @@
 	{
 		"chartID": "2153b680dfaa506c4a69de26cedbd9654563d0cb",
 		"data": {
-			"inGameID": "lucifer",
+			"inGameStrID": "lucifer",
 			"notecount": 506
 		},
 		"difficulty": "Present",
@@ -322,7 +322,7 @@
 	{
 		"chartID": "1f180fdc666a310654658a2a028f66502780e290",
 		"data": {
-			"inGameID": "fairytale",
+			"inGameStrID": "fairytale",
 			"notecount": 932
 		},
 		"difficulty": "Beyond",
@@ -338,7 +338,7 @@
 	{
 		"chartID": "454461c39ff91127f5dcc8db370a42339577464e",
 		"data": {
-			"inGameID": "fairytale",
+			"inGameStrID": "fairytale",
 			"notecount": 782
 		},
 		"difficulty": "Future",
@@ -354,7 +354,7 @@
 	{
 		"chartID": "b1b157f99905fbb8d184a182683cedc88735a0b3",
 		"data": {
-			"inGameID": "fairytale",
+			"inGameStrID": "fairytale",
 			"notecount": 336
 		},
 		"difficulty": "Past",
@@ -370,7 +370,7 @@
 	{
 		"chartID": "078d77a9f13669c1196a11f081696a74c6f9e84f",
 		"data": {
-			"inGameID": "fairytale",
+			"inGameStrID": "fairytale",
 			"notecount": 511
 		},
 		"difficulty": "Present",
@@ -386,7 +386,7 @@
 	{
 		"chartID": "c46b7f643dfc445bd86d483072f58f838fd2f360",
 		"data": {
-			"inGameID": "hearditsaid",
+			"inGameStrID": "hearditsaid",
 			"notecount": 864
 		},
 		"difficulty": "Future",
@@ -402,7 +402,7 @@
 	{
 		"chartID": "c569757d5e315b66fc547a4b6bda0975612095b5",
 		"data": {
-			"inGameID": "hearditsaid",
+			"inGameStrID": "hearditsaid",
 			"notecount": 510
 		},
 		"difficulty": "Past",
@@ -418,7 +418,7 @@
 	{
 		"chartID": "f1c79bd5a15748f9006d5d273719ccaa56431546",
 		"data": {
-			"inGameID": "hearditsaid",
+			"inGameStrID": "hearditsaid",
 			"notecount": 664
 		},
 		"difficulty": "Present",
@@ -434,7 +434,7 @@
 	{
 		"chartID": "1d255efeeb42c598d57ee27b5543c8593ff12fec",
 		"data": {
-			"inGameID": "babaroque",
+			"inGameStrID": "babaroque",
 			"notecount": 808
 		},
 		"difficulty": "Future",
@@ -450,7 +450,7 @@
 	{
 		"chartID": "be71c4269786b46fadf46cd21a896016cbc4d4aa",
 		"data": {
-			"inGameID": "babaroque",
+			"inGameStrID": "babaroque",
 			"notecount": 402
 		},
 		"difficulty": "Past",
@@ -466,7 +466,7 @@
 	{
 		"chartID": "1389daa58fc5e623ab6009c39b83b3960ff470fd",
 		"data": {
-			"inGameID": "babaroque",
+			"inGameStrID": "babaroque",
 			"notecount": 645
 		},
 		"difficulty": "Present",
@@ -482,7 +482,7 @@
 	{
 		"chartID": "85da18fd30d1fe2ae42538571d02dd9f84c7dac6",
 		"data": {
-			"inGameID": "memoryfactory",
+			"inGameStrID": "memoryfactory",
 			"notecount": 672
 		},
 		"difficulty": "Future",
@@ -498,7 +498,7 @@
 	{
 		"chartID": "8a0a41253470630ca98db6f6b03bf5f551741511",
 		"data": {
-			"inGameID": "memoryfactory",
+			"inGameStrID": "memoryfactory",
 			"notecount": 308
 		},
 		"difficulty": "Past",
@@ -514,7 +514,7 @@
 	{
 		"chartID": "d0775db8e9e6e1150d8a3372f471cda95350d618",
 		"data": {
-			"inGameID": "memoryfactory",
+			"inGameStrID": "memoryfactory",
 			"notecount": 448
 		},
 		"difficulty": "Present",
@@ -530,7 +530,7 @@
 	{
 		"chartID": "afdecb40db294c1243d06d96fd37e65b462cc2a2",
 		"data": {
-			"inGameID": "snowwhite",
+			"inGameStrID": "snowwhite",
 			"notecount": 978
 		},
 		"difficulty": "Future",
@@ -546,7 +546,7 @@
 	{
 		"chartID": "277feb3e3ff01fb108a576cf9a0f3648283f0520",
 		"data": {
-			"inGameID": "snowwhite",
+			"inGameStrID": "snowwhite",
 			"notecount": 486
 		},
 		"difficulty": "Past",
@@ -562,7 +562,7 @@
 	{
 		"chartID": "6bac95cde243209061f9b47b7589ea9e5b73fdd5",
 		"data": {
-			"inGameID": "snowwhite",
+			"inGameStrID": "snowwhite",
 			"notecount": 672
 		},
 		"difficulty": "Present",
@@ -578,7 +578,7 @@
 	{
 		"chartID": "7bbb6eb7363cf3a941148eaad3e3593cd6d6c470",
 		"data": {
-			"inGameID": "relentless",
+			"inGameStrID": "relentless",
 			"notecount": 1015
 		},
 		"difficulty": "Future",
@@ -594,7 +594,7 @@
 	{
 		"chartID": "4160394695c73217a1c69ef464d638f87c5be936",
 		"data": {
-			"inGameID": "relentless",
+			"inGameStrID": "relentless",
 			"notecount": 607
 		},
 		"difficulty": "Past",
@@ -610,7 +610,7 @@
 	{
 		"chartID": "671cc2af317a47f620e917928b7b417f89b71a19",
 		"data": {
-			"inGameID": "relentless",
+			"inGameStrID": "relentless",
 			"notecount": 722
 		},
 		"difficulty": "Present",
@@ -626,7 +626,7 @@
 	{
 		"chartID": "6de80c703b255d9fcb6cb80106c32dbf1f60e2b6",
 		"data": {
-			"inGameID": "shadesoflight",
+			"inGameStrID": "shadesoflight",
 			"notecount": 1042
 		},
 		"difficulty": "Beyond",
@@ -642,7 +642,7 @@
 	{
 		"chartID": "ca4dc78989a6ee936b85c1bc76ae9d74c3004fb2",
 		"data": {
-			"inGameID": "shadesoflight",
+			"inGameStrID": "shadesoflight",
 			"notecount": 1067
 		},
 		"difficulty": "Future",
@@ -658,7 +658,7 @@
 	{
 		"chartID": "e43782aa2e47bd5eda475ad416bc1fe2a681654e",
 		"data": {
-			"inGameID": "shadesoflight",
+			"inGameStrID": "shadesoflight",
 			"notecount": 517
 		},
 		"difficulty": "Past",
@@ -674,7 +674,7 @@
 	{
 		"chartID": "5511d4bd67fbef863e12a8ab7add91b625dfaa26",
 		"data": {
-			"inGameID": "shadesoflight",
+			"inGameStrID": "shadesoflight",
 			"notecount": 789
 		},
 		"difficulty": "Present",
@@ -690,7 +690,7 @@
 	{
 		"chartID": "59d6e90c392d27c38b6542ca52dee94c684034e6",
 		"data": {
-			"inGameID": "vexaria",
+			"inGameStrID": "vexaria",
 			"notecount": 785
 		},
 		"difficulty": "Beyond",
@@ -706,7 +706,7 @@
 	{
 		"chartID": "8d168393a549c38b85c7f1b179efa741ec45815b",
 		"data": {
-			"inGameID": "vexaria",
+			"inGameStrID": "vexaria",
 			"notecount": 734
 		},
 		"difficulty": "Future",
@@ -722,7 +722,7 @@
 	{
 		"chartID": "7cec39c1c30ebfd2b934ebb52c139ed1dd559928",
 		"data": {
-			"inGameID": "vexaria",
+			"inGameStrID": "vexaria",
 			"notecount": 369
 		},
 		"difficulty": "Past",
@@ -738,7 +738,7 @@
 	{
 		"chartID": "bbc5ff0d083b80f8c14db084fd756dca3010a342",
 		"data": {
-			"inGameID": "vexaria",
+			"inGameStrID": "vexaria",
 			"notecount": 534
 		},
 		"difficulty": "Present",
@@ -754,7 +754,7 @@
 	{
 		"chartID": "4b34b1d58316a2b1675782247302deb45ba610c8",
 		"data": {
-			"inGameID": "essenceoftwilight",
+			"inGameStrID": "essenceoftwilight",
 			"notecount": 1204
 		},
 		"difficulty": "Future",
@@ -770,7 +770,7 @@
 	{
 		"chartID": "37f665b190523723714cc66b546e19860b3600d7",
 		"data": {
-			"inGameID": "essenceoftwilight",
+			"inGameStrID": "essenceoftwilight",
 			"notecount": 556
 		},
 		"difficulty": "Past",
@@ -786,7 +786,7 @@
 	{
 		"chartID": "031a313296ace1ec2a85f61e6bb2f753a51003f8",
 		"data": {
-			"inGameID": "essenceoftwilight",
+			"inGameStrID": "essenceoftwilight",
 			"notecount": 767
 		},
 		"difficulty": "Present",
@@ -802,7 +802,7 @@
 	{
 		"chartID": "9c369d3219967916316ba46ea734ab07e8c2d708",
 		"data": {
-			"inGameID": "qualia",
+			"inGameStrID": "qualia",
 			"notecount": 1288
 		},
 		"difficulty": "Beyond",
@@ -818,7 +818,7 @@
 	{
 		"chartID": "a2dcb987da83c2c19bcee0e02155947807a33824",
 		"data": {
-			"inGameID": "qualia",
+			"inGameStrID": "qualia",
 			"notecount": 1022
 		},
 		"difficulty": "Future",
@@ -834,7 +834,7 @@
 	{
 		"chartID": "e298d7ecc1b3567c9e057238b3f79c1a805537c4",
 		"data": {
-			"inGameID": "qualia",
+			"inGameStrID": "qualia",
 			"notecount": 550
 		},
 		"difficulty": "Past",
@@ -850,7 +850,7 @@
 	{
 		"chartID": "ec1f6c82d4d1c9b77a829834d85eecbbd1c0f391",
 		"data": {
-			"inGameID": "qualia",
+			"inGameStrID": "qualia",
 			"notecount": 875
 		},
 		"difficulty": "Present",
@@ -866,7 +866,7 @@
 	{
 		"chartID": "5d23b1788188746518b3371e3ec2b2bd5ed22ca5",
 		"data": {
-			"inGameID": "pragmatism",
+			"inGameStrID": "pragmatism",
 			"notecount": 942
 		},
 		"difficulty": "Future",
@@ -882,7 +882,7 @@
 	{
 		"chartID": "5741caf08e19d6b0bcf480a2f365b36992671dea",
 		"data": {
-			"inGameID": "pragmatism",
+			"inGameStrID": "pragmatism",
 			"notecount": 476
 		},
 		"difficulty": "Past",
@@ -898,7 +898,7 @@
 	{
 		"chartID": "31bc4974f123fde7c8b03c89760105fe694fe9a2",
 		"data": {
-			"inGameID": "pragmatism",
+			"inGameStrID": "pragmatism",
 			"notecount": 855
 		},
 		"difficulty": "Present",
@@ -914,7 +914,7 @@
 	{
 		"chartID": "3bc66e2b592349f623b3cfe695adc3b7cbfaa47b",
 		"data": {
-			"inGameID": "pragmatism",
+			"inGameStrID": "pragmatism",
 			"notecount": 1502
 		},
 		"difficulty": "Beyond",
@@ -930,7 +930,7 @@
 	{
 		"chartID": "48de13e0be17a282eed6ef97e6e1478eb59bc55e",
 		"data": {
-			"inGameID": "sheriruth",
+			"inGameStrID": "sheriruth",
 			"notecount": 1151
 		},
 		"difficulty": "Future",
@@ -946,7 +946,7 @@
 	{
 		"chartID": "20e34f6605218199b12c32d50357bec3e887ab63",
 		"data": {
-			"inGameID": "sheriruth",
+			"inGameStrID": "sheriruth",
 			"notecount": 611
 		},
 		"difficulty": "Past",
@@ -962,7 +962,7 @@
 	{
 		"chartID": "5f76f7d9cb6553d926d2ae28e1ff1f048d8c2a34",
 		"data": {
-			"inGameID": "sheriruth",
+			"inGameStrID": "sheriruth",
 			"notecount": 832
 		},
 		"difficulty": "Present",
@@ -978,7 +978,7 @@
 	{
 		"chartID": "04ddfba6bb85192a2892bc4f1498778ddeac2a8c",
 		"data": {
-			"inGameID": "lumia",
+			"inGameStrID": "lumia",
 			"notecount": 814
 		},
 		"difficulty": "Beyond",
@@ -994,7 +994,7 @@
 	{
 		"chartID": "b8f23cfe8329394ac70a015c99491e0727c50d65",
 		"data": {
-			"inGameID": "lumia",
+			"inGameStrID": "lumia",
 			"notecount": 961
 		},
 		"difficulty": "Future",
@@ -1010,7 +1010,7 @@
 	{
 		"chartID": "e59c8ea268f5999bf1ab4a9b11374e6436991ff8",
 		"data": {
-			"inGameID": "lumia",
+			"inGameStrID": "lumia",
 			"notecount": 469
 		},
 		"difficulty": "Past",
@@ -1026,7 +1026,7 @@
 	{
 		"chartID": "6b82d83af776cd9fc42dd168a69475cbfe3b4b09",
 		"data": {
-			"inGameID": "lumia",
+			"inGameStrID": "lumia",
 			"notecount": 438
 		},
 		"difficulty": "Present",
@@ -1042,7 +1042,7 @@
 	{
 		"chartID": "768b2924db059ee1e6fc82f0d5b48244c6cce459",
 		"data": {
-			"inGameID": "dement",
+			"inGameStrID": "dement",
 			"notecount": 1040
 		},
 		"difficulty": "Beyond",
@@ -1058,7 +1058,7 @@
 	{
 		"chartID": "7f5d76c42137cf42b35b0d50acd1f2bbd99b0b85",
 		"data": {
-			"inGameID": "dement",
+			"inGameStrID": "dement",
 			"notecount": 970
 		},
 		"difficulty": "Future",
@@ -1074,7 +1074,7 @@
 	{
 		"chartID": "bf74e2fd01f2290f913509938a97c1b8cf4f0b42",
 		"data": {
-			"inGameID": "dement",
+			"inGameStrID": "dement",
 			"notecount": 548
 		},
 		"difficulty": "Past",
@@ -1090,7 +1090,7 @@
 	{
 		"chartID": "875ed0d9f4f0a20c9a125b62de91a872c56fee21",
 		"data": {
-			"inGameID": "dement",
+			"inGameStrID": "dement",
 			"notecount": 756
 		},
 		"difficulty": "Present",
@@ -1106,7 +1106,7 @@
 	{
 		"chartID": "2654b87a1b178f7b0e354bc40edec9c888d9d694",
 		"data": {
-			"inGameID": "dandelion",
+			"inGameStrID": "dandelion",
 			"notecount": 921
 		},
 		"difficulty": "Future",
@@ -1122,7 +1122,7 @@
 	{
 		"chartID": "df91261b2a1e0194f12a6dfe112b3c1fb383f47e",
 		"data": {
-			"inGameID": "dandelion",
+			"inGameStrID": "dandelion",
 			"notecount": 391
 		},
 		"difficulty": "Past",
@@ -1138,7 +1138,7 @@
 	{
 		"chartID": "cb27e5f8df842061d869df9e0e37792baa20cf96",
 		"data": {
-			"inGameID": "dandelion",
+			"inGameStrID": "dandelion",
 			"notecount": 698
 		},
 		"difficulty": "Present",
@@ -1154,7 +1154,7 @@
 	{
 		"chartID": "98b7f232de1401b8da697318c4b9e29818659a6b",
 		"data": {
-			"inGameID": "anokumene",
+			"inGameStrID": "anokumene",
 			"notecount": 851
 		},
 		"difficulty": "Future",
@@ -1170,7 +1170,7 @@
 	{
 		"chartID": "0c370a8c37ac07741434669a2b1219a045d782c2",
 		"data": {
-			"inGameID": "anokumene",
+			"inGameStrID": "anokumene",
 			"notecount": 412
 		},
 		"difficulty": "Past",
@@ -1186,7 +1186,7 @@
 	{
 		"chartID": "ad06a01f2153cf1ccf2d0387ae41d901e69f7dec",
 		"data": {
-			"inGameID": "anokumene",
+			"inGameStrID": "anokumene",
 			"notecount": 588
 		},
 		"difficulty": "Present",
@@ -1202,7 +1202,7 @@
 	{
 		"chartID": "a6806a8295acb54b2e2a5d90fbd5a1611299e0d8",
 		"data": {
-			"inGameID": "infinityheaven",
+			"inGameStrID": "infinityheaven",
 			"notecount": 986
 		},
 		"difficulty": "Beyond",
@@ -1218,7 +1218,7 @@
 	{
 		"chartID": "a91cb464429a89fb2b9440bbe5f4a24728683868",
 		"data": {
-			"inGameID": "infinityheaven",
+			"inGameStrID": "infinityheaven",
 			"notecount": 853
 		},
 		"difficulty": "Future",
@@ -1234,7 +1234,7 @@
 	{
 		"chartID": "f828a3bbc9d0d04e41fd219ba85c166388683907",
 		"data": {
-			"inGameID": "infinityheaven",
+			"inGameStrID": "infinityheaven",
 			"notecount": 336
 		},
 		"difficulty": "Past",
@@ -1250,7 +1250,7 @@
 	{
 		"chartID": "fc5f877bce6914c72269f418da9a602838987031",
 		"data": {
-			"inGameID": "infinityheaven",
+			"inGameStrID": "infinityheaven",
 			"notecount": 545
 		},
 		"difficulty": "Present",
@@ -1266,7 +1266,7 @@
 	{
 		"chartID": "e6e44009a1eab08003ababbe1396d770ec974f05",
 		"data": {
-			"inGameID": "partyvinyl",
+			"inGameStrID": "partyvinyl",
 			"notecount": 946
 		},
 		"difficulty": "Beyond",
@@ -1282,7 +1282,7 @@
 	{
 		"chartID": "c8efa3bc27e7152b8c67f6225513fc5a404bf9eb",
 		"data": {
-			"inGameID": "partyvinyl",
+			"inGameStrID": "partyvinyl",
 			"notecount": 800
 		},
 		"difficulty": "Future",
@@ -1298,7 +1298,7 @@
 	{
 		"chartID": "9831a36744b3d932925978fd14212cde4bbc54d7",
 		"data": {
-			"inGameID": "partyvinyl",
+			"inGameStrID": "partyvinyl",
 			"notecount": 337
 		},
 		"difficulty": "Past",
@@ -1314,7 +1314,7 @@
 	{
 		"chartID": "2a9a232641cddfbcc9847f24c5be7b900a6f6c49",
 		"data": {
-			"inGameID": "partyvinyl",
+			"inGameStrID": "partyvinyl",
 			"notecount": 543
 		},
 		"difficulty": "Present",
@@ -1330,7 +1330,7 @@
 	{
 		"chartID": "d38de7c42b01b434558e96ff89cd02ef1e1ced62",
 		"data": {
-			"inGameID": "flashback",
+			"inGameStrID": "flashback",
 			"notecount": 856
 		},
 		"difficulty": "Future",
@@ -1346,7 +1346,7 @@
 	{
 		"chartID": "3156f8cccb5eb7b0e11c49f8c2d5c89b1bfaaab2",
 		"data": {
-			"inGameID": "flashback",
+			"inGameStrID": "flashback",
 			"notecount": 356
 		},
 		"difficulty": "Past",
@@ -1362,7 +1362,7 @@
 	{
 		"chartID": "ff4a28e51552e31f4f1564183c98df48f7612f89",
 		"data": {
-			"inGameID": "flashback",
+			"inGameStrID": "flashback",
 			"notecount": 488
 		},
 		"difficulty": "Present",
@@ -1378,7 +1378,7 @@
 	{
 		"chartID": "94a3435224ab008e911af22cd7aa581c4b3e5b3d",
 		"data": {
-			"inGameID": "flyburg",
+			"inGameStrID": "flyburg",
 			"notecount": 930
 		},
 		"difficulty": "Future",
@@ -1394,7 +1394,7 @@
 	{
 		"chartID": "c529bcf5e0e3d3c17f31dad608723743455e9b15",
 		"data": {
-			"inGameID": "flyburg",
+			"inGameStrID": "flyburg",
 			"notecount": 413
 		},
 		"difficulty": "Past",
@@ -1410,7 +1410,7 @@
 	{
 		"chartID": "4867e3c1f03b3471765ce73ec5649529e30cad9d",
 		"data": {
-			"inGameID": "flyburg",
+			"inGameStrID": "flyburg",
 			"notecount": 650
 		},
 		"difficulty": "Present",
@@ -1426,7 +1426,7 @@
 	{
 		"chartID": "ab8450a847f819e192a75e1863e7588f2bd78a9d",
 		"data": {
-			"inGameID": "nirvluce",
+			"inGameStrID": "nirvluce",
 			"notecount": 980
 		},
 		"difficulty": "Future",
@@ -1442,7 +1442,7 @@
 	{
 		"chartID": "d88f5240bbad33f720c41a5bfa7e1a487025176c",
 		"data": {
-			"inGameID": "nirvluce",
+			"inGameStrID": "nirvluce",
 			"notecount": 297
 		},
 		"difficulty": "Past",
@@ -1458,7 +1458,7 @@
 	{
 		"chartID": "cb866510d1b0cf68081734e42e62eed764d8d7ae",
 		"data": {
-			"inGameID": "nirvluce",
+			"inGameStrID": "nirvluce",
 			"notecount": 547
 		},
 		"difficulty": "Present",
@@ -1474,7 +1474,7 @@
 	{
 		"chartID": "dc04e752082e363028bcf38ea3d12529e13993d4",
 		"data": {
-			"inGameID": "paradise",
+			"inGameStrID": "paradise",
 			"notecount": 729
 		},
 		"difficulty": "Future",
@@ -1490,7 +1490,7 @@
 	{
 		"chartID": "2712fb5b9d6145c556a7a15b6afa92197f75a06f",
 		"data": {
-			"inGameID": "paradise",
+			"inGameStrID": "paradise",
 			"notecount": 253
 		},
 		"difficulty": "Past",
@@ -1506,7 +1506,7 @@
 	{
 		"chartID": "3f8f4491617da5f931e25f8c19a917a6fc17882e",
 		"data": {
-			"inGameID": "paradise",
+			"inGameStrID": "paradise",
 			"notecount": 349
 		},
 		"difficulty": "Present",
@@ -1522,7 +1522,7 @@
 	{
 		"chartID": "34c13cf63d7cce89afd648a4af4c5fae7bbfb83f",
 		"data": {
-			"inGameID": "brandnewworld",
+			"inGameStrID": "brandnewworld",
 			"notecount": 787
 		},
 		"difficulty": "Future",
@@ -1538,7 +1538,7 @@
 	{
 		"chartID": "65d568927d5541bcd3046db110db7a350830e9b4",
 		"data": {
-			"inGameID": "brandnewworld",
+			"inGameStrID": "brandnewworld",
 			"notecount": 322
 		},
 		"difficulty": "Past",
@@ -1554,7 +1554,7 @@
 	{
 		"chartID": "8e82341d822f820dc185b46679932b7d28aacfe9",
 		"data": {
-			"inGameID": "brandnewworld",
+			"inGameStrID": "brandnewworld",
 			"notecount": 432
 		},
 		"difficulty": "Present",
@@ -1570,7 +1570,7 @@
 	{
 		"chartID": "f04720ab949ac1b4f78b7543f9de64c0cd0da4b8",
 		"data": {
-			"inGameID": "dataerror",
+			"inGameStrID": "dataerror",
 			"notecount": 955
 		},
 		"difficulty": "Future",
@@ -1586,7 +1586,7 @@
 	{
 		"chartID": "e2aec16ee0838d6867207b4c4135bcf6348fc112",
 		"data": {
-			"inGameID": "dataerror",
+			"inGameStrID": "dataerror",
 			"notecount": 502
 		},
 		"difficulty": "Past",
@@ -1602,7 +1602,7 @@
 	{
 		"chartID": "09795a1493410d85407540371b04d2c27003fe68",
 		"data": {
-			"inGameID": "dataerror",
+			"inGameStrID": "dataerror",
 			"notecount": 785
 		},
 		"difficulty": "Present",
@@ -1618,7 +1618,7 @@
 	{
 		"chartID": "6bb9606c87045d5ee08c730df4bb025d618453c1",
 		"data": {
-			"inGameID": "crosssoul",
+			"inGameStrID": "crosssoul",
 			"notecount": 1081
 		},
 		"difficulty": "Future",
@@ -1634,7 +1634,7 @@
 	{
 		"chartID": "9fa8bcfcb1b71af1a1fac5ad39898695d5723be1",
 		"data": {
-			"inGameID": "crosssoul",
+			"inGameStrID": "crosssoul",
 			"notecount": 606
 		},
 		"difficulty": "Past",
@@ -1650,7 +1650,7 @@
 	{
 		"chartID": "d106c63ff401752c892b23e2c9833235abb1547d",
 		"data": {
-			"inGameID": "crosssoul",
+			"inGameStrID": "crosssoul",
 			"notecount": 823
 		},
 		"difficulty": "Present",
@@ -1666,7 +1666,7 @@
 	{
 		"chartID": "b18fa5f185a1022f3a4972a4b6683498eaee54db",
 		"data": {
-			"inGameID": "yourvoiceso",
+			"inGameStrID": "yourvoiceso",
 			"notecount": 1013
 		},
 		"difficulty": "Future",
@@ -1682,7 +1682,7 @@
 	{
 		"chartID": "9c4f1980aaacaa8e10c8d0ef67d285ae2d72fa41",
 		"data": {
-			"inGameID": "yourvoiceso",
+			"inGameStrID": "yourvoiceso",
 			"notecount": 469
 		},
 		"difficulty": "Past",
@@ -1698,7 +1698,7 @@
 	{
 		"chartID": "607206b339b7559b9f469e0faa789c53e86d8fb7",
 		"data": {
-			"inGameID": "yourvoiceso",
+			"inGameStrID": "yourvoiceso",
 			"notecount": 677
 		},
 		"difficulty": "Present",
@@ -1714,7 +1714,7 @@
 	{
 		"chartID": "32aefd4688f91d2ad057c405ae539a0ce546a0b4",
 		"data": {
-			"inGameID": "chronostasis",
+			"inGameStrID": "chronostasis",
 			"notecount": 916
 		},
 		"difficulty": "Future",
@@ -1730,7 +1730,7 @@
 	{
 		"chartID": "cbc51e3e57112c8fa1395b48d853681913b88a71",
 		"data": {
-			"inGameID": "chronostasis",
+			"inGameStrID": "chronostasis",
 			"notecount": 619
 		},
 		"difficulty": "Past",
@@ -1746,7 +1746,7 @@
 	{
 		"chartID": "8fd2bb4f984078d15e6adf29c191ae6610190602",
 		"data": {
-			"inGameID": "chronostasis",
+			"inGameStrID": "chronostasis",
 			"notecount": 812
 		},
 		"difficulty": "Present",
@@ -1762,7 +1762,7 @@
 	{
 		"chartID": "137f169af3321e9f51f2807b9a646aee9e63fdcc",
 		"data": {
-			"inGameID": "kanagawa",
+			"inGameStrID": "kanagawa",
 			"notecount": 1121
 		},
 		"difficulty": "Beyond",
@@ -1778,7 +1778,7 @@
 	{
 		"chartID": "2e3861e1ac8c43ad7425d4e48898ba38e69b2df2",
 		"data": {
-			"inGameID": "kanagawa",
+			"inGameStrID": "kanagawa",
 			"notecount": 1111
 		},
 		"difficulty": "Future",
@@ -1794,7 +1794,7 @@
 	{
 		"chartID": "f61fc5e10ffa901d32ce165137ab065f9ad389ab",
 		"data": {
-			"inGameID": "kanagawa",
+			"inGameStrID": "kanagawa",
 			"notecount": 375
 		},
 		"difficulty": "Past",
@@ -1810,7 +1810,7 @@
 	{
 		"chartID": "b39f7733f590963e1e1443297808c956db750ea5",
 		"data": {
-			"inGameID": "kanagawa",
+			"inGameStrID": "kanagawa",
 			"notecount": 707
 		},
 		"difficulty": "Present",
@@ -1826,7 +1826,7 @@
 	{
 		"chartID": "99487ab7e99d4a216ec31a1ddfda88c8a2d15b73",
 		"data": {
-			"inGameID": "moonlightofsandcastle",
+			"inGameStrID": "moonlightofsandcastle",
 			"notecount": 645
 		},
 		"difficulty": "Future",
@@ -1842,7 +1842,7 @@
 	{
 		"chartID": "4dc994f124fa051e3aa37e1a6d2f905dd68b4e81",
 		"data": {
-			"inGameID": "moonlightofsandcastle",
+			"inGameStrID": "moonlightofsandcastle",
 			"notecount": 418
 		},
 		"difficulty": "Past",
@@ -1858,7 +1858,7 @@
 	{
 		"chartID": "344234e122df4f0caac24f8a6c93e7bdb6ce9e5c",
 		"data": {
-			"inGameID": "moonlightofsandcastle",
+			"inGameStrID": "moonlightofsandcastle",
 			"notecount": 394
 		},
 		"difficulty": "Present",
@@ -1874,7 +1874,7 @@
 	{
 		"chartID": "35bbd3c9cd519048ee21484a6824881d2e458f1b",
 		"data": {
-			"inGameID": "reconstruction",
+			"inGameStrID": "reconstruction",
 			"notecount": 825
 		},
 		"difficulty": "Future",
@@ -1890,7 +1890,7 @@
 	{
 		"chartID": "aa2a489d4f55a26b229cf6e1efb7ca0234817a36",
 		"data": {
-			"inGameID": "reconstruction",
+			"inGameStrID": "reconstruction",
 			"notecount": 347
 		},
 		"difficulty": "Past",
@@ -1906,7 +1906,7 @@
 	{
 		"chartID": "48943c0e77b84a1dbd2c7729114afd7654bf6e89",
 		"data": {
-			"inGameID": "reconstruction",
+			"inGameStrID": "reconstruction",
 			"notecount": 469
 		},
 		"difficulty": "Present",
@@ -1922,7 +1922,7 @@
 	{
 		"chartID": "e33e9d394a5d4f94ad8f568f6c3b8f75b1aa218e",
 		"data": {
-			"inGameID": "evoltex",
+			"inGameStrID": "evoltex",
 			"notecount": 775
 		},
 		"difficulty": "Future",
@@ -1938,7 +1938,7 @@
 	{
 		"chartID": "743480a82195f331b0b7c2ac3322a4730fe9ebd0",
 		"data": {
-			"inGameID": "evoltex",
+			"inGameStrID": "evoltex",
 			"notecount": 297
 		},
 		"difficulty": "Past",
@@ -1954,7 +1954,7 @@
 	{
 		"chartID": "f6ca94db258de118c6b9de206c46b0e721e90d9f",
 		"data": {
-			"inGameID": "evoltex",
+			"inGameStrID": "evoltex",
 			"notecount": 627
 		},
 		"difficulty": "Present",
@@ -1970,7 +1970,7 @@
 	{
 		"chartID": "dd1938a81a4178e2953ad270729495f8750e99f5",
 		"data": {
-			"inGameID": "oracle",
+			"inGameStrID": "oracle",
 			"notecount": 963
 		},
 		"difficulty": "Future",
@@ -1986,7 +1986,7 @@
 	{
 		"chartID": "08679c3fd31db49ade06ba222825dfd8ecaf6528",
 		"data": {
-			"inGameID": "oracle",
+			"inGameStrID": "oracle",
 			"notecount": 425
 		},
 		"difficulty": "Past",
@@ -2002,7 +2002,7 @@
 	{
 		"chartID": "f96b437e348dfbbd02e60cb0557da173bad66940",
 		"data": {
-			"inGameID": "oracle",
+			"inGameStrID": "oracle",
 			"notecount": 508
 		},
 		"difficulty": "Present",
@@ -2018,7 +2018,7 @@
 	{
 		"chartID": "f7b6256f166b1512ace4094438b4b1b8ff2eb5e3",
 		"data": {
-			"inGameID": "aterlbus",
+			"inGameStrID": "aterlbus",
 			"notecount": 1030
 		},
 		"difficulty": "Future",
@@ -2034,7 +2034,7 @@
 	{
 		"chartID": "76cd369edfda5568c93336e55ce52f5fcb241f4d",
 		"data": {
-			"inGameID": "aterlbus",
+			"inGameStrID": "aterlbus",
 			"notecount": 505
 		},
 		"difficulty": "Past",
@@ -2050,7 +2050,7 @@
 	{
 		"chartID": "ae08f833ab562a9e7159327d3eb08dac195b2da5",
 		"data": {
-			"inGameID": "aterlbus",
+			"inGameStrID": "aterlbus",
 			"notecount": 668
 		},
 		"difficulty": "Present",
@@ -2066,7 +2066,7 @@
 	{
 		"chartID": "18cb8a6db9cbc0ee192b792ffbed82eac5c1249a",
 		"data": {
-			"inGameID": "clotho",
+			"inGameStrID": "clotho",
 			"notecount": 1021
 		},
 		"difficulty": "Future",
@@ -2082,7 +2082,7 @@
 	{
 		"chartID": "2315171026fe6f1101d3b22a7f8897297dca8480",
 		"data": {
-			"inGameID": "clotho",
+			"inGameStrID": "clotho",
 			"notecount": 519
 		},
 		"difficulty": "Past",
@@ -2098,7 +2098,7 @@
 	{
 		"chartID": "93bf49d65cd99b79a50fceedaceacd06774833b4",
 		"data": {
-			"inGameID": "clotho",
+			"inGameStrID": "clotho",
 			"notecount": 745
 		},
 		"difficulty": "Present",
@@ -2114,7 +2114,7 @@
 	{
 		"chartID": "a09cbe4f97b135329aee69504e6198fd217aba06",
 		"data": {
-			"inGameID": "impurebird",
+			"inGameStrID": "impurebird",
 			"notecount": 805
 		},
 		"difficulty": "Future",
@@ -2130,7 +2130,7 @@
 	{
 		"chartID": "05a96e606a50bbe982e06ae585a319d985614ab7",
 		"data": {
-			"inGameID": "impurebird",
+			"inGameStrID": "impurebird",
 			"notecount": 350
 		},
 		"difficulty": "Past",
@@ -2146,7 +2146,7 @@
 	{
 		"chartID": "9f9751b846ee38673b9cd5ba1b5cf2d00cad9e31",
 		"data": {
-			"inGameID": "impurebird",
+			"inGameStrID": "impurebird",
 			"notecount": 518
 		},
 		"difficulty": "Present",
@@ -2162,7 +2162,7 @@
 	{
 		"chartID": "031d8bd681614f60d8fc790d795dddc7f729f20f",
 		"data": {
-			"inGameID": "ignotus",
+			"inGameStrID": "ignotus",
 			"notecount": 1225
 		},
 		"difficulty": "Future",
@@ -2178,7 +2178,7 @@
 	{
 		"chartID": "fb46f9a0e9f1f9ec43c82b8b628f76ecb3e5998b",
 		"data": {
-			"inGameID": "ignotus",
+			"inGameStrID": "ignotus",
 			"notecount": 579
 		},
 		"difficulty": "Past",
@@ -2194,7 +2194,7 @@
 	{
 		"chartID": "d10a8f2971db3d3998be3056978974d19763b6a5",
 		"data": {
-			"inGameID": "ignotus",
+			"inGameStrID": "ignotus",
 			"notecount": 809
 		},
 		"difficulty": "Present",
@@ -2210,7 +2210,7 @@
 	{
 		"chartID": "f79024f4124273f8cc8b9a2f593c2bc883ba84ab",
 		"data": {
-			"inGameID": "ignotus",
+			"inGameStrID": "ignotus",
 			"notecount": 1077
 		},
 		"difficulty": "Beyond",
@@ -2226,7 +2226,7 @@
 	{
 		"chartID": "f7b82a496cc661c419ef33e145941e9eedd18f55",
 		"data": {
-			"inGameID": "lethaeus",
+			"inGameStrID": "lethaeus",
 			"notecount": 900
 		},
 		"difficulty": "Future",
@@ -2242,7 +2242,7 @@
 	{
 		"chartID": "a581af034c801ddd457d58ac31848508c2ca4bd8",
 		"data": {
-			"inGameID": "lethaeus",
+			"inGameStrID": "lethaeus",
 			"notecount": 480
 		},
 		"difficulty": "Past",
@@ -2258,7 +2258,7 @@
 	{
 		"chartID": "5ba891f9d38a4b4c420ef2dcf75e02174681fdbf",
 		"data": {
-			"inGameID": "lethaeus",
+			"inGameStrID": "lethaeus",
 			"notecount": 717
 		},
 		"difficulty": "Present",
@@ -2274,7 +2274,7 @@
 	{
 		"chartID": "b47fe31a1cedf38d2957b5e1f3edb51144fb2bf8",
 		"data": {
-			"inGameID": "romancewars",
+			"inGameStrID": "romancewars",
 			"notecount": 641
 		},
 		"difficulty": "Future",
@@ -2290,7 +2290,7 @@
 	{
 		"chartID": "93bdcc738f818c69a0c4ae5c4c337054856ad4c2",
 		"data": {
-			"inGameID": "romancewars",
+			"inGameStrID": "romancewars",
 			"notecount": 423
 		},
 		"difficulty": "Past",
@@ -2306,7 +2306,7 @@
 	{
 		"chartID": "587592ad581fd448e482101ea95b0516f7160afb",
 		"data": {
-			"inGameID": "romancewars",
+			"inGameStrID": "romancewars",
 			"notecount": 378
 		},
 		"difficulty": "Present",
@@ -2322,7 +2322,7 @@
 	{
 		"chartID": "bee455588bf601595ca4cdb0905f256962dab100",
 		"data": {
-			"inGameID": "blossoms",
+			"inGameStrID": "blossoms",
 			"notecount": 655
 		},
 		"difficulty": "Future",
@@ -2338,7 +2338,7 @@
 	{
 		"chartID": "0b4fb7178a38454ec6a3fd6705d796fffdffc0ab",
 		"data": {
-			"inGameID": "blossoms",
+			"inGameStrID": "blossoms",
 			"notecount": 275
 		},
 		"difficulty": "Past",
@@ -2354,7 +2354,7 @@
 	{
 		"chartID": "023cf74a5c4b5ea79b767e411f0987b60ee10c26",
 		"data": {
-			"inGameID": "blossoms",
+			"inGameStrID": "blossoms",
 			"notecount": 383
 		},
 		"difficulty": "Present",
@@ -2370,7 +2370,7 @@
 	{
 		"chartID": "4544130aa9531439e690d7bb867277a87be7503c",
 		"data": {
-			"inGameID": "moonheart",
+			"inGameStrID": "moonheart",
 			"notecount": 1139
 		},
 		"difficulty": "Beyond",
@@ -2386,7 +2386,7 @@
 	{
 		"chartID": "c988ea5c36dbcad8dc3280b1f415aee007e56a6d",
 		"data": {
-			"inGameID": "moonheart",
+			"inGameStrID": "moonheart",
 			"notecount": 947
 		},
 		"difficulty": "Future",
@@ -2402,7 +2402,7 @@
 	{
 		"chartID": "4dbfacfdcd97df12f019e03a3ab7f7f934970b98",
 		"data": {
-			"inGameID": "moonheart",
+			"inGameStrID": "moonheart",
 			"notecount": 449
 		},
 		"difficulty": "Past",
@@ -2418,7 +2418,7 @@
 	{
 		"chartID": "483719eb6239823d5d459e3f68bddcf981109dda",
 		"data": {
-			"inGameID": "moonheart",
+			"inGameStrID": "moonheart",
 			"notecount": 566
 		},
 		"difficulty": "Present",
@@ -2434,7 +2434,7 @@
 	{
 		"chartID": "9fc130a18f5641ffacfa1821c167021c43974c4e",
 		"data": {
-			"inGameID": "genesis",
+			"inGameStrID": "genesis",
 			"notecount": 713
 		},
 		"difficulty": "Future",
@@ -2450,7 +2450,7 @@
 	{
 		"chartID": "029842ddadff6c66e413a841ecc17fe7dc31f8df",
 		"data": {
-			"inGameID": "genesis",
+			"inGameStrID": "genesis",
 			"notecount": 275
 		},
 		"difficulty": "Past",
@@ -2466,7 +2466,7 @@
 	{
 		"chartID": "98339806bb9db91f63586017b92ca3c449ee7b5e",
 		"data": {
-			"inGameID": "genesis",
+			"inGameStrID": "genesis",
 			"notecount": 399
 		},
 		"difficulty": "Present",
@@ -2482,7 +2482,7 @@
 	{
 		"chartID": "dc16c97c121e104260d88d5c13b539341bd8d849",
 		"data": {
-			"inGameID": "harutopia",
+			"inGameStrID": "harutopia",
 			"notecount": 1061
 		},
 		"difficulty": "Future",
@@ -2498,7 +2498,7 @@
 	{
 		"chartID": "8af9f25c81b014f4891cb55f2f2a4b07e5064f66",
 		"data": {
-			"inGameID": "harutopia",
+			"inGameStrID": "harutopia",
 			"notecount": 444
 		},
 		"difficulty": "Past",
@@ -2514,7 +2514,7 @@
 	{
 		"chartID": "b4d5128448e73c085215fe2e6ead17a3065d1e5e",
 		"data": {
-			"inGameID": "harutopia",
+			"inGameStrID": "harutopia",
 			"notecount": 706
 		},
 		"difficulty": "Present",
@@ -2530,7 +2530,7 @@
 	{
 		"chartID": "802f564b632ba2b94f5d3b28ba20df8ae86314fc",
 		"data": {
-			"inGameID": "auxesia",
+			"inGameStrID": "auxesia",
 			"notecount": 1000
 		},
 		"difficulty": "Future",
@@ -2546,7 +2546,7 @@
 	{
 		"chartID": "9429404e1b4dbc7e4f968918811398d20a210c76",
 		"data": {
-			"inGameID": "auxesia",
+			"inGameStrID": "auxesia",
 			"notecount": 385
 		},
 		"difficulty": "Past",
@@ -2562,7 +2562,7 @@
 	{
 		"chartID": "abde359b2f32f880348c33c1660482af9e2ea262",
 		"data": {
-			"inGameID": "auxesia",
+			"inGameStrID": "auxesia",
 			"notecount": 648
 		},
 		"difficulty": "Present",
@@ -2578,7 +2578,7 @@
 	{
 		"chartID": "d78c5f008cdfc744ccbea7d1dfd67f5c58bd0924",
 		"data": {
-			"inGameID": "rabbitintheblackroom",
+			"inGameStrID": "rabbitintheblackroom",
 			"notecount": 772
 		},
 		"difficulty": "Future",
@@ -2594,7 +2594,7 @@
 	{
 		"chartID": "ac852a1ef180863c6ce581f85497d9e4ca584d0b",
 		"data": {
-			"inGameID": "rabbitintheblackroom",
+			"inGameStrID": "rabbitintheblackroom",
 			"notecount": 373
 		},
 		"difficulty": "Past",
@@ -2610,7 +2610,7 @@
 	{
 		"chartID": "0c4e21312442075487988550acc254945eb9d160",
 		"data": {
-			"inGameID": "rabbitintheblackroom",
+			"inGameStrID": "rabbitintheblackroom",
 			"notecount": 467
 		},
 		"difficulty": "Present",
@@ -2626,7 +2626,7 @@
 	{
 		"chartID": "224d6cf87f135f35f4bd1149c34a352bce93e00a",
 		"data": {
-			"inGameID": "modelista",
+			"inGameStrID": "modelista",
 			"notecount": 1010
 		},
 		"difficulty": "Future",
@@ -2642,7 +2642,7 @@
 	{
 		"chartID": "939ee689cda4b13c830fc10339b53514f00520ad",
 		"data": {
-			"inGameID": "modelista",
+			"inGameStrID": "modelista",
 			"notecount": 418
 		},
 		"difficulty": "Past",
@@ -2658,7 +2658,7 @@
 	{
 		"chartID": "a655059094aa95c7935563160729a4cac0437b34",
 		"data": {
-			"inGameID": "modelista",
+			"inGameStrID": "modelista",
 			"notecount": 691
 		},
 		"difficulty": "Present",
@@ -2674,7 +2674,7 @@
 	{
 		"chartID": "c3cf93aa0603222a925c87a4a56b193d39131f7e",
 		"data": {
-			"inGameID": "soundwitch",
+			"inGameStrID": "soundwitch",
 			"notecount": 785
 		},
 		"difficulty": "Future",
@@ -2690,7 +2690,7 @@
 	{
 		"chartID": "50c03f459cfb560984dc6d97abe00365515c9107",
 		"data": {
-			"inGameID": "soundwitch",
+			"inGameStrID": "soundwitch",
 			"notecount": 315
 		},
 		"difficulty": "Past",
@@ -2706,7 +2706,7 @@
 	{
 		"chartID": "b0cbbb592737e3396b1f66ae5e32bdb4158fb1c1",
 		"data": {
-			"inGameID": "soundwitch",
+			"inGameStrID": "soundwitch",
 			"notecount": 488
 		},
 		"difficulty": "Present",
@@ -2722,7 +2722,7 @@
 	{
 		"chartID": "b20150a691b46a3570721343ec26d5b6d42211fc",
 		"data": {
-			"inGameID": "trappola",
+			"inGameStrID": "trappola",
 			"notecount": 1086
 		},
 		"difficulty": "Beyond",
@@ -2738,7 +2738,7 @@
 	{
 		"chartID": "436608368455d840cb49332cef30eb030e72d2ec",
 		"data": {
-			"inGameID": "trappola",
+			"inGameStrID": "trappola",
 			"notecount": 1044
 		},
 		"difficulty": "Future",
@@ -2754,7 +2754,7 @@
 	{
 		"chartID": "a273aa857fd0aa02c105234e93eda408c815dd51",
 		"data": {
-			"inGameID": "trappola",
+			"inGameStrID": "trappola",
 			"notecount": 415
 		},
 		"difficulty": "Past",
@@ -2770,7 +2770,7 @@
 	{
 		"chartID": "c96767de02cdf5b9ad78dca5b478c5fc6c095854",
 		"data": {
-			"inGameID": "trappola",
+			"inGameStrID": "trappola",
 			"notecount": 541
 		},
 		"difficulty": "Present",
@@ -2786,7 +2786,7 @@
 	{
 		"chartID": "bf4385e3069c59ed17d99476254bb274b87a770a",
 		"data": {
-			"inGameID": "iconoclast",
+			"inGameStrID": "iconoclast",
 			"notecount": 795
 		},
 		"difficulty": "Future",
@@ -2802,7 +2802,7 @@
 	{
 		"chartID": "806370b9480fef407a610eb9a4bc9dbe0197638f",
 		"data": {
-			"inGameID": "iconoclast",
+			"inGameStrID": "iconoclast",
 			"notecount": 443
 		},
 		"difficulty": "Past",
@@ -2818,7 +2818,7 @@
 	{
 		"chartID": "4c3dfc0f8da271971016b94b34cd7515f6c63a87",
 		"data": {
-			"inGameID": "iconoclast",
+			"inGameStrID": "iconoclast",
 			"notecount": 593
 		},
 		"difficulty": "Present",
@@ -2834,7 +2834,7 @@
 	{
 		"chartID": "f351d391770f29138243dc47e0c843e00c636c94",
 		"data": {
-			"inGameID": "conflict",
+			"inGameStrID": "conflict",
 			"notecount": 1056
 		},
 		"difficulty": "Future",
@@ -2850,7 +2850,7 @@
 	{
 		"chartID": "cb8ef06f447bfc40ad98dbc022db8260121a3d9f",
 		"data": {
-			"inGameID": "conflict",
+			"inGameStrID": "conflict",
 			"notecount": 520
 		},
 		"difficulty": "Past",
@@ -2866,7 +2866,7 @@
 	{
 		"chartID": "816f71729b2e178d4e4521134acb0ca2be561fe9",
 		"data": {
-			"inGameID": "conflict",
+			"inGameStrID": "conflict",
 			"notecount": 731
 		},
 		"difficulty": "Present",
@@ -2882,7 +2882,7 @@
 	{
 		"chartID": "012e1020fbe7f03e7c36d02e56a15e641cc9b9a4",
 		"data": {
-			"inGameID": "axiumcrisis",
+			"inGameStrID": "axiumcrisis",
 			"notecount": 1094
 		},
 		"difficulty": "Future",
@@ -2898,7 +2898,7 @@
 	{
 		"chartID": "afee056a3f64ecacdfcd1e25c0c0a51a7abd2693",
 		"data": {
-			"inGameID": "axiumcrisis",
+			"inGameStrID": "axiumcrisis",
 			"notecount": 685
 		},
 		"difficulty": "Past",
@@ -2914,7 +2914,7 @@
 	{
 		"chartID": "665e312749b2ad1d7ea2ca1a6b08a5e98aceec49",
 		"data": {
-			"inGameID": "axiumcrisis",
+			"inGameStrID": "axiumcrisis",
 			"notecount": 1065
 		},
 		"difficulty": "Present",
@@ -2930,7 +2930,7 @@
 	{
 		"chartID": "5e7baa2b68395f2590b49fee23f6394aee5f1fbd",
 		"data": {
-			"inGameID": "grievouslady",
+			"inGameStrID": "grievouslady",
 			"notecount": 1450
 		},
 		"difficulty": "Future",
@@ -2946,7 +2946,7 @@
 	{
 		"chartID": "76f504c828d1dddf639799abaaf189fc8941a911",
 		"data": {
-			"inGameID": "grievouslady",
+			"inGameStrID": "grievouslady",
 			"notecount": 956
 		},
 		"difficulty": "Past",
@@ -2962,7 +2962,7 @@
 	{
 		"chartID": "f46be58a266db97c19cbf9bc08090da0dcd9a6c6",
 		"data": {
-			"inGameID": "grievouslady",
+			"inGameStrID": "grievouslady",
 			"notecount": 1194
 		},
 		"difficulty": "Present",
@@ -2978,7 +2978,7 @@
 	{
 		"chartID": "b5c6d5f4b324bf37e170ee9dab419ac524551d46",
 		"data": {
-			"inGameID": "dreaminattraction",
+			"inGameStrID": "dreaminattraction",
 			"notecount": 1129
 		},
 		"difficulty": "Future",
@@ -2994,7 +2994,7 @@
 	{
 		"chartID": "be8d425c761c48906b378e723cc2b512093f1e18",
 		"data": {
-			"inGameID": "dreaminattraction",
+			"inGameStrID": "dreaminattraction",
 			"notecount": 592
 		},
 		"difficulty": "Past",
@@ -3010,7 +3010,7 @@
 	{
 		"chartID": "d441441ea51808efb3646bc4453827f7a6119fda",
 		"data": {
-			"inGameID": "dreaminattraction",
+			"inGameStrID": "dreaminattraction",
 			"notecount": 785
 		},
 		"difficulty": "Present",
@@ -3026,7 +3026,7 @@
 	{
 		"chartID": "1ff6262d995c4111fee7f32a7b26a42ac185a0a5",
 		"data": {
-			"inGameID": "redandblue",
+			"inGameStrID": "redandblue",
 			"notecount": 845
 		},
 		"difficulty": "Future",
@@ -3042,7 +3042,7 @@
 	{
 		"chartID": "8b2ae4651acfe001ef3514383e515ddc7464f669",
 		"data": {
-			"inGameID": "redandblue",
+			"inGameStrID": "redandblue",
 			"notecount": 464
 		},
 		"difficulty": "Past",
@@ -3058,7 +3058,7 @@
 	{
 		"chartID": "6aa11c6da7dad064dc4211f8f6af6f668ab18630",
 		"data": {
-			"inGameID": "redandblue",
+			"inGameStrID": "redandblue",
 			"notecount": 597
 		},
 		"difficulty": "Present",
@@ -3074,7 +3074,7 @@
 	{
 		"chartID": "e43105d6fc625a5ac90273e07611a242315f4dba",
 		"data": {
-			"inGameID": "redandblue",
+			"inGameStrID": "redandblue",
 			"notecount": 1194
 		},
 		"difficulty": "Beyond",
@@ -3090,7 +3090,7 @@
 	{
 		"chartID": "c3086c579aebbe880612aaeb3ccd134661b629d0",
 		"data": {
-			"inGameID": "onelastdrive",
+			"inGameStrID": "onelastdrive",
 			"notecount": 885
 		},
 		"difficulty": "Future",
@@ -3106,7 +3106,7 @@
 	{
 		"chartID": "66fd070a6081b3936426e74e0d69dff6e58aba04",
 		"data": {
-			"inGameID": "onelastdrive",
+			"inGameStrID": "onelastdrive",
 			"notecount": 604
 		},
 		"difficulty": "Past",
@@ -3122,7 +3122,7 @@
 	{
 		"chartID": "894cbc65843d696599ad8dbb8c5fe0839ae043f4",
 		"data": {
-			"inGameID": "onelastdrive",
+			"inGameStrID": "onelastdrive",
 			"notecount": 564
 		},
 		"difficulty": "Present",
@@ -3138,7 +3138,7 @@
 	{
 		"chartID": "1024d36bb8e302554ac076f6178e77e327cfa8fb",
 		"data": {
-			"inGameID": "surrender",
+			"inGameStrID": "surrender",
 			"notecount": 925
 		},
 		"difficulty": "Future",
@@ -3154,7 +3154,7 @@
 	{
 		"chartID": "86e669ca85ff25ee12af0af7154a8703e0cda7bf",
 		"data": {
-			"inGameID": "surrender",
+			"inGameStrID": "surrender",
 			"notecount": 550
 		},
 		"difficulty": "Past",
@@ -3170,7 +3170,7 @@
 	{
 		"chartID": "dd5895d657a10269b698e81c00a5f06a3e2f19c8",
 		"data": {
-			"inGameID": "surrender",
+			"inGameStrID": "surrender",
 			"notecount": 721
 		},
 		"difficulty": "Present",
@@ -3186,7 +3186,7 @@
 	{
 		"chartID": "3005e40578058d3ab2ee655e2f6902fea733d637",
 		"data": {
-			"inGameID": "yozakurafubuki",
+			"inGameStrID": "yozakurafubuki",
 			"notecount": 931
 		},
 		"difficulty": "Future",
@@ -3202,7 +3202,7 @@
 	{
 		"chartID": "34a144097b7e829e8c3a01b17c84c51c8217d94f",
 		"data": {
-			"inGameID": "yozakurafubuki",
+			"inGameStrID": "yozakurafubuki",
 			"notecount": 416
 		},
 		"difficulty": "Past",
@@ -3218,7 +3218,7 @@
 	{
 		"chartID": "9ec0383da66190f0b8ae9a66a19544859a2ea49d",
 		"data": {
-			"inGameID": "yozakurafubuki",
+			"inGameStrID": "yozakurafubuki",
 			"notecount": 582
 		},
 		"difficulty": "Present",
@@ -3234,7 +3234,7 @@
 	{
 		"chartID": "7167783fadf3a4fa0d0360c46a4fe08750e8328e",
 		"data": {
-			"inGameID": "cyanine",
+			"inGameStrID": "cyanine",
 			"notecount": 1171
 		},
 		"difficulty": "Future",
@@ -3250,7 +3250,7 @@
 	{
 		"chartID": "c46a7f776f88dff090a7327186b1b3f7776b196f",
 		"data": {
-			"inGameID": "cyanine",
+			"inGameStrID": "cyanine",
 			"notecount": 661
 		},
 		"difficulty": "Past",
@@ -3266,7 +3266,7 @@
 	{
 		"chartID": "661e5990b15e8d1e4d0cc3366731cff18121a425",
 		"data": {
-			"inGameID": "cyanine",
+			"inGameStrID": "cyanine",
 			"notecount": 947
 		},
 		"difficulty": "Present",
@@ -3282,7 +3282,7 @@
 	{
 		"chartID": "956e50d9a8a248e0346a3d331f748f4bd90b2053",
 		"data": {
-			"inGameID": "dreamgoeson",
+			"inGameStrID": "dreamgoeson",
 			"notecount": 719
 		},
 		"difficulty": "Future",
@@ -3298,7 +3298,7 @@
 	{
 		"chartID": "1fe4bcb6537b656b2a7893ac18bb76f1eee4685b",
 		"data": {
-			"inGameID": "dreamgoeson",
+			"inGameStrID": "dreamgoeson",
 			"notecount": 532
 		},
 		"difficulty": "Past",
@@ -3314,7 +3314,7 @@
 	{
 		"chartID": "1cdd1d49b600a8ad72096d0a61d6cbd41f4ada1c",
 		"data": {
-			"inGameID": "dreamgoeson",
+			"inGameStrID": "dreamgoeson",
 			"notecount": 751
 		},
 		"difficulty": "Present",
@@ -3330,7 +3330,7 @@
 	{
 		"chartID": "f1b4f76cd82c2d1e9a7f9730059123fdde874284",
 		"data": {
-			"inGameID": "journey",
+			"inGameStrID": "journey",
 			"notecount": 997
 		},
 		"difficulty": "Future",
@@ -3346,7 +3346,7 @@
 	{
 		"chartID": "020d6c18d5f900f2ba65fb41eb59a891fc14e7ea",
 		"data": {
-			"inGameID": "journey",
+			"inGameStrID": "journey",
 			"notecount": 551
 		},
 		"difficulty": "Past",
@@ -3362,7 +3362,7 @@
 	{
 		"chartID": "4bf45cc3e9600de9be978ac6ebb22a04aedd777f",
 		"data": {
-			"inGameID": "journey",
+			"inGameStrID": "journey",
 			"notecount": 778
 		},
 		"difficulty": "Present",
@@ -3378,7 +3378,7 @@
 	{
 		"chartID": "5c97bf06e95c0cdc4fd6be4336a7c422f3ce5c83",
 		"data": {
-			"inGameID": "specta",
+			"inGameStrID": "specta",
 			"notecount": 1096
 		},
 		"difficulty": "Future",
@@ -3394,7 +3394,7 @@
 	{
 		"chartID": "9311c3012eed466e99fc4521bf204f59e5d57b33",
 		"data": {
-			"inGameID": "specta",
+			"inGameStrID": "specta",
 			"notecount": 390
 		},
 		"difficulty": "Past",
@@ -3410,7 +3410,7 @@
 	{
 		"chartID": "b59e3367ee8f5d452338f72c3c8c9fe8b4f2aa82",
 		"data": {
-			"inGameID": "specta",
+			"inGameStrID": "specta",
 			"notecount": 706
 		},
 		"difficulty": "Present",
@@ -3426,7 +3426,7 @@
 	{
 		"chartID": "6d709c45ea4b10c3ac1b9e2258379293d1888079",
 		"data": {
-			"inGameID": "quon",
+			"inGameStrID": "quon",
 			"notecount": 991
 		},
 		"difficulty": "Future",
@@ -3442,7 +3442,7 @@
 	{
 		"chartID": "99c044ef72cba0e7724e4fe91301ccd6a7049f3a",
 		"data": {
-			"inGameID": "quon",
+			"inGameStrID": "quon",
 			"notecount": 547
 		},
 		"difficulty": "Past",
@@ -3458,7 +3458,7 @@
 	{
 		"chartID": "9722f24e1b68d12b0a2c0095aaa826999151eb59",
 		"data": {
-			"inGameID": "quon",
+			"inGameStrID": "quon",
 			"notecount": 718
 		},
 		"difficulty": "Present",
@@ -3474,7 +3474,7 @@
 	{
 		"chartID": "b279455709d2a2c291ef9515ff90aa2581e08e3d",
 		"data": {
-			"inGameID": "syro",
+			"inGameStrID": "syro",
 			"notecount": 1150
 		},
 		"difficulty": "Future",
@@ -3490,7 +3490,7 @@
 	{
 		"chartID": "eae1ef50d1ae931cc26f1f4b32621bb374cc730f",
 		"data": {
-			"inGameID": "syro",
+			"inGameStrID": "syro",
 			"notecount": 535
 		},
 		"difficulty": "Past",
@@ -3506,7 +3506,7 @@
 	{
 		"chartID": "0add6d94673f5bd098f93285aa8a3f25aab0a6b2",
 		"data": {
-			"inGameID": "syro",
+			"inGameStrID": "syro",
 			"notecount": 829
 		},
 		"difficulty": "Present",
@@ -3522,7 +3522,7 @@
 	{
 		"chartID": "6e36a6400e3afd46cf9c3a02409de98ab376aa4c",
 		"data": {
-			"inGameID": "reinvent",
+			"inGameStrID": "reinvent",
 			"notecount": 852
 		},
 		"difficulty": "Future",
@@ -3538,7 +3538,7 @@
 	{
 		"chartID": "0976aaca0c66ac490f7d74781316997bbb1560a6",
 		"data": {
-			"inGameID": "reinvent",
+			"inGameStrID": "reinvent",
 			"notecount": 570
 		},
 		"difficulty": "Past",
@@ -3554,7 +3554,7 @@
 	{
 		"chartID": "1dba3f61a1d1dcfc2ccc916d5ec7a35dcc82f22a",
 		"data": {
-			"inGameID": "reinvent",
+			"inGameStrID": "reinvent",
 			"notecount": 703
 		},
 		"difficulty": "Present",
@@ -3570,7 +3570,7 @@
 	{
 		"chartID": "e259c1e43c223ad9f642b94df2640939ebaf654d",
 		"data": {
-			"inGameID": "silentrush",
+			"inGameStrID": "silentrush",
 			"notecount": 941
 		},
 		"difficulty": "Future",
@@ -3586,7 +3586,7 @@
 	{
 		"chartID": "3ae4eb5e15245d47b22265fb3aaf983623049145",
 		"data": {
-			"inGameID": "silentrush",
+			"inGameStrID": "silentrush",
 			"notecount": 416
 		},
 		"difficulty": "Past",
@@ -3602,7 +3602,7 @@
 	{
 		"chartID": "b0424e44e27b32acafd6fd380f693c5de8e6cc9e",
 		"data": {
-			"inGameID": "silentrush",
+			"inGameStrID": "silentrush",
 			"notecount": 674
 		},
 		"difficulty": "Present",
@@ -3618,7 +3618,7 @@
 	{
 		"chartID": "539dee6eeceb19b3c8ff4e41d2048f9a0d82d4a6",
 		"data": {
-			"inGameID": "singularity",
+			"inGameStrID": "singularity",
 			"notecount": 1105
 		},
 		"difficulty": "Future",
@@ -3634,7 +3634,7 @@
 	{
 		"chartID": "3f5d05371c7236fdeace76fa6be01b14c78971c6",
 		"data": {
-			"inGameID": "singularity",
+			"inGameStrID": "singularity",
 			"notecount": 534
 		},
 		"difficulty": "Past",
@@ -3650,7 +3650,7 @@
 	{
 		"chartID": "22e80fbe45d3248f471ab1d421d3a29ed6c601a2",
 		"data": {
-			"inGameID": "singularity",
+			"inGameStrID": "singularity",
 			"notecount": 678
 		},
 		"difficulty": "Present",
@@ -3666,7 +3666,7 @@
 	{
 		"chartID": "ed5842da92202fd9b3dad248f960b2c7a1f41559",
 		"data": {
-			"inGameID": "singularity",
+			"inGameStrID": "singularity",
 			"notecount": 1114
 		},
 		"difficulty": "Beyond",
@@ -3682,7 +3682,7 @@
 	{
 		"chartID": "71794bc07b0a0e6d07d32bf2f69bf34b46f1f2d9",
 		"data": {
-			"inGameID": "memoryforest",
+			"inGameStrID": "memoryforest",
 			"notecount": 978
 		},
 		"difficulty": "Future",
@@ -3698,7 +3698,7 @@
 	{
 		"chartID": "84c9248044ccf840e0754850b99e2f9f598c755d",
 		"data": {
-			"inGameID": "memoryforest",
+			"inGameStrID": "memoryforest",
 			"notecount": 639
 		},
 		"difficulty": "Past",
@@ -3714,7 +3714,7 @@
 	{
 		"chartID": "0bb4e24938a6a2b8e9b875f9586ad3af26978259",
 		"data": {
-			"inGameID": "memoryforest",
+			"inGameStrID": "memoryforest",
 			"notecount": 726
 		},
 		"difficulty": "Present",
@@ -3730,7 +3730,7 @@
 	{
 		"chartID": "ef902f24c6733edc29008911b9083473912d5e80",
 		"data": {
-			"inGameID": "strongholds",
+			"inGameStrID": "strongholds",
 			"notecount": 922
 		},
 		"difficulty": "Future",
@@ -3746,7 +3746,7 @@
 	{
 		"chartID": "3bd55bf2c06608824e59a0bc44508b42c037b81f",
 		"data": {
-			"inGameID": "strongholds",
+			"inGameStrID": "strongholds",
 			"notecount": 570
 		},
 		"difficulty": "Past",
@@ -3762,7 +3762,7 @@
 	{
 		"chartID": "940b684c220f0b95044b549f66fdab871a309b41",
 		"data": {
-			"inGameID": "strongholds",
+			"inGameStrID": "strongholds",
 			"notecount": 778
 		},
 		"difficulty": "Present",
@@ -3778,7 +3778,7 @@
 	{
 		"chartID": "1efa2677c0b5be9ce35ed6fd2e0f1ac6978ef0df",
 		"data": {
-			"inGameID": "nexttoyou",
+			"inGameStrID": "nexttoyou",
 			"notecount": 954
 		},
 		"difficulty": "Beyond",
@@ -3794,7 +3794,7 @@
 	{
 		"chartID": "e2268eb66929d3caf8cd6afa5aacf028a7aba84a",
 		"data": {
-			"inGameID": "nexttoyou",
+			"inGameStrID": "nexttoyou",
 			"notecount": 824
 		},
 		"difficulty": "Future",
@@ -3810,7 +3810,7 @@
 	{
 		"chartID": "ab128cae24c706840c4f7f4b94baeb905bbb44fc",
 		"data": {
-			"inGameID": "nexttoyou",
+			"inGameStrID": "nexttoyou",
 			"notecount": 454
 		},
 		"difficulty": "Past",
@@ -3826,7 +3826,7 @@
 	{
 		"chartID": "227f58eace04d2fcb2d2d32e87a9a59ef57e3c90",
 		"data": {
-			"inGameID": "nexttoyou",
+			"inGameStrID": "nexttoyou",
 			"notecount": 583
 		},
 		"difficulty": "Present",
@@ -3842,7 +3842,7 @@
 	{
 		"chartID": "4b9d0cceaf9bbe3dc3fd3c90d794ab7af0395258",
 		"data": {
-			"inGameID": "metallicpunisher",
+			"inGameStrID": "metallicpunisher",
 			"notecount": 1238
 		},
 		"difficulty": "Future",
@@ -3858,7 +3858,7 @@
 	{
 		"chartID": "a75aaea69f19ebb33e4c500e46ccfdbb35c5b135",
 		"data": {
-			"inGameID": "metallicpunisher",
+			"inGameStrID": "metallicpunisher",
 			"notecount": 500
 		},
 		"difficulty": "Past",
@@ -3874,7 +3874,7 @@
 	{
 		"chartID": "02c8ecdc562cc448abdd313592c096dd80f14916",
 		"data": {
-			"inGameID": "metallicpunisher",
+			"inGameStrID": "metallicpunisher",
 			"notecount": 846
 		},
 		"difficulty": "Present",
@@ -3890,7 +3890,7 @@
 	{
 		"chartID": "1dc827919d1cedbc5e6d5a2aa7911d593a8c590a",
 		"data": {
-			"inGameID": "blaster",
+			"inGameStrID": "blaster",
 			"notecount": 1002
 		},
 		"difficulty": "Future",
@@ -3906,7 +3906,7 @@
 	{
 		"chartID": "b17b9791823e08df5d74b3a65b0e8d1317a60069",
 		"data": {
-			"inGameID": "blaster",
+			"inGameStrID": "blaster",
 			"notecount": 571
 		},
 		"difficulty": "Past",
@@ -3922,7 +3922,7 @@
 	{
 		"chartID": "c7adcc4204352d5758485ea56216323b9085d3b5",
 		"data": {
-			"inGameID": "blaster",
+			"inGameStrID": "blaster",
 			"notecount": 635
 		},
 		"difficulty": "Present",
@@ -3938,7 +3938,7 @@
 	{
 		"chartID": "d9bc3c3dc662c3f1ac4cfd1d2fd5eb25181311b5",
 		"data": {
-			"inGameID": "guardina",
+			"inGameStrID": "guardina",
 			"notecount": 1120
 		},
 		"difficulty": "Future",
@@ -3954,7 +3954,7 @@
 	{
 		"chartID": "da3c21ef5321f207c3ab9b48ea23b9a8cb37f9c7",
 		"data": {
-			"inGameID": "guardina",
+			"inGameStrID": "guardina",
 			"notecount": 507
 		},
 		"difficulty": "Past",
@@ -3970,7 +3970,7 @@
 	{
 		"chartID": "b347db32fbe280f1197751d8c5f493e18549ffd3",
 		"data": {
-			"inGameID": "guardina",
+			"inGameStrID": "guardina",
 			"notecount": 678
 		},
 		"difficulty": "Present",
@@ -3986,7 +3986,7 @@
 	{
 		"chartID": "cd4b13b3f6725dc6b349c3f2a5c58a568161f842",
 		"data": {
-			"inGameID": "carminescythe",
+			"inGameStrID": "carminescythe",
 			"notecount": 1164
 		},
 		"difficulty": "Future",
@@ -4002,7 +4002,7 @@
 	{
 		"chartID": "c9e134050ffa21c351fa1c667c01fc7dffc9def2",
 		"data": {
-			"inGameID": "carminescythe",
+			"inGameStrID": "carminescythe",
 			"notecount": 493
 		},
 		"difficulty": "Past",
@@ -4018,7 +4018,7 @@
 	{
 		"chartID": "55e87516635485216f1eadf0756e2dc65520e79d",
 		"data": {
-			"inGameID": "carminescythe",
+			"inGameStrID": "carminescythe",
 			"notecount": 710
 		},
 		"difficulty": "Present",
@@ -4034,7 +4034,7 @@
 	{
 		"chartID": "05273735d20f2cf0ce62abd76c81877bf228f5c6",
 		"data": {
-			"inGameID": "bethere",
+			"inGameStrID": "bethere",
 			"notecount": 982
 		},
 		"difficulty": "Future",
@@ -4050,7 +4050,7 @@
 	{
 		"chartID": "a10a2eb6554cc09104b34a317f354e4850d16c4c",
 		"data": {
-			"inGameID": "bethere",
+			"inGameStrID": "bethere",
 			"notecount": 592
 		},
 		"difficulty": "Past",
@@ -4066,7 +4066,7 @@
 	{
 		"chartID": "54d250d448376174ecf070930f48b2d9dfc1b50d",
 		"data": {
-			"inGameID": "bethere",
+			"inGameStrID": "bethere",
 			"notecount": 792
 		},
 		"difficulty": "Present",
@@ -4082,7 +4082,7 @@
 	{
 		"chartID": "3c4f917b3eae8a40e0274b2323ff080882c490a4",
 		"data": {
-			"inGameID": "cyberneciacatharsis",
+			"inGameStrID": "cyberneciacatharsis",
 			"notecount": 946
 		},
 		"difficulty": "Future",
@@ -4098,7 +4098,7 @@
 	{
 		"chartID": "e080b5d155d3b5fd39e03988138d5e8fc0a0033a",
 		"data": {
-			"inGameID": "cyberneciacatharsis",
+			"inGameStrID": "cyberneciacatharsis",
 			"notecount": 377
 		},
 		"difficulty": "Past",
@@ -4114,7 +4114,7 @@
 	{
 		"chartID": "c9fbbc42bb06d39098c9102e6bade3d095c5ed79",
 		"data": {
-			"inGameID": "cyberneciacatharsis",
+			"inGameStrID": "cyberneciacatharsis",
 			"notecount": 655
 		},
 		"difficulty": "Present",
@@ -4130,7 +4130,7 @@
 	{
 		"chartID": "c58b44e09f1861b3ff63cfd198924ac2215f45e4",
 		"data": {
-			"inGameID": "callmyname",
+			"inGameStrID": "callmyname",
 			"notecount": 921
 		},
 		"difficulty": "Future",
@@ -4146,7 +4146,7 @@
 	{
 		"chartID": "db9446d74c091cb761fce19858b5cbd2549419a1",
 		"data": {
-			"inGameID": "callmyname",
+			"inGameStrID": "callmyname",
 			"notecount": 591
 		},
 		"difficulty": "Past",
@@ -4162,7 +4162,7 @@
 	{
 		"chartID": "da85109aed4c58c22940a5455c9b4e1917655908",
 		"data": {
-			"inGameID": "callmyname",
+			"inGameStrID": "callmyname",
 			"notecount": 653
 		},
 		"difficulty": "Present",
@@ -4178,7 +4178,7 @@
 	{
 		"chartID": "0a6f8d916176fc340ffc5138e4177a50b6b256a5",
 		"data": {
-			"inGameID": "inkarusi",
+			"inGameStrID": "inkarusi",
 			"notecount": 463
 		},
 		"difficulty": "Future",
@@ -4194,7 +4194,7 @@
 	{
 		"chartID": "69cd32ce7725dd262ce671aa7d21f49c6926a84d",
 		"data": {
-			"inGameID": "inkarusi",
+			"inGameStrID": "inkarusi",
 			"notecount": 276
 		},
 		"difficulty": "Past",
@@ -4210,7 +4210,7 @@
 	{
 		"chartID": "5ea993139d36b7a0b97877933a52983488d5e19b",
 		"data": {
-			"inGameID": "inkarusi",
+			"inGameStrID": "inkarusi",
 			"notecount": 326
 		},
 		"difficulty": "Present",
@@ -4226,7 +4226,7 @@
 	{
 		"chartID": "70eb594419c6ebc2571f281bce04353de5c0a396",
 		"data": {
-			"inGameID": "mazenine",
+			"inGameStrID": "mazenine",
 			"notecount": 775
 		},
 		"difficulty": "Future",
@@ -4242,7 +4242,7 @@
 	{
 		"chartID": "a171612fd532235b3b570856f3e627158e7598df",
 		"data": {
-			"inGameID": "mazenine",
+			"inGameStrID": "mazenine",
 			"notecount": 494
 		},
 		"difficulty": "Past",
@@ -4258,7 +4258,7 @@
 	{
 		"chartID": "c930fc24ea1ba42e7750cb1b932dd50668c45603",
 		"data": {
-			"inGameID": "mazenine",
+			"inGameStrID": "mazenine",
 			"notecount": 445
 		},
 		"difficulty": "Present",
@@ -4274,7 +4274,7 @@
 	{
 		"chartID": "25989f8b1794b963497984bc9e3306cae101f8a8",
 		"data": {
-			"inGameID": "themessage",
+			"inGameStrID": "themessage",
 			"notecount": 992
 		},
 		"difficulty": "Future",
@@ -4290,7 +4290,7 @@
 	{
 		"chartID": "82c2afd4ec6c8fdf53f07555042539f7c9e0b5a6",
 		"data": {
-			"inGameID": "themessage",
+			"inGameStrID": "themessage",
 			"notecount": 536
 		},
 		"difficulty": "Past",
@@ -4306,7 +4306,7 @@
 	{
 		"chartID": "1c9097e637211e43457685198b6f52c629dea542",
 		"data": {
-			"inGameID": "themessage",
+			"inGameStrID": "themessage",
 			"notecount": 630
 		},
 		"difficulty": "Present",
@@ -4322,7 +4322,7 @@
 	{
 		"chartID": "bddef5e7930b5b396595eef9df6056295b576c05",
 		"data": {
-			"inGameID": "sulfur",
+			"inGameStrID": "sulfur",
 			"notecount": 1045
 		},
 		"difficulty": "Future",
@@ -4338,7 +4338,7 @@
 	{
 		"chartID": "ca1436fd616c5b099ccbd6dcf5f8d99c9ebfd15e",
 		"data": {
-			"inGameID": "sulfur",
+			"inGameStrID": "sulfur",
 			"notecount": 458
 		},
 		"difficulty": "Past",
@@ -4354,7 +4354,7 @@
 	{
 		"chartID": "0acbbac04862320d0ef97735d3990e471132200b",
 		"data": {
-			"inGameID": "sulfur",
+			"inGameStrID": "sulfur",
 			"notecount": 608
 		},
 		"difficulty": "Present",
@@ -4370,7 +4370,7 @@
 	{
 		"chartID": "a08253b94995d63aa6a84582f3d9c642a11da74e",
 		"data": {
-			"inGameID": "halcyon",
+			"inGameStrID": "halcyon",
 			"notecount": 1227
 		},
 		"difficulty": "Future",
@@ -4386,7 +4386,7 @@
 	{
 		"chartID": "150cbf0ef7dd608a1acefabf701ee02399afa6d3",
 		"data": {
-			"inGameID": "halcyon",
+			"inGameStrID": "halcyon",
 			"notecount": 662
 		},
 		"difficulty": "Past",
@@ -4402,7 +4402,7 @@
 	{
 		"chartID": "b33467127542f81753e9c7fef142965f76d6bd28",
 		"data": {
-			"inGameID": "halcyon",
+			"inGameStrID": "halcyon",
 			"notecount": 943
 		},
 		"difficulty": "Present",
@@ -4418,7 +4418,7 @@
 	{
 		"chartID": "02e9a8e69dd55d0499006a58b4d5be076651245c",
 		"data": {
-			"inGameID": "etherstrike",
+			"inGameStrID": "etherstrike",
 			"notecount": 1170
 		},
 		"difficulty": "Future",
@@ -4434,7 +4434,7 @@
 	{
 		"chartID": "29b99b2ae86ffc440a8cefeb59a137562ee24273",
 		"data": {
-			"inGameID": "etherstrike",
+			"inGameStrID": "etherstrike",
 			"notecount": 659
 		},
 		"difficulty": "Past",
@@ -4450,7 +4450,7 @@
 	{
 		"chartID": "a7099c1206854a4ef0a8781bfb098428daae1e11",
 		"data": {
-			"inGameID": "etherstrike",
+			"inGameStrID": "etherstrike",
 			"notecount": 837
 		},
 		"difficulty": "Present",
@@ -4466,7 +4466,7 @@
 	{
 		"chartID": "9d3ddec8b98f4b8cd3e55dc91223c14f5b01a405",
 		"data": {
-			"inGameID": "fractureray",
+			"inGameStrID": "fractureray",
 			"notecount": 1279
 		},
 		"difficulty": "Future",
@@ -4482,7 +4482,7 @@
 	{
 		"chartID": "dcdd7ec8d9996a5d520645b6cf3004445dc792c7",
 		"data": {
-			"inGameID": "fractureray",
+			"inGameStrID": "fractureray",
 			"notecount": 983
 		},
 		"difficulty": "Past",
@@ -4498,7 +4498,7 @@
 	{
 		"chartID": "1f6dfcf427e01518c86ba705ae2a057bf7878e26",
 		"data": {
-			"inGameID": "fractureray",
+			"inGameStrID": "fractureray",
 			"notecount": 1343
 		},
 		"difficulty": "Present",
@@ -4514,7 +4514,7 @@
 	{
 		"chartID": "0e3a9f726ecc56c6b75c0c6305318cd7e9a2c940",
 		"data": {
-			"inGameID": "suomi",
+			"inGameStrID": "suomi",
 			"notecount": 818
 		},
 		"difficulty": "Future",
@@ -4530,7 +4530,7 @@
 	{
 		"chartID": "276d296322b66c32784a1e0135e7e5bd23d95ca9",
 		"data": {
-			"inGameID": "suomi",
+			"inGameStrID": "suomi",
 			"notecount": 368
 		},
 		"difficulty": "Past",
@@ -4546,7 +4546,7 @@
 	{
 		"chartID": "3cd1ea87a8d9ef76bae7b45ae12ea40b74fe40f1",
 		"data": {
-			"inGameID": "suomi",
+			"inGameStrID": "suomi",
 			"notecount": 550
 		},
 		"difficulty": "Present",
@@ -4562,7 +4562,7 @@
 	{
 		"chartID": "5d63271c2cef61a1c0f8c04916986668fc80e325",
 		"data": {
-			"inGameID": "bookmaker",
+			"inGameStrID": "bookmaker",
 			"notecount": 1287
 		},
 		"difficulty": "Beyond",
@@ -4578,7 +4578,7 @@
 	{
 		"chartID": "78398e4e96987dd0bd29531c320145cc3a5759c3",
 		"data": {
-			"inGameID": "bookmaker",
+			"inGameStrID": "bookmaker",
 			"notecount": 1124
 		},
 		"difficulty": "Future",
@@ -4594,7 +4594,7 @@
 	{
 		"chartID": "6bc7013a7e59726e24c15d1c587ae3c289f0ab75",
 		"data": {
-			"inGameID": "bookmaker",
+			"inGameStrID": "bookmaker",
 			"notecount": 538
 		},
 		"difficulty": "Past",
@@ -4610,7 +4610,7 @@
 	{
 		"chartID": "242aaf5748d2eb339fd7ec2dfd8493db79b949ae",
 		"data": {
-			"inGameID": "bookmaker",
+			"inGameStrID": "bookmaker",
 			"notecount": 728
 		},
 		"difficulty": "Present",
@@ -4626,7 +4626,7 @@
 	{
 		"chartID": "209b67f9d9bab349b2548acb344a09cd39ddde07",
 		"data": {
-			"inGameID": "darakunosono",
+			"inGameStrID": "darakunosono",
 			"notecount": 1061
 		},
 		"difficulty": "Future",
@@ -4642,7 +4642,7 @@
 	{
 		"chartID": "b85681d73440751c712c81a8f8b1550ff82975c7",
 		"data": {
-			"inGameID": "darakunosono",
+			"inGameStrID": "darakunosono",
 			"notecount": 535
 		},
 		"difficulty": "Past",
@@ -4658,7 +4658,7 @@
 	{
 		"chartID": "bcce5047e7322b7ee1498c1177a1168fb8cf1583",
 		"data": {
-			"inGameID": "darakunosono",
+			"inGameStrID": "darakunosono",
 			"notecount": 585
 		},
 		"difficulty": "Present",
@@ -4674,7 +4674,7 @@
 	{
 		"chartID": "02924f2599e05d9779539dd07de5407f5ccf4da1",
 		"data": {
-			"inGameID": "dropdead",
+			"inGameStrID": "dropdead",
 			"notecount": 823
 		},
 		"difficulty": "Future",
@@ -4690,7 +4690,7 @@
 	{
 		"chartID": "da485f0dab29d6e251b862381ebad1b85dc75758",
 		"data": {
-			"inGameID": "dropdead",
+			"inGameStrID": "dropdead",
 			"notecount": 44
 		},
 		"difficulty": "Past",
@@ -4706,7 +4706,7 @@
 	{
 		"chartID": "cf127338ae628e4446db2782724865af4a88111d",
 		"data": {
-			"inGameID": "dropdead",
+			"inGameStrID": "dropdead",
 			"notecount": 1323
 		},
 		"difficulty": "Present",
@@ -4722,7 +4722,7 @@
 	{
 		"chartID": "368473d5b5ca14e9381fddb5caac375f7ba07837",
 		"data": {
-			"inGameID": "dropdead",
+			"inGameStrID": "dropdead",
 			"notecount": 1503
 		},
 		"difficulty": "Beyond",
@@ -4738,7 +4738,7 @@
 	{
 		"chartID": "b7cbb8c497c28a18a094fc5b7ef292fe7dbfe311",
 		"data": {
-			"inGameID": "fallensquare",
+			"inGameStrID": "fallensquare",
 			"notecount": 703
 		},
 		"difficulty": "Future",
@@ -4754,7 +4754,7 @@
 	{
 		"chartID": "b5953db2c371b14e991e7580da383249839b520d",
 		"data": {
-			"inGameID": "fallensquare",
+			"inGameStrID": "fallensquare",
 			"notecount": 316
 		},
 		"difficulty": "Past",
@@ -4770,7 +4770,7 @@
 	{
 		"chartID": "d947604ebde20ecc0e518154da8cbe846048e517",
 		"data": {
-			"inGameID": "fallensquare",
+			"inGameStrID": "fallensquare",
 			"notecount": 486
 		},
 		"difficulty": "Present",
@@ -4786,7 +4786,7 @@
 	{
 		"chartID": "b48708da2124bf2f88aa61b24bb3e193219506d5",
 		"data": {
-			"inGameID": "nhelv",
+			"inGameStrID": "nhelv",
 			"notecount": 1108
 		},
 		"difficulty": "Future",
@@ -4802,7 +4802,7 @@
 	{
 		"chartID": "dc1961a4b16e164cf15c6b59c6e0a357ad9a4c89",
 		"data": {
-			"inGameID": "nhelv",
+			"inGameStrID": "nhelv",
 			"notecount": 647
 		},
 		"difficulty": "Past",
@@ -4818,7 +4818,7 @@
 	{
 		"chartID": "3de02404dc23f9f06406b2f89fee880e50794bc2",
 		"data": {
-			"inGameID": "nhelv",
+			"inGameStrID": "nhelv",
 			"notecount": 913
 		},
 		"difficulty": "Present",
@@ -4834,7 +4834,7 @@
 	{
 		"chartID": "b2b8c44e4925693b0051308c41051e3f3edf5220",
 		"data": {
-			"inGameID": "espebranch",
+			"inGameStrID": "espebranch",
 			"notecount": 1058
 		},
 		"difficulty": "Future",
@@ -4850,7 +4850,7 @@
 	{
 		"chartID": "c4b064d2a9712b443e020383b0b4f0ec01093bd0",
 		"data": {
-			"inGameID": "espebranch",
+			"inGameStrID": "espebranch",
 			"notecount": 624
 		},
 		"difficulty": "Past",
@@ -4866,7 +4866,7 @@
 	{
 		"chartID": "f93343ba950cfa2b1ec22758a5fcf46b1ded4e4a",
 		"data": {
-			"inGameID": "espebranch",
+			"inGameStrID": "espebranch",
 			"notecount": 757
 		},
 		"difficulty": "Present",
@@ -4882,7 +4882,7 @@
 	{
 		"chartID": "fa55367128605cf5ccc114ed29da9409b0cba241",
 		"data": {
-			"inGameID": "purgatorium",
+			"inGameStrID": "purgatorium",
 			"notecount": 1051
 		},
 		"difficulty": "Beyond",
@@ -4898,7 +4898,7 @@
 	{
 		"chartID": "5417e563731b7f040d86f812b4d497be3b66b2ce",
 		"data": {
-			"inGameID": "purgatorium",
+			"inGameStrID": "purgatorium",
 			"notecount": 983
 		},
 		"difficulty": "Future",
@@ -4914,7 +4914,7 @@
 	{
 		"chartID": "f2c25248d2c945afa38c67fb6fd32583fd02d228",
 		"data": {
-			"inGameID": "purgatorium",
+			"inGameStrID": "purgatorium",
 			"notecount": 609
 		},
 		"difficulty": "Past",
@@ -4930,7 +4930,7 @@
 	{
 		"chartID": "aa5e0a95d007995b39b62b83255d7ca98d91d681",
 		"data": {
-			"inGameID": "purgatorium",
+			"inGameStrID": "purgatorium",
 			"notecount": 641
 		},
 		"difficulty": "Present",
@@ -4946,7 +4946,7 @@
 	{
 		"chartID": "656922f0a28a7dcbb6c044095db683a6b550f495",
 		"data": {
-			"inGameID": "hikari",
+			"inGameStrID": "hikari",
 			"notecount": 684
 		},
 		"difficulty": "Future",
@@ -4962,7 +4962,7 @@
 	{
 		"chartID": "871860bcda24a38b717853fd944af97dba9d96f3",
 		"data": {
-			"inGameID": "hikari",
+			"inGameStrID": "hikari",
 			"notecount": 237
 		},
 		"difficulty": "Past",
@@ -4978,7 +4978,7 @@
 	{
 		"chartID": "9c15b34603a1098d5ab90d338ff6919d397da08a",
 		"data": {
-			"inGameID": "hikari",
+			"inGameStrID": "hikari",
 			"notecount": 450
 		},
 		"difficulty": "Present",
@@ -4994,7 +4994,7 @@
 	{
 		"chartID": "57727c2bbb60719dadf2158eb984a6ce1d2bd3dd",
 		"data": {
-			"inGameID": "stager",
+			"inGameStrID": "stager",
 			"notecount": 1004
 		},
 		"difficulty": "Future",
@@ -5010,7 +5010,7 @@
 	{
 		"chartID": "b3a11f0a19b55f7b5f42a22760a12e9c2e090276",
 		"data": {
-			"inGameID": "stager",
+			"inGameStrID": "stager",
 			"notecount": 453
 		},
 		"difficulty": "Past",
@@ -5026,7 +5026,7 @@
 	{
 		"chartID": "4feb0c6aa9aa097e8a3f5c72454af6cd6966da05",
 		"data": {
-			"inGameID": "stager",
+			"inGameStrID": "stager",
 			"notecount": 559
 		},
 		"difficulty": "Present",
@@ -5042,7 +5042,7 @@
 	{
 		"chartID": "abf64986c5333ce2e2523b0b8300889af294f84a",
 		"data": {
-			"inGameID": "hallofmirrors",
+			"inGameStrID": "hallofmirrors",
 			"notecount": 898
 		},
 		"difficulty": "Future",
@@ -5058,7 +5058,7 @@
 	{
 		"chartID": "8f4bb18a8b58b1b7077ca976c4882c2e96396527",
 		"data": {
-			"inGameID": "hallofmirrors",
+			"inGameStrID": "hallofmirrors",
 			"notecount": 535
 		},
 		"difficulty": "Past",
@@ -5074,7 +5074,7 @@
 	{
 		"chartID": "449c532bd280415247ca670d60cb5bc27525a6fe",
 		"data": {
-			"inGameID": "hallofmirrors",
+			"inGameStrID": "hallofmirrors",
 			"notecount": 553
 		},
 		"difficulty": "Present",
@@ -5090,7 +5090,7 @@
 	{
 		"chartID": "f3ac640b8612fc84ba051932e60c78101cb3d7f5",
 		"data": {
-			"inGameID": "linearaccelerator",
+			"inGameStrID": "linearaccelerator",
 			"notecount": 905
 		},
 		"difficulty": "Future",
@@ -5106,7 +5106,7 @@
 	{
 		"chartID": "f4423a9bf7df4126f642c1c63f7da81071b8001c",
 		"data": {
-			"inGameID": "linearaccelerator",
+			"inGameStrID": "linearaccelerator",
 			"notecount": 438
 		},
 		"difficulty": "Past",
@@ -5122,7 +5122,7 @@
 	{
 		"chartID": "9b20930eebdbb7e69f75ebcc08afdcdf6ba1435f",
 		"data": {
-			"inGameID": "linearaccelerator",
+			"inGameStrID": "linearaccelerator",
 			"notecount": 488
 		},
 		"difficulty": "Present",
@@ -5138,7 +5138,7 @@
 	{
 		"chartID": "96b08f00bc386b024ff842ab1b14ee85f06f794c",
 		"data": {
-			"inGameID": "tiferet",
+			"inGameStrID": "tiferet",
 			"notecount": 1086
 		},
 		"difficulty": "Future",
@@ -5154,7 +5154,7 @@
 	{
 		"chartID": "15fa5954e7f613aca3b313f7f9d8ca859d13d197",
 		"data": {
-			"inGameID": "tiferet",
+			"inGameStrID": "tiferet",
 			"notecount": 450
 		},
 		"difficulty": "Past",
@@ -5170,7 +5170,7 @@
 	{
 		"chartID": "fb5f949ca839b0e435b96a1fd7be44e90456f055",
 		"data": {
-			"inGameID": "tiferet",
+			"inGameStrID": "tiferet",
 			"notecount": 720
 		},
 		"difficulty": "Present",
@@ -5186,7 +5186,7 @@
 	{
 		"chartID": "ca61f68f125df1fac933d0d124e612fc5520c782",
 		"data": {
-			"inGameID": "alexandrite",
+			"inGameStrID": "alexandrite",
 			"notecount": 1040
 		},
 		"difficulty": "Future",
@@ -5202,7 +5202,7 @@
 	{
 		"chartID": "8f8a8d73b2eff8b90758867e473e168cab32fb4e",
 		"data": {
-			"inGameID": "alexandrite",
+			"inGameStrID": "alexandrite",
 			"notecount": 507
 		},
 		"difficulty": "Past",
@@ -5218,7 +5218,7 @@
 	{
 		"chartID": "d660791677b93fc1bea1c8c42d955a0b183f38f5",
 		"data": {
-			"inGameID": "alexandrite",
+			"inGameStrID": "alexandrite",
 			"notecount": 699
 		},
 		"difficulty": "Present",
@@ -5234,7 +5234,7 @@
 	{
 		"chartID": "4b1d1324afed9a7d73d48f911faf3db4f57fdc82",
 		"data": {
-			"inGameID": "rugie",
+			"inGameStrID": "rugie",
 			"notecount": 975
 		},
 		"difficulty": "Future",
@@ -5250,7 +5250,7 @@
 	{
 		"chartID": "101759f796b17373a47f56d5326cdce08c13c361",
 		"data": {
-			"inGameID": "rugie",
+			"inGameStrID": "rugie",
 			"notecount": 566
 		},
 		"difficulty": "Past",
@@ -5266,7 +5266,7 @@
 	{
 		"chartID": "622f284eb66a0b4e682844b9e83b2dffd5fdd478",
 		"data": {
-			"inGameID": "rugie",
+			"inGameStrID": "rugie",
 			"notecount": 754
 		},
 		"difficulty": "Present",
@@ -5282,7 +5282,7 @@
 	{
 		"chartID": "80eb1545f541e6f103058c4b65cc54a28beb9391",
 		"data": {
-			"inGameID": "astraltale",
+			"inGameStrID": "astraltale",
 			"notecount": 884
 		},
 		"difficulty": "Future",
@@ -5298,7 +5298,7 @@
 	{
 		"chartID": "9f56cd2c74a8525b5516a3d5de1d2a8b5a80e350",
 		"data": {
-			"inGameID": "astraltale",
+			"inGameStrID": "astraltale",
 			"notecount": 445
 		},
 		"difficulty": "Past",
@@ -5314,7 +5314,7 @@
 	{
 		"chartID": "876c22023b6793cbeef4f0fcb14ea932383e42d5",
 		"data": {
-			"inGameID": "astraltale",
+			"inGameStrID": "astraltale",
 			"notecount": 642
 		},
 		"difficulty": "Present",
@@ -5330,7 +5330,7 @@
 	{
 		"chartID": "0775cf76375d3c1ddd8790a42ca2f0cf4e3dd279",
 		"data": {
-			"inGameID": "phantasia",
+			"inGameStrID": "phantasia",
 			"notecount": 952
 		},
 		"difficulty": "Future",
@@ -5346,7 +5346,7 @@
 	{
 		"chartID": "278c7063b6d33d4be074bf1a7d40708bd7e73e71",
 		"data": {
-			"inGameID": "phantasia",
+			"inGameStrID": "phantasia",
 			"notecount": 544
 		},
 		"difficulty": "Past",
@@ -5362,7 +5362,7 @@
 	{
 		"chartID": "1d57214f1e3d33d9b9b81824637ebb71d871bcf6",
 		"data": {
-			"inGameID": "phantasia",
+			"inGameStrID": "phantasia",
 			"notecount": 579
 		},
 		"difficulty": "Present",
@@ -5378,7 +5378,7 @@
 	{
 		"chartID": "2d4d43f6fac00ce419f44e07002ec00eece10cec",
 		"data": {
-			"inGameID": "empireofwinter",
+			"inGameStrID": "empireofwinter",
 			"notecount": 920
 		},
 		"difficulty": "Future",
@@ -5394,7 +5394,7 @@
 	{
 		"chartID": "af33552dbf20ee887d3b0cc3a9075ec02114b48a",
 		"data": {
-			"inGameID": "empireofwinter",
+			"inGameStrID": "empireofwinter",
 			"notecount": 484
 		},
 		"difficulty": "Past",
@@ -5410,7 +5410,7 @@
 	{
 		"chartID": "c883be945636d343e73a37a39bb1284d088c2525",
 		"data": {
-			"inGameID": "empireofwinter",
+			"inGameStrID": "empireofwinter",
 			"notecount": 662
 		},
 		"difficulty": "Present",
@@ -5426,7 +5426,7 @@
 	{
 		"chartID": "47c239d5fb23183f3a33288c431d5fbe384b0af0",
 		"data": {
-			"inGameID": "merlin",
+			"inGameStrID": "merlin",
 			"notecount": 881
 		},
 		"difficulty": "Beyond",
@@ -5442,7 +5442,7 @@
 	{
 		"chartID": "238d818e94980ac72757c4de91ec29883c5016b8",
 		"data": {
-			"inGameID": "merlin",
+			"inGameStrID": "merlin",
 			"notecount": 712
 		},
 		"difficulty": "Future",
@@ -5458,7 +5458,7 @@
 	{
 		"chartID": "b8a6ab6317a743496fd5fbb7f2767d548d896991",
 		"data": {
-			"inGameID": "merlin",
+			"inGameStrID": "merlin",
 			"notecount": 315
 		},
 		"difficulty": "Past",
@@ -5474,7 +5474,7 @@
 	{
 		"chartID": "74e5bfc198b9dfd2bc8447936a2decc2fe930cca",
 		"data": {
-			"inGameID": "merlin",
+			"inGameStrID": "merlin",
 			"notecount": 428
 		},
 		"difficulty": "Present",
@@ -5490,7 +5490,7 @@
 	{
 		"chartID": "9fdf5f2af4b18a86f2e55a8aa13a289d26e0bf79",
 		"data": {
-			"inGameID": "dxfullmetal",
+			"inGameStrID": "dxfullmetal",
 			"notecount": 808
 		},
 		"difficulty": "Future",
@@ -5506,7 +5506,7 @@
 	{
 		"chartID": "7313adce7a826fbc0656d9a0371699f790f8a3e8",
 		"data": {
-			"inGameID": "dxfullmetal",
+			"inGameStrID": "dxfullmetal",
 			"notecount": 327
 		},
 		"difficulty": "Past",
@@ -5522,7 +5522,7 @@
 	{
 		"chartID": "d08edfb73a8f172b6b7133b9fff7a9865e7a5248",
 		"data": {
-			"inGameID": "dxfullmetal",
+			"inGameStrID": "dxfullmetal",
 			"notecount": 556
 		},
 		"difficulty": "Present",
@@ -5538,7 +5538,7 @@
 	{
 		"chartID": "ad9c19f235ef4ce9372e570fac7eb37c917e4f26",
 		"data": {
-			"inGameID": "omakeno",
+			"inGameStrID": "omakeno",
 			"notecount": 931
 		},
 		"difficulty": "Beyond",
@@ -5554,7 +5554,7 @@
 	{
 		"chartID": "cb32a54118838b88e859bf19bb8550bc7778eaa1",
 		"data": {
-			"inGameID": "omakeno",
+			"inGameStrID": "omakeno",
 			"notecount": 869
 		},
 		"difficulty": "Future",
@@ -5570,7 +5570,7 @@
 	{
 		"chartID": "996a66d40e2938592078096238cd72cd469726a4",
 		"data": {
-			"inGameID": "omakeno",
+			"inGameStrID": "omakeno",
 			"notecount": 502
 		},
 		"difficulty": "Past",
@@ -5586,7 +5586,7 @@
 	{
 		"chartID": "d263980b97ac9af2cec76de762491296af14fcc0",
 		"data": {
-			"inGameID": "omakeno",
+			"inGameStrID": "omakeno",
 			"notecount": 616
 		},
 		"difficulty": "Present",
@@ -5602,7 +5602,7 @@
 	{
 		"chartID": "4612d05489d5768eec927d99bf76aa75bb54861d",
 		"data": {
-			"inGameID": "scarletlance",
+			"inGameStrID": "scarletlance",
 			"notecount": 1130
 		},
 		"difficulty": "Future",
@@ -5618,7 +5618,7 @@
 	{
 		"chartID": "db7cd87af569c0ecfe5e474afd98398a920db0e9",
 		"data": {
-			"inGameID": "scarletlance",
+			"inGameStrID": "scarletlance",
 			"notecount": 517
 		},
 		"difficulty": "Past",
@@ -5634,7 +5634,7 @@
 	{
 		"chartID": "6310d782ff93fff512bc975aed348f52d34ebb1e",
 		"data": {
-			"inGameID": "scarletlance",
+			"inGameStrID": "scarletlance",
 			"notecount": 644
 		},
 		"difficulty": "Present",
@@ -5650,7 +5650,7 @@
 	{
 		"chartID": "e3e82e299f66e7a1f9e6a650a48953abc5182e38",
 		"data": {
-			"inGameID": "ouroboros",
+			"inGameStrID": "ouroboros",
 			"notecount": 1369
 		},
 		"difficulty": "Future",
@@ -5666,7 +5666,7 @@
 	{
 		"chartID": "5ae2d00bc9e37a59e7691d39ea1b942f281d72c9",
 		"data": {
-			"inGameID": "ouroboros",
+			"inGameStrID": "ouroboros",
 			"notecount": 575
 		},
 		"difficulty": "Past",
@@ -5682,7 +5682,7 @@
 	{
 		"chartID": "bfd2ec6bc509bb687a42bfaabd87c5b43df6c668",
 		"data": {
-			"inGameID": "ouroboros",
+			"inGameStrID": "ouroboros",
 			"notecount": 832
 		},
 		"difficulty": "Present",
@@ -5698,7 +5698,7 @@
 	{
 		"chartID": "76ea71e9ad27406df98c433735ca7437fcee8cc1",
 		"data": {
-			"inGameID": "libertas",
+			"inGameStrID": "libertas",
 			"notecount": 947
 		},
 		"difficulty": "Future",
@@ -5714,7 +5714,7 @@
 	{
 		"chartID": "74ae268386e13a93a2fb7704978f9af68c0fb1de",
 		"data": {
-			"inGameID": "libertas",
+			"inGameStrID": "libertas",
 			"notecount": 476
 		},
 		"difficulty": "Past",
@@ -5730,7 +5730,7 @@
 	{
 		"chartID": "72a689e15551f514c55d1af16ce3b2486fda2a8c",
 		"data": {
-			"inGameID": "libertas",
+			"inGameStrID": "libertas",
 			"notecount": 514
 		},
 		"difficulty": "Present",
@@ -5746,7 +5746,7 @@
 	{
 		"chartID": "a64ff677d5b086f722110183fc63d00be494f85c",
 		"data": {
-			"inGameID": "solitarydream",
+			"inGameStrID": "solitarydream",
 			"notecount": 972
 		},
 		"difficulty": "Future",
@@ -5762,7 +5762,7 @@
 	{
 		"chartID": "8403c1269641b08c76b5d41ad0cc1344f5731c1b",
 		"data": {
-			"inGameID": "solitarydream",
+			"inGameStrID": "solitarydream",
 			"notecount": 712
 		},
 		"difficulty": "Past",
@@ -5778,7 +5778,7 @@
 	{
 		"chartID": "9faaec36d1b07f1b003a160c79b746b2f3b5845f",
 		"data": {
-			"inGameID": "solitarydream",
+			"inGameStrID": "solitarydream",
 			"notecount": 854
 		},
 		"difficulty": "Present",
@@ -5794,7 +5794,7 @@
 	{
 		"chartID": "ec10073cf0e09728939db5a203820d6ff09893be",
 		"data": {
-			"inGameID": "antithese",
+			"inGameStrID": "antithese",
 			"notecount": 968
 		},
 		"difficulty": "Beyond",
@@ -5810,7 +5810,7 @@
 	{
 		"chartID": "317de4b2bca681160691c7aa0e15b8db5b68c670",
 		"data": {
-			"inGameID": "antithese",
+			"inGameStrID": "antithese",
 			"notecount": 877
 		},
 		"difficulty": "Future",
@@ -5826,7 +5826,7 @@
 	{
 		"chartID": "9fa3298d93d4f55f8d655041077471094ded96c8",
 		"data": {
-			"inGameID": "antithese",
+			"inGameStrID": "antithese",
 			"notecount": 845
 		},
 		"difficulty": "Past",
@@ -5842,7 +5842,7 @@
 	{
 		"chartID": "a46c2a7672e8b78e36d0896afd34a3c947ba6d4f",
 		"data": {
-			"inGameID": "antithese",
+			"inGameStrID": "antithese",
 			"notecount": 826
 		},
 		"difficulty": "Present",
@@ -5858,7 +5858,7 @@
 	{
 		"chartID": "94148f4c12bcdf50e30edf050cc126b2a2345c5b",
 		"data": {
-			"inGameID": "corruption",
+			"inGameStrID": "corruption",
 			"notecount": 1293
 		},
 		"difficulty": "Future",
@@ -5874,7 +5874,7 @@
 	{
 		"chartID": "84cd0d7a38d54dc85d3e09b5d419a1251b4fc352",
 		"data": {
-			"inGameID": "corruption",
+			"inGameStrID": "corruption",
 			"notecount": 664
 		},
 		"difficulty": "Past",
@@ -5890,7 +5890,7 @@
 	{
 		"chartID": "da3bb5bd86a6e160a6204fce11b71684af5d9db6",
 		"data": {
-			"inGameID": "corruption",
+			"inGameStrID": "corruption",
 			"notecount": 847
 		},
 		"difficulty": "Present",
@@ -5906,7 +5906,7 @@
 	{
 		"chartID": "54fe1e0402d1851d34b2a0fef2293f47b6469c3f",
 		"data": {
-			"inGameID": "blackterritory",
+			"inGameStrID": "blackterritory",
 			"notecount": 1195
 		},
 		"difficulty": "Future",
@@ -5922,7 +5922,7 @@
 	{
 		"chartID": "f21ec7eda10603630d6b349edb551c6fee957ae2",
 		"data": {
-			"inGameID": "blackterritory",
+			"inGameStrID": "blackterritory",
 			"notecount": 627
 		},
 		"difficulty": "Past",
@@ -5938,7 +5938,7 @@
 	{
 		"chartID": "81dfc3cb815c229e266659c792219c402942990c",
 		"data": {
-			"inGameID": "blackterritory",
+			"inGameStrID": "blackterritory",
 			"notecount": 785
 		},
 		"difficulty": "Present",
@@ -5954,7 +5954,7 @@
 	{
 		"chartID": "3b6156d03a5e88aee10017430bf6954c4f8725fa",
 		"data": {
-			"inGameID": "viciousheroism",
+			"inGameStrID": "viciousheroism",
 			"notecount": 1150
 		},
 		"difficulty": "Future",
@@ -5970,7 +5970,7 @@
 	{
 		"chartID": "2a45015d6a7a88a9d20f83cd9a17abbb2665c61a",
 		"data": {
-			"inGameID": "viciousheroism",
+			"inGameStrID": "viciousheroism",
 			"notecount": 430
 		},
 		"difficulty": "Past",
@@ -5986,7 +5986,7 @@
 	{
 		"chartID": "167f127b0ef906edd2e9675fb72fcd6457374155",
 		"data": {
-			"inGameID": "viciousheroism",
+			"inGameStrID": "viciousheroism",
 			"notecount": 756
 		},
 		"difficulty": "Present",
@@ -6002,7 +6002,7 @@
 	{
 		"chartID": "e58e879b0d962b11d17d4d6f346a727e1b926939",
 		"data": {
-			"inGameID": "cyaegha",
+			"inGameStrID": "cyaegha",
 			"notecount": 1368
 		},
 		"difficulty": "Future",
@@ -6018,7 +6018,7 @@
 	{
 		"chartID": "838673bc7977735fc84a925c07ed72193d71af4a",
 		"data": {
-			"inGameID": "cyaegha",
+			"inGameStrID": "cyaegha",
 			"notecount": 760
 		},
 		"difficulty": "Past",
@@ -6034,7 +6034,7 @@
 	{
 		"chartID": "69a162250f0ccc5a6c309516beae2441e0b9fbf7",
 		"data": {
-			"inGameID": "cyaegha",
+			"inGameStrID": "cyaegha",
 			"notecount": 984
 		},
 		"difficulty": "Present",
@@ -6050,7 +6050,7 @@
 	{
 		"chartID": "71b3ecf95d51e839779baa9acd31b61c66f20ab5",
 		"data": {
-			"inGameID": "revixy",
+			"inGameStrID": "revixy",
 			"notecount": 1047
 		},
 		"difficulty": "Future",
@@ -6066,7 +6066,7 @@
 	{
 		"chartID": "80fa7b603c17845760d09b5244d8a8786d13659a",
 		"data": {
-			"inGameID": "revixy",
+			"inGameStrID": "revixy",
 			"notecount": 538
 		},
 		"difficulty": "Past",
@@ -6082,7 +6082,7 @@
 	{
 		"chartID": "852fe6e9c89bc672905031bab4efa060ce827453",
 		"data": {
-			"inGameID": "revixy",
+			"inGameStrID": "revixy",
 			"notecount": 729
 		},
 		"difficulty": "Present",
@@ -6098,7 +6098,7 @@
 	{
 		"chartID": "a0445813ca8e93cef1ea92cb7d6b6e8046359cca",
 		"data": {
-			"inGameID": "grimheart",
+			"inGameStrID": "grimheart",
 			"notecount": 959
 		},
 		"difficulty": "Future",
@@ -6114,7 +6114,7 @@
 	{
 		"chartID": "696c60f034a638916f5ec0047e79c92272c7f6d0",
 		"data": {
-			"inGameID": "grimheart",
+			"inGameStrID": "grimheart",
 			"notecount": 728
 		},
 		"difficulty": "Past",
@@ -6130,7 +6130,7 @@
 	{
 		"chartID": "0b7af319040bb8254c752a451d1eb3fd9d98e06e",
 		"data": {
-			"inGameID": "grimheart",
+			"inGameStrID": "grimheart",
 			"notecount": 699
 		},
 		"difficulty": "Present",
@@ -6146,7 +6146,7 @@
 	{
 		"chartID": "8fdc03555e0146190c017576184abfec72e96efe",
 		"data": {
-			"inGameID": "vector",
+			"inGameStrID": "vector",
 			"notecount": 1299
 		},
 		"difficulty": "Future",
@@ -6162,7 +6162,7 @@
 	{
 		"chartID": "f265073eed37717fb0f6f72732c7cc8b24176fb5",
 		"data": {
-			"inGameID": "vector",
+			"inGameStrID": "vector",
 			"notecount": 675
 		},
 		"difficulty": "Past",
@@ -6178,7 +6178,7 @@
 	{
 		"chartID": "6f21123510c7d690664fe0040da76e00d3093dc4",
 		"data": {
-			"inGameID": "vector",
+			"inGameStrID": "vector",
 			"notecount": 1002
 		},
 		"difficulty": "Present",
@@ -6194,7 +6194,7 @@
 	{
 		"chartID": "6ded77406641f532252d00053f14dc92cc0b31d0",
 		"data": {
-			"inGameID": "supernova",
+			"inGameStrID": "supernova",
 			"notecount": 1123
 		},
 		"difficulty": "Future",
@@ -6210,7 +6210,7 @@
 	{
 		"chartID": "6387595dc8bbeb82fd7bf0b0638762d3225cecde",
 		"data": {
-			"inGameID": "supernova",
+			"inGameStrID": "supernova",
 			"notecount": 664
 		},
 		"difficulty": "Past",
@@ -6226,7 +6226,7 @@
 	{
 		"chartID": "df290f3d7b22d0a63c9557a389bb5ec1f91b2957",
 		"data": {
-			"inGameID": "supernova",
+			"inGameStrID": "supernova",
 			"notecount": 564
 		},
 		"difficulty": "Present",
@@ -6242,7 +6242,7 @@
 	{
 		"chartID": "c6bd1534605813801d2a72afa51f4823c1074a0f",
 		"data": {
-			"inGameID": "dottodot",
+			"inGameStrID": "dottodot",
 			"notecount": 739
 		},
 		"difficulty": "Future",
@@ -6258,7 +6258,7 @@
 	{
 		"chartID": "f3075d0176b91d271e3d0bf688ad73a0fa385fe9",
 		"data": {
-			"inGameID": "dottodot",
+			"inGameStrID": "dottodot",
 			"notecount": 453
 		},
 		"difficulty": "Past",
@@ -6274,7 +6274,7 @@
 	{
 		"chartID": "4e2202da6409d4ffc499178f5c126f307cde7a37",
 		"data": {
-			"inGameID": "dottodot",
+			"inGameStrID": "dottodot",
 			"notecount": 522
 		},
 		"difficulty": "Present",
@@ -6290,7 +6290,7 @@
 	{
 		"chartID": "154a819bf9704c45cb33427507a4d373eeaa2f45",
 		"data": {
-			"inGameID": "garakuta",
+			"inGameStrID": "garakuta",
 			"notecount": 1035
 		},
 		"difficulty": "Future",
@@ -6306,7 +6306,7 @@
 	{
 		"chartID": "b3f5e56c1f86c94a8e7d6163987037a538eb7ac0",
 		"data": {
-			"inGameID": "garakuta",
+			"inGameStrID": "garakuta",
 			"notecount": 444
 		},
 		"difficulty": "Past",
@@ -6322,7 +6322,7 @@
 	{
 		"chartID": "17ab74498194a4da6241d53224169c60b8e0d339",
 		"data": {
-			"inGameID": "garakuta",
+			"inGameStrID": "garakuta",
 			"notecount": 572
 		},
 		"difficulty": "Present",
@@ -6338,7 +6338,7 @@
 	{
 		"chartID": "33a3f02e7418064ae02312bd09f00cfe8b12922c",
 		"data": {
-			"inGameID": "ikazuchi",
+			"inGameStrID": "ikazuchi",
 			"notecount": 1347
 		},
 		"difficulty": "Future",
@@ -6354,7 +6354,7 @@
 	{
 		"chartID": "ae1cc5755b154b32414d84040876ea38b31907bd",
 		"data": {
-			"inGameID": "ikazuchi",
+			"inGameStrID": "ikazuchi",
 			"notecount": 656
 		},
 		"difficulty": "Past",
@@ -6370,7 +6370,7 @@
 	{
 		"chartID": "bf897cfd571f76f64e02488c2e802c67632d7e94",
 		"data": {
-			"inGameID": "ikazuchi",
+			"inGameStrID": "ikazuchi",
 			"notecount": 976
 		},
 		"difficulty": "Present",
@@ -6386,7 +6386,7 @@
 	{
 		"chartID": "f4616e4a712e28ab1fc1528508bd1f78cd86ae5c",
 		"data": {
-			"inGameID": "worldvanquisher",
+			"inGameStrID": "worldvanquisher",
 			"notecount": 1452
 		},
 		"difficulty": "Future",
@@ -6402,7 +6402,7 @@
 	{
 		"chartID": "5c37d4fb14487178b8618a8de08a0c1d80eb8766",
 		"data": {
-			"inGameID": "worldvanquisher",
+			"inGameStrID": "worldvanquisher",
 			"notecount": 529
 		},
 		"difficulty": "Past",
@@ -6418,7 +6418,7 @@
 	{
 		"chartID": "4dc3df372ad702cdf804daa501c53dab51e8f912",
 		"data": {
-			"inGameID": "worldvanquisher",
+			"inGameStrID": "worldvanquisher",
 			"notecount": 759
 		},
 		"difficulty": "Present",
@@ -6434,7 +6434,7 @@
 	{
 		"chartID": "1ac152825571b3686efc7ada68023cc012c44df9",
 		"data": {
-			"inGameID": "dreadnought",
+			"inGameStrID": "dreadnought",
 			"notecount": 1099
 		},
 		"difficulty": "Future",
@@ -6450,7 +6450,7 @@
 	{
 		"chartID": "068cbc72b96585e31e7ae8d0fd5e429791a8493e",
 		"data": {
-			"inGameID": "dreadnought",
+			"inGameStrID": "dreadnought",
 			"notecount": 715
 		},
 		"difficulty": "Past",
@@ -6466,7 +6466,7 @@
 	{
 		"chartID": "1057355ee4f6d3bead8d280f7d6fe37c26ce831f",
 		"data": {
-			"inGameID": "dreadnought",
+			"inGameStrID": "dreadnought",
 			"notecount": 897
 		},
 		"difficulty": "Present",
@@ -6482,7 +6482,7 @@
 	{
 		"chartID": "784daf5fba65c17bf2e3131f452154aa494dd49e",
 		"data": {
-			"inGameID": "particlearts",
+			"inGameStrID": "particlearts",
 			"notecount": 925
 		},
 		"difficulty": "Future",
@@ -6498,7 +6498,7 @@
 	{
 		"chartID": "f03b8b258d9f86f9136fe768c669bdc9de628126",
 		"data": {
-			"inGameID": "particlearts",
+			"inGameStrID": "particlearts",
 			"notecount": 529
 		},
 		"difficulty": "Past",
@@ -6514,7 +6514,7 @@
 	{
 		"chartID": "9677d9d8a323fdde50b7bfc5178ec16bd2c78ad6",
 		"data": {
-			"inGameID": "particlearts",
+			"inGameStrID": "particlearts",
 			"notecount": 637
 		},
 		"difficulty": "Present",
@@ -6530,7 +6530,7 @@
 	{
 		"chartID": "496b326c22b821bcb9574586d8614dfb97b3a86b",
 		"data": {
-			"inGameID": "vindication",
+			"inGameStrID": "vindication",
 			"notecount": 1075
 		},
 		"difficulty": "Future",
@@ -6546,7 +6546,7 @@
 	{
 		"chartID": "a1484245d1224de12ec8fcade8ed98aab2c0c519",
 		"data": {
-			"inGameID": "vindication",
+			"inGameStrID": "vindication",
 			"notecount": 721
 		},
 		"difficulty": "Past",
@@ -6562,7 +6562,7 @@
 	{
 		"chartID": "5cddc9e9d6f01bb9cf88d79ab6423fda1dfc552a",
 		"data": {
-			"inGameID": "vindication",
+			"inGameStrID": "vindication",
 			"notecount": 899
 		},
 		"difficulty": "Present",
@@ -6578,7 +6578,7 @@
 	{
 		"chartID": "e56d54e26c40daeed9c0341a194b107493f1e069",
 		"data": {
-			"inGameID": "heavensdoor",
+			"inGameStrID": "heavensdoor",
 			"notecount": 1534
 		},
 		"difficulty": "Beyond",
@@ -6594,7 +6594,7 @@
 	{
 		"chartID": "45a2ec7552e1c50bbfc97a959adf3a23de0e4c87",
 		"data": {
-			"inGameID": "heavensdoor",
+			"inGameStrID": "heavensdoor",
 			"notecount": 1101
 		},
 		"difficulty": "Future",
@@ -6610,7 +6610,7 @@
 	{
 		"chartID": "72c6e69769ec4b1be72a7eb1346361ef1c6c0fb7",
 		"data": {
-			"inGameID": "heavensdoor",
+			"inGameStrID": "heavensdoor",
 			"notecount": 766
 		},
 		"difficulty": "Past",
@@ -6626,7 +6626,7 @@
 	{
 		"chartID": "770580f4daf01c5f6467171c7971362f7a1c7090",
 		"data": {
-			"inGameID": "heavensdoor",
+			"inGameStrID": "heavensdoor",
 			"notecount": 869
 		},
 		"difficulty": "Present",
@@ -6642,7 +6642,7 @@
 	{
 		"chartID": "26cacb6c52d0a360d5daf3e3a2709a310ad2afb6",
 		"data": {
-			"inGameID": "ringedgenesis",
+			"inGameStrID": "ringedgenesis",
 			"notecount": 1146
 		},
 		"difficulty": "Future",
@@ -6658,7 +6658,7 @@
 	{
 		"chartID": "048e70371a548a44e8a2275d3001279ab1b2ab59",
 		"data": {
-			"inGameID": "ringedgenesis",
+			"inGameStrID": "ringedgenesis",
 			"notecount": 672
 		},
 		"difficulty": "Past",
@@ -6674,7 +6674,7 @@
 	{
 		"chartID": "f509fb84d1bf92a3143c597a836ca123fd81325d",
 		"data": {
-			"inGameID": "ringedgenesis",
+			"inGameStrID": "ringedgenesis",
 			"notecount": 860
 		},
 		"difficulty": "Present",
@@ -6690,7 +6690,7 @@
 	{
 		"chartID": "631762ffd303cb7f63a8833a50cf7650d7a1a8fb",
 		"data": {
-			"inGameID": "chelsea",
+			"inGameStrID": "chelsea",
 			"notecount": 650
 		},
 		"difficulty": "Future",
@@ -6706,7 +6706,7 @@
 	{
 		"chartID": "bcc57e670a5473e689b09d79dd223e8927b4762f",
 		"data": {
-			"inGameID": "chelsea",
+			"inGameStrID": "chelsea",
 			"notecount": 388
 		},
 		"difficulty": "Past",
@@ -6722,7 +6722,7 @@
 	{
 		"chartID": "da05367d3308bb63feb2a57bde74066d41ee624e",
 		"data": {
-			"inGameID": "chelsea",
+			"inGameStrID": "chelsea",
 			"notecount": 503
 		},
 		"difficulty": "Present",
@@ -6738,7 +6738,7 @@
 	{
 		"chartID": "3d7b3fdca0c405f3f3314ed23b6de47201ffd0e9",
 		"data": {
-			"inGameID": "aiueoon",
+			"inGameStrID": "aiueoon",
 			"notecount": 989
 		},
 		"difficulty": "Future",
@@ -6754,7 +6754,7 @@
 	{
 		"chartID": "d2548a10f1cd9de06095e64d459a24d986c2d5b9",
 		"data": {
-			"inGameID": "aiueoon",
+			"inGameStrID": "aiueoon",
 			"notecount": 436
 		},
 		"difficulty": "Past",
@@ -6770,7 +6770,7 @@
 	{
 		"chartID": "cec5d7ab87151b75374586ac7b844dd3b773bfe5",
 		"data": {
-			"inGameID": "aiueoon",
+			"inGameStrID": "aiueoon",
 			"notecount": 623
 		},
 		"difficulty": "Present",
@@ -6786,7 +6786,7 @@
 	{
 		"chartID": "c4ffe407da25a89499ebcc6ed8875c41339720ee",
 		"data": {
-			"inGameID": "melodyoflove",
+			"inGameStrID": "melodyoflove",
 			"notecount": 931
 		},
 		"difficulty": "Future",
@@ -6802,7 +6802,7 @@
 	{
 		"chartID": "ac66ee2ab2e1f7f5089c843f651f42164b5dd601",
 		"data": {
-			"inGameID": "melodyoflove",
+			"inGameStrID": "melodyoflove",
 			"notecount": 422
 		},
 		"difficulty": "Past",
@@ -6818,7 +6818,7 @@
 	{
 		"chartID": "7364f9d7154be820704fdb393729f1866e0ec54d",
 		"data": {
-			"inGameID": "melodyoflove",
+			"inGameStrID": "melodyoflove",
 			"notecount": 670
 		},
 		"difficulty": "Present",
@@ -6834,7 +6834,7 @@
 	{
 		"chartID": "ac655e979f49d4d4c895e4e94f4cd7fed74d5d89",
 		"data": {
-			"inGameID": "tiemedowngently",
+			"inGameStrID": "tiemedowngently",
 			"notecount": 724
 		},
 		"difficulty": "Future",
@@ -6850,7 +6850,7 @@
 	{
 		"chartID": "ea18a7a566cb38f369ae4656ade7b7804744d48d",
 		"data": {
-			"inGameID": "tiemedowngently",
+			"inGameStrID": "tiemedowngently",
 			"notecount": 581
 		},
 		"difficulty": "Past",
@@ -6866,7 +6866,7 @@
 	{
 		"chartID": "ba88d7113baa2a17682f765ced5be284e04d08e2",
 		"data": {
-			"inGameID": "tiemedowngently",
+			"inGameStrID": "tiemedowngently",
 			"notecount": 535
 		},
 		"difficulty": "Present",
@@ -6882,7 +6882,7 @@
 	{
 		"chartID": "ad422e58b009455174cf168e00a3ccb9f7dc83e5",
 		"data": {
-			"inGameID": "valhallazero",
+			"inGameStrID": "valhallazero",
 			"notecount": 1173
 		},
 		"difficulty": "Future",
@@ -6898,7 +6898,7 @@
 	{
 		"chartID": "c16b279718454fd8b55cc0e0b5a3df416d82789f",
 		"data": {
-			"inGameID": "valhallazero",
+			"inGameStrID": "valhallazero",
 			"notecount": 624
 		},
 		"difficulty": "Past",
@@ -6914,7 +6914,7 @@
 	{
 		"chartID": "9723fe8693d1f6fb696296c960f9f8d2c4c15884",
 		"data": {
-			"inGameID": "valhallazero",
+			"inGameStrID": "valhallazero",
 			"notecount": 893
 		},
 		"difficulty": "Present",
@@ -6930,7 +6930,7 @@
 	{
 		"chartID": "acfb424b1f0fd166e7c2093343ef44ae11fc0582",
 		"data": {
-			"inGameID": "mirzam",
+			"inGameStrID": "mirzam",
 			"notecount": 1303
 		},
 		"difficulty": "Future",
@@ -6946,7 +6946,7 @@
 	{
 		"chartID": "d50d6b36e49d32e7867fda17ee4737507472c7da",
 		"data": {
-			"inGameID": "mirzam",
+			"inGameStrID": "mirzam",
 			"notecount": 662
 		},
 		"difficulty": "Past",
@@ -6962,7 +6962,7 @@
 	{
 		"chartID": "8860dbe7f16dcb76683f17a0de7acda09259ad79",
 		"data": {
-			"inGameID": "mirzam",
+			"inGameStrID": "mirzam",
 			"notecount": 885
 		},
 		"difficulty": "Present",
@@ -6978,7 +6978,7 @@
 	{
 		"chartID": "367a7ea6a5cd0adace8d7ab5302ba7c0bbec8ad4",
 		"data": {
-			"inGameID": "diode",
+			"inGameStrID": "diode",
 			"notecount": 709
 		},
 		"difficulty": "Future",
@@ -6994,7 +6994,7 @@
 	{
 		"chartID": "a5b219ec82fb5f9b431afb236bd0836df51d72e6",
 		"data": {
-			"inGameID": "diode",
+			"inGameStrID": "diode",
 			"notecount": 452
 		},
 		"difficulty": "Past",
@@ -7010,7 +7010,7 @@
 	{
 		"chartID": "1cff156ff5da9a424015f9c72c74edf6cbb3749d",
 		"data": {
-			"inGameID": "diode",
+			"inGameStrID": "diode",
 			"notecount": 472
 		},
 		"difficulty": "Present",
@@ -7026,7 +7026,7 @@
 	{
 		"chartID": "c092f2d59e54f3f86c75ec7323233d2b078c8f10",
 		"data": {
-			"inGameID": "freefall",
+			"inGameStrID": "freefall",
 			"notecount": 1336
 		},
 		"difficulty": "Beyond",
@@ -7042,7 +7042,7 @@
 	{
 		"chartID": "f5042ca9f1508ebd130caad7a470a75829f0300e",
 		"data": {
-			"inGameID": "freefall",
+			"inGameStrID": "freefall",
 			"notecount": 1023
 		},
 		"difficulty": "Future",
@@ -7058,7 +7058,7 @@
 	{
 		"chartID": "46799690ce44c12f5f0be100f31f4d3fc03230de",
 		"data": {
-			"inGameID": "freefall",
+			"inGameStrID": "freefall",
 			"notecount": 589
 		},
 		"difficulty": "Past",
@@ -7074,7 +7074,7 @@
 	{
 		"chartID": "a2a7d99486d01bad30cbdd819425757bb512552f",
 		"data": {
-			"inGameID": "freefall",
+			"inGameStrID": "freefall",
 			"notecount": 782
 		},
 		"difficulty": "Present",
@@ -7090,7 +7090,7 @@
 	{
 		"chartID": "f3ad5a0ba73c1c719ef8f25194aeba8b995a4551",
 		"data": {
-			"inGameID": "gloryroad",
+			"inGameStrID": "gloryroad",
 			"notecount": 1479
 		},
 		"difficulty": "Future",
@@ -7106,7 +7106,7 @@
 	{
 		"chartID": "3f0a31e0983e7a76b632a27f7d4daebbaeaf5db2",
 		"data": {
-			"inGameID": "gloryroad",
+			"inGameStrID": "gloryroad",
 			"notecount": 868
 		},
 		"difficulty": "Past",
@@ -7122,7 +7122,7 @@
 	{
 		"chartID": "fcf2e32a8666134819dcfb701f13d30456ee7571",
 		"data": {
-			"inGameID": "gloryroad",
+			"inGameStrID": "gloryroad",
 			"notecount": 999
 		},
 		"difficulty": "Present",
@@ -7138,7 +7138,7 @@
 	{
 		"chartID": "ed702f01992c8fabcc76a77b40eb0a67ad34ac2c",
 		"data": {
-			"inGameID": "monochromeprincess",
+			"inGameStrID": "monochromeprincess",
 			"notecount": 974
 		},
 		"difficulty": "Future",
@@ -7154,7 +7154,7 @@
 	{
 		"chartID": "558b28dfdf35fb7adac8037fecc2c0f3d125caae",
 		"data": {
-			"inGameID": "monochromeprincess",
+			"inGameStrID": "monochromeprincess",
 			"notecount": 621
 		},
 		"difficulty": "Past",
@@ -7170,7 +7170,7 @@
 	{
 		"chartID": "936e54e4c49d65e4fb3122a844011a70d06213e9",
 		"data": {
-			"inGameID": "monochromeprincess",
+			"inGameStrID": "monochromeprincess",
 			"notecount": 756
 		},
 		"difficulty": "Present",
@@ -7186,7 +7186,7 @@
 	{
 		"chartID": "ec24080e3581978de0ce2d744aabc85f035618aa",
 		"data": {
-			"inGameID": "heavenlycaress",
+			"inGameStrID": "heavenlycaress",
 			"notecount": 1560
 		},
 		"difficulty": "Future",
@@ -7202,7 +7202,7 @@
 	{
 		"chartID": "bd62a3616da8faceda1061f3ed1beb7902dfbcf6",
 		"data": {
-			"inGameID": "heavenlycaress",
+			"inGameStrID": "heavenlycaress",
 			"notecount": 855
 		},
 		"difficulty": "Past",
@@ -7218,7 +7218,7 @@
 	{
 		"chartID": "ceda499234e5a70c469e92c8840774709b8cb9d4",
 		"data": {
-			"inGameID": "heavenlycaress",
+			"inGameStrID": "heavenlycaress",
 			"notecount": 909
 		},
 		"difficulty": "Present",
@@ -7234,7 +7234,7 @@
 	{
 		"chartID": "47391fae612564041d58916c3e04bcf72a68b589",
 		"data": {
-			"inGameID": "senkyou",
+			"inGameStrID": "senkyou",
 			"notecount": 964
 		},
 		"difficulty": "Future",
@@ -7250,7 +7250,7 @@
 	{
 		"chartID": "93469fa45cd106601d51f5546a0afebe30849162",
 		"data": {
-			"inGameID": "senkyou",
+			"inGameStrID": "senkyou",
 			"notecount": 627
 		},
 		"difficulty": "Past",
@@ -7266,7 +7266,7 @@
 	{
 		"chartID": "d0e2de9a9256cb0d9a45e56c9565a2eed3975cdf",
 		"data": {
-			"inGameID": "senkyou",
+			"inGameStrID": "senkyou",
 			"notecount": 722
 		},
 		"difficulty": "Present",
@@ -7282,7 +7282,7 @@
 	{
 		"chartID": "b90a8af9b429c762a08c5fdddc1dd21e0a35b6af",
 		"data": {
-			"inGameID": "filament",
+			"inGameStrID": "filament",
 			"notecount": 991
 		},
 		"difficulty": "Future",
@@ -7298,7 +7298,7 @@
 	{
 		"chartID": "e8673e5acb1bb04ebfbda283a03fa88647df7268",
 		"data": {
-			"inGameID": "filament",
+			"inGameStrID": "filament",
 			"notecount": 582
 		},
 		"difficulty": "Past",
@@ -7314,7 +7314,7 @@
 	{
 		"chartID": "fe9aaa6a9e759219b2f946da7089ab0a70cbfbf5",
 		"data": {
-			"inGameID": "filament",
+			"inGameStrID": "filament",
 			"notecount": 780
 		},
 		"difficulty": "Present",
@@ -7330,7 +7330,7 @@
 	{
 		"chartID": "6a3ef4a03f92e78440d81eeb7cfc9649a793ea90",
 		"data": {
-			"inGameID": "avantraze",
+			"inGameStrID": "avantraze",
 			"notecount": 1125
 		},
 		"difficulty": "Future",
@@ -7346,7 +7346,7 @@
 	{
 		"chartID": "21572e92992099b56988bcbe9851b5ddf5f008c7",
 		"data": {
-			"inGameID": "avantraze",
+			"inGameStrID": "avantraze",
 			"notecount": 580
 		},
 		"difficulty": "Past",
@@ -7362,7 +7362,7 @@
 	{
 		"chartID": "c4366db8a313592152a7c41226e45b235ff93536",
 		"data": {
-			"inGameID": "avantraze",
+			"inGameStrID": "avantraze",
 			"notecount": 727
 		},
 		"difficulty": "Present",
@@ -7378,7 +7378,7 @@
 	{
 		"chartID": "512a97f5bc8852083b23c290cf4ea6d932474b47",
 		"data": {
-			"inGameID": "battlenoone",
+			"inGameStrID": "battlenoone",
 			"notecount": 1042
 		},
 		"difficulty": "Future",
@@ -7394,7 +7394,7 @@
 	{
 		"chartID": "119f8e6c7fa5f8ae9f25f0eeb4f743beecd23944",
 		"data": {
-			"inGameID": "battlenoone",
+			"inGameStrID": "battlenoone",
 			"notecount": 476
 		},
 		"difficulty": "Past",
@@ -7410,7 +7410,7 @@
 	{
 		"chartID": "efa10096b1f13ec77a9d5d86414af964d3fd7f88",
 		"data": {
-			"inGameID": "battlenoone",
+			"inGameStrID": "battlenoone",
 			"notecount": 677
 		},
 		"difficulty": "Present",
@@ -7426,7 +7426,7 @@
 	{
 		"chartID": "7be03df029bd2f9431831e8cc89debb7cd003a04",
 		"data": {
-			"inGameID": "laqryma",
+			"inGameStrID": "laqryma",
 			"notecount": 1161
 		},
 		"difficulty": "Beyond",
@@ -7442,7 +7442,7 @@
 	{
 		"chartID": "053b962751d1a5536253eae270089a13b4a81e5c",
 		"data": {
-			"inGameID": "laqryma",
+			"inGameStrID": "laqryma",
 			"notecount": 956
 		},
 		"difficulty": "Future",
@@ -7458,7 +7458,7 @@
 	{
 		"chartID": "26132a797eb79b5f35738258ae254b2bf142ef34",
 		"data": {
-			"inGameID": "laqryma",
+			"inGameStrID": "laqryma",
 			"notecount": 447
 		},
 		"difficulty": "Past",
@@ -7474,7 +7474,7 @@
 	{
 		"chartID": "2d6dc0c8fe835c4acbba694c8dc16554e496a593",
 		"data": {
-			"inGameID": "laqryma",
+			"inGameStrID": "laqryma",
 			"notecount": 651
 		},
 		"difficulty": "Present",
@@ -7490,7 +7490,7 @@
 	{
 		"chartID": "8e35e716528cb7d089d6b1c5e190542087e795a1",
 		"data": {
-			"inGameID": "einherjar",
+			"inGameStrID": "einherjar",
 			"notecount": 1159
 		},
 		"difficulty": "Future",
@@ -7506,7 +7506,7 @@
 	{
 		"chartID": "1450b0675d0caabba7ff040c7a53b65c0d241853",
 		"data": {
-			"inGameID": "einherjar",
+			"inGameStrID": "einherjar",
 			"notecount": 582
 		},
 		"difficulty": "Past",
@@ -7522,7 +7522,7 @@
 	{
 		"chartID": "fbfe7aaf598ebeeff61c616a0d91a29155b2d5e3",
 		"data": {
-			"inGameID": "einherjar",
+			"inGameStrID": "einherjar",
 			"notecount": 767
 		},
 		"difficulty": "Present",
@@ -7538,7 +7538,7 @@
 	{
 		"chartID": "72f4e4ad679aba1f7232c100283fdc06831e9b43",
 		"data": {
-			"inGameID": "izana",
+			"inGameStrID": "izana",
 			"notecount": 976
 		},
 		"difficulty": "Future",
@@ -7554,7 +7554,7 @@
 	{
 		"chartID": "e0d91eab458eb56e86c442af5928d2cbcba43cd1",
 		"data": {
-			"inGameID": "izana",
+			"inGameStrID": "izana",
 			"notecount": 609
 		},
 		"difficulty": "Past",
@@ -7570,7 +7570,7 @@
 	{
 		"chartID": "39ee4478c995d06f7e4e3af5f7e92074895a8b30",
 		"data": {
-			"inGameID": "izana",
+			"inGameStrID": "izana",
 			"notecount": 836
 		},
 		"difficulty": "Present",
@@ -7586,7 +7586,7 @@
 	{
 		"chartID": "9badc37b815294332d15fb0689cf84b6209d0f0d",
 		"data": {
-			"inGameID": "saikyostronger",
+			"inGameStrID": "saikyostronger",
 			"notecount": 1384
 		},
 		"difficulty": "Future",
@@ -7602,7 +7602,7 @@
 	{
 		"chartID": "630e2c18a9722ba5a95e615aa637aa65d5252468",
 		"data": {
-			"inGameID": "saikyostronger",
+			"inGameStrID": "saikyostronger",
 			"notecount": 654
 		},
 		"difficulty": "Past",
@@ -7618,7 +7618,7 @@
 	{
 		"chartID": "44755f17564dda603a194d7597de4449915e9e9b",
 		"data": {
-			"inGameID": "saikyostronger",
+			"inGameStrID": "saikyostronger",
 			"notecount": 1067
 		},
 		"difficulty": "Present",
@@ -7634,7 +7634,7 @@
 	{
 		"chartID": "6ed573e77057b0a0b51cf8e9af77032414e2f141",
 		"data": {
-			"inGameID": "worldexecuteme",
+			"inGameStrID": "worldexecuteme",
 			"notecount": 851
 		},
 		"difficulty": "Future",
@@ -7650,7 +7650,7 @@
 	{
 		"chartID": "ed96506ac79d09620363b56ef7bbf38ba83944c3",
 		"data": {
-			"inGameID": "worldexecuteme",
+			"inGameStrID": "worldexecuteme",
 			"notecount": 452
 		},
 		"difficulty": "Past",
@@ -7666,7 +7666,7 @@
 	{
 		"chartID": "0ff1d0aeea4f5f08c281f26f69ce61a8337c7d5e",
 		"data": {
-			"inGameID": "worldexecuteme",
+			"inGameStrID": "worldexecuteme",
 			"notecount": 582
 		},
 		"difficulty": "Present",
@@ -7682,7 +7682,7 @@
 	{
 		"chartID": "7df21f3dfea8f0fd018fc77c1e99a0afe579b150",
 		"data": {
-			"inGameID": "blrink",
+			"inGameStrID": "blrink",
 			"notecount": 1015
 		},
 		"difficulty": "Future",
@@ -7698,7 +7698,7 @@
 	{
 		"chartID": "0a3ebf73f3670e667265becddc241c1d1d4fa751",
 		"data": {
-			"inGameID": "blrink",
+			"inGameStrID": "blrink",
 			"notecount": 400
 		},
 		"difficulty": "Past",
@@ -7714,7 +7714,7 @@
 	{
 		"chartID": "a3bbd76d3f53099911c71edd50ac28ab65e7a7f4",
 		"data": {
-			"inGameID": "blrink",
+			"inGameStrID": "blrink",
 			"notecount": 683
 		},
 		"difficulty": "Present",
@@ -7730,7 +7730,7 @@
 	{
 		"chartID": "a9b45f0f742c9c39ce8ccb3555e8c1b525a75ade",
 		"data": {
-			"inGameID": "oblivia",
+			"inGameStrID": "oblivia",
 			"notecount": 956
 		},
 		"difficulty": "Future",
@@ -7746,7 +7746,7 @@
 	{
 		"chartID": "1d96fee55dfbb5460229c5a0b52d914f4c9fbfc3",
 		"data": {
-			"inGameID": "oblivia",
+			"inGameStrID": "oblivia",
 			"notecount": 574
 		},
 		"difficulty": "Past",
@@ -7762,7 +7762,7 @@
 	{
 		"chartID": "ff33b0c4083fb9559f800f56fabdf55679df0110",
 		"data": {
-			"inGameID": "oblivia",
+			"inGameStrID": "oblivia",
 			"notecount": 517
 		},
 		"difficulty": "Present",
@@ -7778,7 +7778,7 @@
 	{
 		"chartID": "e87ce5b6504c4651ff654f5892e75df040160854",
 		"data": {
-			"inGameID": "amygdata",
+			"inGameStrID": "amygdata",
 			"notecount": 1199
 		},
 		"difficulty": "Future",
@@ -7794,7 +7794,7 @@
 	{
 		"chartID": "edfbc2053319b07fe4bd385cce69fa1ef600437f",
 		"data": {
-			"inGameID": "amygdata",
+			"inGameStrID": "amygdata",
 			"notecount": 504
 		},
 		"difficulty": "Past",
@@ -7810,7 +7810,7 @@
 	{
 		"chartID": "9003dbb2296cd13eebf3995c5f42dc2a1a9d60d2",
 		"data": {
-			"inGameID": "amygdata",
+			"inGameStrID": "amygdata",
 			"notecount": 711
 		},
 		"difficulty": "Present",
@@ -7826,7 +7826,7 @@
 	{
 		"chartID": "278c04e1cc42ff8ac5e421bfe245ac49b72ed5c7",
 		"data": {
-			"inGameID": "corpssansorganes",
+			"inGameStrID": "corpssansorganes",
 			"notecount": 1077
 		},
 		"difficulty": "Future",
@@ -7842,7 +7842,7 @@
 	{
 		"chartID": "e7dcf4416a95a9c98333d1cf1d2e073d458c147c",
 		"data": {
-			"inGameID": "corpssansorganes",
+			"inGameStrID": "corpssansorganes",
 			"notecount": 438
 		},
 		"difficulty": "Past",
@@ -7858,7 +7858,7 @@
 	{
 		"chartID": "68db9d644f8114f60bc938dfb9b7b2ae79ff44e5",
 		"data": {
-			"inGameID": "corpssansorganes",
+			"inGameStrID": "corpssansorganes",
 			"notecount": 615
 		},
 		"difficulty": "Present",
@@ -7874,7 +7874,7 @@
 	{
 		"chartID": "95d8dde8aaecea93e4b98cd25b7e3d590620fdd0",
 		"data": {
-			"inGameID": "equilibrium",
+			"inGameStrID": "equilibrium",
 			"notecount": 951
 		},
 		"difficulty": "Future",
@@ -7890,7 +7890,7 @@
 	{
 		"chartID": "54331c301b575f36082eb41360512b6b8d7bfcc3",
 		"data": {
-			"inGameID": "equilibrium",
+			"inGameStrID": "equilibrium",
 			"notecount": 587
 		},
 		"difficulty": "Past",
@@ -7906,7 +7906,7 @@
 	{
 		"chartID": "885ab9699c6f25bdb707aa40205665de4b9e7a83",
 		"data": {
-			"inGameID": "equilibrium",
+			"inGameStrID": "equilibrium",
 			"notecount": 724
 		},
 		"difficulty": "Present",
@@ -7922,7 +7922,7 @@
 	{
 		"chartID": "90bd946c4866fa855b2ec62b59b7ebb4755d5354",
 		"data": {
-			"inGameID": "antagonism",
+			"inGameStrID": "antagonism",
 			"notecount": 1142
 		},
 		"difficulty": "Future",
@@ -7938,7 +7938,7 @@
 	{
 		"chartID": "0588c7d3063cccd49663e14c8c00bd43aec9fbaa",
 		"data": {
-			"inGameID": "antagonism",
+			"inGameStrID": "antagonism",
 			"notecount": 431
 		},
 		"difficulty": "Past",
@@ -7954,7 +7954,7 @@
 	{
 		"chartID": "f02066c5947cc0145aa340e8d389b33d690107a8",
 		"data": {
-			"inGameID": "antagonism",
+			"inGameStrID": "antagonism",
 			"notecount": 738
 		},
 		"difficulty": "Present",
@@ -7970,7 +7970,7 @@
 	{
 		"chartID": "cfc5a58d649ec43f3e2ef1ac8aaf065131ce9d4f",
 		"data": {
-			"inGameID": "lostdesire",
+			"inGameStrID": "lostdesire",
 			"notecount": 1154
 		},
 		"difficulty": "Future",
@@ -7986,7 +7986,7 @@
 	{
 		"chartID": "25e694ad4f4c3f72525e3792eb713ef02b6de346",
 		"data": {
-			"inGameID": "lostdesire",
+			"inGameStrID": "lostdesire",
 			"notecount": 684
 		},
 		"difficulty": "Past",
@@ -8002,7 +8002,7 @@
 	{
 		"chartID": "836c94e53adbded8b9bda978b5a2d0636d0de490",
 		"data": {
-			"inGameID": "lostdesire",
+			"inGameStrID": "lostdesire",
 			"notecount": 871
 		},
 		"difficulty": "Present",
@@ -8018,7 +8018,7 @@
 	{
 		"chartID": "59066e583562ef0f806e87324a655315e6c7209a",
 		"data": {
-			"inGameID": "dantalion",
+			"inGameStrID": "dantalion",
 			"notecount": 1476
 		},
 		"difficulty": "Future",
@@ -8034,7 +8034,7 @@
 	{
 		"chartID": "01a312c416fb55e72acdb5fa808a85b86940c8a4",
 		"data": {
-			"inGameID": "dantalion",
+			"inGameStrID": "dantalion",
 			"notecount": 731
 		},
 		"difficulty": "Past",
@@ -8050,7 +8050,7 @@
 	{
 		"chartID": "f1f5d7a4c105c508ae1b1a22e4e89588f1b68aac",
 		"data": {
-			"inGameID": "dantalion",
+			"inGameStrID": "dantalion",
 			"notecount": 843
 		},
 		"difficulty": "Present",
@@ -8066,7 +8066,7 @@
 	{
 		"chartID": "20ddaeb952085d050608be175d1a98c29a671c5a",
 		"data": {
-			"inGameID": "ifi",
+			"inGameStrID": "ifi",
 			"notecount": 1576
 		},
 		"difficulty": "Future",
@@ -8082,7 +8082,7 @@
 	{
 		"chartID": "201a4e90a17b61e40d249da7368d6122e803d8c9",
 		"data": {
-			"inGameID": "ifi",
+			"inGameStrID": "ifi",
 			"notecount": 765
 		},
 		"difficulty": "Past",
@@ -8098,7 +8098,7 @@
 	{
 		"chartID": "cf75a872987028ff581ed8f431ade62b7ea655ad",
 		"data": {
-			"inGameID": "ifi",
+			"inGameStrID": "ifi",
 			"notecount": 1144
 		},
 		"difficulty": "Present",
@@ -8114,7 +8114,7 @@
 	{
 		"chartID": "caf89ca328dac1f496d96a9e587b227a6a01736e",
 		"data": {
-			"inGameID": "tempestissimo",
+			"inGameStrID": "tempestissimo",
 			"notecount": 1540
 		},
 		"difficulty": "Beyond",
@@ -8130,7 +8130,7 @@
 	{
 		"chartID": "0b27112dc35f4643aaa7497492b28c83cde057bd",
 		"data": {
-			"inGameID": "tempestissimo",
+			"inGameStrID": "tempestissimo",
 			"notecount": 1254
 		},
 		"difficulty": "Future",
@@ -8146,7 +8146,7 @@
 	{
 		"chartID": "51605780b793f626d028a0350ca15e17419aba75",
 		"data": {
-			"inGameID": "tempestissimo",
+			"inGameStrID": "tempestissimo",
 			"notecount": 919
 		},
 		"difficulty": "Past",
@@ -8162,7 +8162,7 @@
 	{
 		"chartID": "fda1567a60004f44941dc3c8710c846fb1dd06f1",
 		"data": {
-			"inGameID": "tempestissimo",
+			"inGameStrID": "tempestissimo",
 			"notecount": 1034
 		},
 		"difficulty": "Present",
@@ -8178,7 +8178,7 @@
 	{
 		"chartID": "ded9fcfe1543cfd3066cc15e9a8d40e09b97a11f",
 		"data": {
-			"inGameID": "arcahv",
+			"inGameStrID": "arcahv",
 			"notecount": 1065
 		},
 		"difficulty": "Future",
@@ -8194,7 +8194,7 @@
 	{
 		"chartID": "4160eef243542f11d9fa14fe5a5993383b8b69b9",
 		"data": {
-			"inGameID": "arcahv",
+			"inGameStrID": "arcahv",
 			"notecount": 818
 		},
 		"difficulty": "Past",
@@ -8210,7 +8210,7 @@
 	{
 		"chartID": "3dd58ea10ec996783dc0c04bc08ccab47411fac4",
 		"data": {
-			"inGameID": "arcahv",
+			"inGameStrID": "arcahv",
 			"notecount": 884
 		},
 		"difficulty": "Present",
@@ -8226,7 +8226,7 @@
 	{
 		"chartID": "5c64573005e69a86c99312c01a74f6a71bd00ade",
 		"data": {
-			"inGameID": "altale",
+			"inGameStrID": "altale",
 			"notecount": 690
 		},
 		"difficulty": "Future",
@@ -8242,7 +8242,7 @@
 	{
 		"chartID": "3294343da3de6e722130fc0b7a666e24115fc958",
 		"data": {
-			"inGameID": "altale",
+			"inGameStrID": "altale",
 			"notecount": 357
 		},
 		"difficulty": "Past",
@@ -8258,7 +8258,7 @@
 	{
 		"chartID": "8631efb72998cf0984b9617076d901c9b4133a7c",
 		"data": {
-			"inGameID": "altale",
+			"inGameStrID": "altale",
 			"notecount": 424
 		},
 		"difficulty": "Present",
@@ -8274,7 +8274,7 @@
 	{
 		"chartID": "14785ad4da3b3f8012c2f46d5d66a6a2d86b09f1",
 		"data": {
-			"inGameID": "givemeanightmare",
+			"inGameStrID": "givemeanightmare",
 			"notecount": 948
 		},
 		"difficulty": "Future",
@@ -8290,7 +8290,7 @@
 	{
 		"chartID": "687afe40c18426e59bfcf68c48318a41e333aa08",
 		"data": {
-			"inGameID": "givemeanightmare",
+			"inGameStrID": "givemeanightmare",
 			"notecount": 676
 		},
 		"difficulty": "Past",
@@ -8306,7 +8306,7 @@
 	{
 		"chartID": "59fbcb3b0aa9d5bac74c6ce63ac5ffa51d301d64",
 		"data": {
-			"inGameID": "givemeanightmare",
+			"inGameStrID": "givemeanightmare",
 			"notecount": 817
 		},
 		"difficulty": "Present",
@@ -8322,7 +8322,7 @@
 	{
 		"chartID": "606c4363ce7a1b45ef6e9902b831ca7e7737abe4",
 		"data": {
-			"inGameID": "blacklotus",
+			"inGameStrID": "blacklotus",
 			"notecount": 965
 		},
 		"difficulty": "Future",
@@ -8338,7 +8338,7 @@
 	{
 		"chartID": "30017017949eb650675864c549efd2c544f1bcfd",
 		"data": {
-			"inGameID": "blacklotus",
+			"inGameStrID": "blacklotus",
 			"notecount": 653
 		},
 		"difficulty": "Past",
@@ -8354,7 +8354,7 @@
 	{
 		"chartID": "77f0a15516616baecbd7fa3f72979d29b5f7b64b",
 		"data": {
-			"inGameID": "blacklotus",
+			"inGameStrID": "blacklotus",
 			"notecount": 687
 		},
 		"difficulty": "Present",
@@ -8370,7 +8370,7 @@
 	{
 		"chartID": "4387fe477cbad0f9603788592c2baba777121616",
 		"data": {
-			"inGameID": "gekka",
+			"inGameStrID": "gekka",
 			"notecount": 817
 		},
 		"difficulty": "Future",
@@ -8386,7 +8386,7 @@
 	{
 		"chartID": "28fe579600b2136e50c56c243c5ea605577b8251",
 		"data": {
-			"inGameID": "gekka",
+			"inGameStrID": "gekka",
 			"notecount": 559
 		},
 		"difficulty": "Past",
@@ -8402,7 +8402,7 @@
 	{
 		"chartID": "2fcfd1a79065257f13590c14fe23f9e7e5707a6f",
 		"data": {
-			"inGameID": "gekka",
+			"inGameStrID": "gekka",
 			"notecount": 628
 		},
 		"difficulty": "Present",
@@ -8418,7 +8418,7 @@
 	{
 		"chartID": "ee71edfe490aaca91ea411c8313f23dd2fba8c39",
 		"data": {
-			"inGameID": "vividtheory",
+			"inGameStrID": "vividtheory",
 			"notecount": 885
 		},
 		"difficulty": "Future",
@@ -8434,7 +8434,7 @@
 	{
 		"chartID": "7d568117ed6a292e457bb39acd05120fba1288d1",
 		"data": {
-			"inGameID": "vividtheory",
+			"inGameStrID": "vividtheory",
 			"notecount": 447
 		},
 		"difficulty": "Past",
@@ -8450,7 +8450,7 @@
 	{
 		"chartID": "2b3999ea3419d13d4052ef435e77aa7362a19aaa",
 		"data": {
-			"inGameID": "vividtheory",
+			"inGameStrID": "vividtheory",
 			"notecount": 658
 		},
 		"difficulty": "Present",
@@ -8466,7 +8466,7 @@
 	{
 		"chartID": "b31fd627e03a9ad5797a10a80f28513d3742b081",
 		"data": {
-			"inGameID": "onefr",
+			"inGameStrID": "onefr",
 			"notecount": 758
 		},
 		"difficulty": "Future",
@@ -8482,7 +8482,7 @@
 	{
 		"chartID": "f6b477c63cfdc3d86a3359111817709aa6a3751b",
 		"data": {
-			"inGameID": "onefr",
+			"inGameStrID": "onefr",
 			"notecount": 411
 		},
 		"difficulty": "Past",
@@ -8498,7 +8498,7 @@
 	{
 		"chartID": "77967ae8d987aeb8e6f9c454a5d9fa562f5fdea6",
 		"data": {
-			"inGameID": "onefr",
+			"inGameStrID": "onefr",
 			"notecount": 539
 		},
 		"difficulty": "Present",
@@ -8514,7 +8514,7 @@
 	{
 		"chartID": "f3ccd3f66326f53b3c61e13f5f1f8dc56bb26c59",
 		"data": {
-			"inGameID": "scarletcage",
+			"inGameStrID": "scarletcage",
 			"notecount": 1195
 		},
 		"difficulty": "Future",
@@ -8530,7 +8530,7 @@
 	{
 		"chartID": "b2f7ca890a66a0585c605f33b8c240d6ea0e041d",
 		"data": {
-			"inGameID": "scarletcage",
+			"inGameStrID": "scarletcage",
 			"notecount": 570
 		},
 		"difficulty": "Past",
@@ -8546,7 +8546,7 @@
 	{
 		"chartID": "bbb03d31d178427e0a5702382d4916da39b1458f",
 		"data": {
-			"inGameID": "scarletcage",
+			"inGameStrID": "scarletcage",
 			"notecount": 711
 		},
 		"difficulty": "Present",
@@ -8562,7 +8562,7 @@
 	{
 		"chartID": "85e4fc26fb516b05f73d34f74bb9b0a9805524b6",
 		"data": {
-			"inGameID": "faintlight",
+			"inGameStrID": "faintlight",
 			"notecount": 809
 		},
 		"difficulty": "Future",
@@ -8578,7 +8578,7 @@
 	{
 		"chartID": "9f1a5664a01b1fe3e45825708f3a1c673427530b",
 		"data": {
-			"inGameID": "faintlight",
+			"inGameStrID": "faintlight",
 			"notecount": 587
 		},
 		"difficulty": "Past",
@@ -8594,7 +8594,7 @@
 	{
 		"chartID": "d4af937449c8f002ce63499c9bcc3c12dd4467ed",
 		"data": {
-			"inGameID": "faintlight",
+			"inGameStrID": "faintlight",
 			"notecount": 711
 		},
 		"difficulty": "Present",
@@ -8610,7 +8610,7 @@
 	{
 		"chartID": "14481348017106242148c6f9581def7b4c13dcc6",
 		"data": {
-			"inGameID": "feelssoright",
+			"inGameStrID": "feelssoright",
 			"notecount": 947
 		},
 		"difficulty": "Future",
@@ -8626,7 +8626,7 @@
 	{
 		"chartID": "efc985a84c6f378886dcbe67de84eab6c1856ddd",
 		"data": {
-			"inGameID": "feelssoright",
+			"inGameStrID": "feelssoright",
 			"notecount": 594
 		},
 		"difficulty": "Past",
@@ -8642,7 +8642,7 @@
 	{
 		"chartID": "946914aa8cd9b53a7b34c973e3bf525999aa25c3",
 		"data": {
-			"inGameID": "feelssoright",
+			"inGameStrID": "feelssoright",
 			"notecount": 636
 		},
 		"difficulty": "Present",
@@ -8658,7 +8658,7 @@
 	{
 		"chartID": "09181c22a75049b104564b0b63a8a70de7edd98c",
 		"data": {
-			"inGameID": "teriqma",
+			"inGameStrID": "teriqma",
 			"notecount": 954
 		},
 		"difficulty": "Beyond",
@@ -8674,7 +8674,7 @@
 	{
 		"chartID": "71218db0271eff418c6a5cb7b82818cdea5e16cb",
 		"data": {
-			"inGameID": "teriqma",
+			"inGameStrID": "teriqma",
 			"notecount": 873
 		},
 		"difficulty": "Future",
@@ -8690,7 +8690,7 @@
 	{
 		"chartID": "2c6e358b1f2a1ecc2a5595586d2e8d4d680f290c",
 		"data": {
-			"inGameID": "teriqma",
+			"inGameStrID": "teriqma",
 			"notecount": 345
 		},
 		"difficulty": "Past",
@@ -8706,7 +8706,7 @@
 	{
 		"chartID": "3aa571d5bd4bb209b64d35fbed2ffbd4d504f8ab",
 		"data": {
-			"inGameID": "teriqma",
+			"inGameStrID": "teriqma",
 			"notecount": 579
 		},
 		"difficulty": "Present",
@@ -8722,7 +8722,7 @@
 	{
 		"chartID": "93250b77e6ae11fee62294c18aece6e797c36ad6",
 		"data": {
-			"inGameID": "mahoroba",
+			"inGameStrID": "mahoroba",
 			"notecount": 828
 		},
 		"difficulty": "Future",
@@ -8738,7 +8738,7 @@
 	{
 		"chartID": "69d5eb01188ab518f49dcdd85c75858578f5691c",
 		"data": {
-			"inGameID": "mahoroba",
+			"inGameStrID": "mahoroba",
 			"notecount": 422
 		},
 		"difficulty": "Past",
@@ -8754,7 +8754,7 @@
 	{
 		"chartID": "98488e4a85b49fa7bef10af8c674c923412c0162",
 		"data": {
-			"inGameID": "mahoroba",
+			"inGameStrID": "mahoroba",
 			"notecount": 632
 		},
 		"difficulty": "Present",
@@ -8770,7 +8770,7 @@
 	{
 		"chartID": "16d1e078e82276fc748ad6baaa12af6ab1991684",
 		"data": {
-			"inGameID": "badtek",
+			"inGameStrID": "badtek",
 			"notecount": 916
 		},
 		"difficulty": "Future",
@@ -8786,7 +8786,7 @@
 	{
 		"chartID": "b3538311c13383f46e7b388a110009b027e8feeb",
 		"data": {
-			"inGameID": "badtek",
+			"inGameStrID": "badtek",
 			"notecount": 532
 		},
 		"difficulty": "Past",
@@ -8802,7 +8802,7 @@
 	{
 		"chartID": "918d6d0d62136e2e67159fde8f560aea0fbb75d8",
 		"data": {
-			"inGameID": "badtek",
+			"inGameStrID": "badtek",
 			"notecount": 595
 		},
 		"difficulty": "Present",
@@ -8818,7 +8818,7 @@
 	{
 		"chartID": "53a4c353eeb56077702adf279f85159455cdd76a",
 		"data": {
-			"inGameID": "maliciousmischance",
+			"inGameStrID": "maliciousmischance",
 			"notecount": 1126
 		},
 		"difficulty": "Future",
@@ -8834,7 +8834,7 @@
 	{
 		"chartID": "c2c807aa342d9622989776e39c41c078b313f78f",
 		"data": {
-			"inGameID": "maliciousmischance",
+			"inGameStrID": "maliciousmischance",
 			"notecount": 510
 		},
 		"difficulty": "Past",
@@ -8850,7 +8850,7 @@
 	{
 		"chartID": "11f43206eb39dd9f6c803213e8332750426555c1",
 		"data": {
-			"inGameID": "maliciousmischance",
+			"inGameStrID": "maliciousmischance",
 			"notecount": 706
 		},
 		"difficulty": "Present",
@@ -8866,7 +8866,7 @@
 	{
 		"chartID": "b8efba49ae2a3fb6a40c8015999d5e82e021502a",
 		"data": {
-			"inGameID": "gothiveofra",
+			"inGameStrID": "gothiveofra",
 			"notecount": 794
 		},
 		"difficulty": "Future",
@@ -8882,7 +8882,7 @@
 	{
 		"chartID": "f4aff2eadb38c7330a5b2055f061bd0dd1f95a9b",
 		"data": {
-			"inGameID": "gothiveofra",
+			"inGameStrID": "gothiveofra",
 			"notecount": 322
 		},
 		"difficulty": "Past",
@@ -8898,7 +8898,7 @@
 	{
 		"chartID": "c113e2163ef745346c906cd621dce38e070153c6",
 		"data": {
-			"inGameID": "gothiveofra",
+			"inGameStrID": "gothiveofra",
 			"notecount": 509
 		},
 		"difficulty": "Present",
@@ -8914,7 +8914,7 @@
 	{
 		"chartID": "06258ad1fa423750c2b27027b0041713d75fd4c5",
 		"data": {
-			"inGameID": "buchigireberserker",
+			"inGameStrID": "buchigireberserker",
 			"notecount": 1412
 		},
 		"difficulty": "Future",
@@ -8930,7 +8930,7 @@
 	{
 		"chartID": "2d309aee0d949099f889fe8b69b3b1cbfb00ca59",
 		"data": {
-			"inGameID": "buchigireberserker",
+			"inGameStrID": "buchigireberserker",
 			"notecount": 850
 		},
 		"difficulty": "Past",
@@ -8946,7 +8946,7 @@
 	{
 		"chartID": "feabf95983defc614805d85ad22718b7959e00cf",
 		"data": {
-			"inGameID": "buchigireberserker",
+			"inGameStrID": "buchigireberserker",
 			"notecount": 1046
 		},
 		"difficulty": "Present",
@@ -8962,7 +8962,7 @@
 	{
 		"chartID": "300298ef2f2b37d969ad3a40cb8b36180bc77005",
 		"data": {
-			"inGameID": "galaxyfriends",
+			"inGameStrID": "galaxyfriends",
 			"notecount": 1013
 		},
 		"difficulty": "Future",
@@ -8978,7 +8978,7 @@
 	{
 		"chartID": "885158da5e0ee1a452ded222e9638931e1b400e2",
 		"data": {
-			"inGameID": "galaxyfriends",
+			"inGameStrID": "galaxyfriends",
 			"notecount": 474
 		},
 		"difficulty": "Past",
@@ -8994,7 +8994,7 @@
 	{
 		"chartID": "6444bcd9488ffad61a102858ceab45c51429968c",
 		"data": {
-			"inGameID": "galaxyfriends",
+			"inGameStrID": "galaxyfriends",
 			"notecount": 572
 		},
 		"difficulty": "Present",
@@ -9010,7 +9010,7 @@
 	{
 		"chartID": "aec7835ba7a84fda1e6a623c3f73710fca7cd121",
 		"data": {
-			"inGameID": "crossover",
+			"inGameStrID": "crossover",
 			"notecount": 1094
 		},
 		"difficulty": "Future",
@@ -9026,7 +9026,7 @@
 	{
 		"chartID": "81ee4d0cdda69fa664c3995b8eb97a2d90cbba3f",
 		"data": {
-			"inGameID": "crossover",
+			"inGameStrID": "crossover",
 			"notecount": 653
 		},
 		"difficulty": "Past",
@@ -9042,7 +9042,7 @@
 	{
 		"chartID": "a5c2ff603df5706a81cc2e10d866b51ce4b636bc",
 		"data": {
-			"inGameID": "crossover",
+			"inGameStrID": "crossover",
 			"notecount": 810
 		},
 		"difficulty": "Present",
@@ -9058,7 +9058,7 @@
 	{
 		"chartID": "df54647af1423a31d07bd451634bf29be23d39c6",
 		"data": {
-			"inGameID": "xeraphinite",
+			"inGameStrID": "xeraphinite",
 			"notecount": 1048
 		},
 		"difficulty": "Future",
@@ -9074,7 +9074,7 @@
 	{
 		"chartID": "0cc1f05ef764ffa8da7df0df8d8178fc80eea9b2",
 		"data": {
-			"inGameID": "xeraphinite",
+			"inGameStrID": "xeraphinite",
 			"notecount": 383
 		},
 		"difficulty": "Past",
@@ -9090,7 +9090,7 @@
 	{
 		"chartID": "1867ba1a0ca4f44283e4652dd94cec34d1edb440",
 		"data": {
-			"inGameID": "xeraphinite",
+			"inGameStrID": "xeraphinite",
 			"notecount": 643
 		},
 		"difficulty": "Present",
@@ -9106,7 +9106,7 @@
 	{
 		"chartID": "5be578b407c5890fbbdf44dd685cef76aac8fac7",
 		"data": {
-			"inGameID": "lapis",
+			"inGameStrID": "lapis",
 			"notecount": 920
 		},
 		"difficulty": "Future",
@@ -9122,7 +9122,7 @@
 	{
 		"chartID": "78fb987cdb54d2670b7635c3343dded17dc7cacb",
 		"data": {
-			"inGameID": "lapis",
+			"inGameStrID": "lapis",
 			"notecount": 391
 		},
 		"difficulty": "Past",
@@ -9138,7 +9138,7 @@
 	{
 		"chartID": "54dbd4ef29e6802a0e8ba36585d9fae68ee41a3a",
 		"data": {
-			"inGameID": "lapis",
+			"inGameStrID": "lapis",
 			"notecount": 520
 		},
 		"difficulty": "Present",
@@ -9154,7 +9154,7 @@
 	{
 		"chartID": "9807d25e433a2a3391b7645ef1aa981f429df3c1",
 		"data": {
-			"inGameID": "xanatos",
+			"inGameStrID": "xanatos",
 			"notecount": 1232
 		},
 		"difficulty": "Future",
@@ -9170,7 +9170,7 @@
 	{
 		"chartID": "c04a1d4994d2b2b90937b541c0506aeb3166ab7f",
 		"data": {
-			"inGameID": "xanatos",
+			"inGameStrID": "xanatos",
 			"notecount": 735
 		},
 		"difficulty": "Past",
@@ -9186,7 +9186,7 @@
 	{
 		"chartID": "6aae1bcc25aece568264af8d85a513e762173f1d",
 		"data": {
-			"inGameID": "xanatos",
+			"inGameStrID": "xanatos",
 			"notecount": 938
 		},
 		"difficulty": "Present",
@@ -9202,7 +9202,7 @@
 	{
 		"chartID": "5d2dab6c6c72e2d0021ac33444e73f01a58bed63",
 		"data": {
-			"inGameID": "purpleverse",
+			"inGameStrID": "purpleverse",
 			"notecount": 1023
 		},
 		"difficulty": "Future",
@@ -9218,7 +9218,7 @@
 	{
 		"chartID": "86c149ae6ec7ab20a043861ee8f266fdf5a4e500",
 		"data": {
-			"inGameID": "purpleverse",
+			"inGameStrID": "purpleverse",
 			"notecount": 558
 		},
 		"difficulty": "Past",
@@ -9234,7 +9234,7 @@
 	{
 		"chartID": "686baed5409043148138219ec415d56dee89224e",
 		"data": {
-			"inGameID": "purpleverse",
+			"inGameStrID": "purpleverse",
 			"notecount": 664
 		},
 		"difficulty": "Present",
@@ -9250,7 +9250,7 @@
 	{
 		"chartID": "9c7e46d0e1bc8e0291435ecd1124fc1e6a83da0e",
 		"data": {
-			"inGameID": "alicealamode",
+			"inGameStrID": "alicealamode",
 			"notecount": 872
 		},
 		"difficulty": "Future",
@@ -9266,7 +9266,7 @@
 	{
 		"chartID": "1c6615999173975319914d18be35e3bbeda6ff78",
 		"data": {
-			"inGameID": "alicealamode",
+			"inGameStrID": "alicealamode",
 			"notecount": 436
 		},
 		"difficulty": "Past",
@@ -9282,7 +9282,7 @@
 	{
 		"chartID": "7e301cbfc8a144a63fcce908d53d96dc0b767b3a",
 		"data": {
-			"inGameID": "alicealamode",
+			"inGameStrID": "alicealamode",
 			"notecount": 618
 		},
 		"difficulty": "Present",
@@ -9298,7 +9298,7 @@
 	{
 		"chartID": "49da1651af39ea1bec6d3c7d3510c079bd8c0b1a",
 		"data": {
-			"inGameID": "eccentrictale",
+			"inGameStrID": "eccentrictale",
 			"notecount": 732
 		},
 		"difficulty": "Future",
@@ -9314,7 +9314,7 @@
 	{
 		"chartID": "844cecb61c7261ad0a6debfb0dc09d866b45d056",
 		"data": {
-			"inGameID": "eccentrictale",
+			"inGameStrID": "eccentrictale",
 			"notecount": 313
 		},
 		"difficulty": "Past",
@@ -9330,7 +9330,7 @@
 	{
 		"chartID": "752d8965f9d00addba2458204e44a6ac0cdd46db",
 		"data": {
-			"inGameID": "eccentrictale",
+			"inGameStrID": "eccentrictale",
 			"notecount": 483
 		},
 		"difficulty": "Present",
@@ -9346,7 +9346,7 @@
 	{
 		"chartID": "d848eb2785c7bb3d199379658575d4900fbcb23b",
 		"data": {
-			"inGameID": "alicessuitcase",
+			"inGameStrID": "alicessuitcase",
 			"notecount": 999
 		},
 		"difficulty": "Future",
@@ -9362,7 +9362,7 @@
 	{
 		"chartID": "654551ecc412c8ff2e2579b870bd6a0c98d91a21",
 		"data": {
-			"inGameID": "alicessuitcase",
+			"inGameStrID": "alicessuitcase",
 			"notecount": 644
 		},
 		"difficulty": "Past",
@@ -9378,7 +9378,7 @@
 	{
 		"chartID": "8e2f3124759c67247a98248a6954be4aa3a1f8f9",
 		"data": {
-			"inGameID": "alicessuitcase",
+			"inGameStrID": "alicessuitcase",
 			"notecount": 660
 		},
 		"difficulty": "Present",
@@ -9394,7 +9394,7 @@
 	{
 		"chartID": "0fed0f75bebf964df9e93d7ed262cb6b928d0651",
 		"data": {
-			"inGameID": "jump",
+			"inGameStrID": "jump",
 			"notecount": 841
 		},
 		"difficulty": "Future",
@@ -9410,7 +9410,7 @@
 	{
 		"chartID": "c655f62bdfd8bf0dfbdbeef7eb1b013998c9aca0",
 		"data": {
-			"inGameID": "jump",
+			"inGameStrID": "jump",
 			"notecount": 531
 		},
 		"difficulty": "Past",
@@ -9426,7 +9426,7 @@
 	{
 		"chartID": "d3124e87e333e83b2cc072cae7b089967cea6a33",
 		"data": {
-			"inGameID": "jump",
+			"inGameStrID": "jump",
 			"notecount": 622
 		},
 		"difficulty": "Present",
@@ -9442,7 +9442,7 @@
 	{
 		"chartID": "7bc23b19913c872e899fd4923cd96c4d661e649e",
 		"data": {
-			"inGameID": "felis",
+			"inGameStrID": "felis",
 			"notecount": 1153
 		},
 		"difficulty": "Future",
@@ -9458,7 +9458,7 @@
 	{
 		"chartID": "c99c4b96d5159c271d533b4a019bd8f4920663b5",
 		"data": {
-			"inGameID": "felis",
+			"inGameStrID": "felis",
 			"notecount": 463
 		},
 		"difficulty": "Past",
@@ -9474,7 +9474,7 @@
 	{
 		"chartID": "ca86dabc1cdc7d5d942634b1e0ea8c368bb4e283",
 		"data": {
-			"inGameID": "felis",
+			"inGameStrID": "felis",
 			"notecount": 624
 		},
 		"difficulty": "Present",
@@ -9490,7 +9490,7 @@
 	{
 		"chartID": "691f52a74a3377f60f50d25be96dbcc0d5b6e452",
 		"data": {
-			"inGameID": "besideyou",
+			"inGameStrID": "besideyou",
 			"notecount": 703
 		},
 		"difficulty": "Future",
@@ -9506,7 +9506,7 @@
 	{
 		"chartID": "ed2b5abc27f81a5d02a82edd8a53f1fc3e4b47f7",
 		"data": {
-			"inGameID": "besideyou",
+			"inGameStrID": "besideyou",
 			"notecount": 526
 		},
 		"difficulty": "Past",
@@ -9522,7 +9522,7 @@
 	{
 		"chartID": "fa98a6ff893ada7a93836f73379d0d70c7881ea1",
 		"data": {
-			"inGameID": "besideyou",
+			"inGameStrID": "besideyou",
 			"notecount": 634
 		},
 		"difficulty": "Present",
@@ -9538,7 +9538,7 @@
 	{
 		"chartID": "dbc3f01359cc81c1d78f8ebdad75bedcf28b77f1",
 		"data": {
-			"inGameID": "heartjackin",
+			"inGameStrID": "heartjackin",
 			"notecount": 1112
 		},
 		"difficulty": "Future",
@@ -9554,7 +9554,7 @@
 	{
 		"chartID": "508cc9d4fa959cda721ab916dfbc02e6f1f8aecb",
 		"data": {
-			"inGameID": "heartjackin",
+			"inGameStrID": "heartjackin",
 			"notecount": 506
 		},
 		"difficulty": "Past",
@@ -9570,7 +9570,7 @@
 	{
 		"chartID": "3f500ed2a69b648810c194f06f97a928ade2e7da",
 		"data": {
-			"inGameID": "heartjackin",
+			"inGameStrID": "heartjackin",
 			"notecount": 543
 		},
 		"difficulty": "Present",
@@ -9586,7 +9586,7 @@
 	{
 		"chartID": "6bb6223fd751aba3fba083d4e73493bd89b86c29",
 		"data": {
-			"inGameID": "toaliceliddell",
+			"inGameStrID": "toaliceliddell",
 			"notecount": 998
 		},
 		"difficulty": "Future",
@@ -9602,7 +9602,7 @@
 	{
 		"chartID": "dde139237a410ff14849ff8de0ece90ae408c910",
 		"data": {
-			"inGameID": "toaliceliddell",
+			"inGameStrID": "toaliceliddell",
 			"notecount": 535
 		},
 		"difficulty": "Past",
@@ -9618,7 +9618,7 @@
 	{
 		"chartID": "537e251cf38286201956974f62ce8c994cac7846",
 		"data": {
-			"inGameID": "toaliceliddell",
+			"inGameStrID": "toaliceliddell",
 			"notecount": 674
 		},
 		"difficulty": "Present",
@@ -9634,7 +9634,7 @@
 	{
 		"chartID": "de1fc9422739322fcce2ec53a4cc4c6576432f3c",
 		"data": {
-			"inGameID": "lazyaddiction",
+			"inGameStrID": "lazyaddiction",
 			"notecount": 1031
 		},
 		"difficulty": "Future",
@@ -9650,7 +9650,7 @@
 	{
 		"chartID": "349c1c5f16ed9e6aca41fee0dc868969f75b0236",
 		"data": {
-			"inGameID": "lazyaddiction",
+			"inGameStrID": "lazyaddiction",
 			"notecount": 462
 		},
 		"difficulty": "Past",
@@ -9666,7 +9666,7 @@
 	{
 		"chartID": "2d6c0c2b84c481c427f6838567116bd3d9cd4bb7",
 		"data": {
-			"inGameID": "lazyaddiction",
+			"inGameStrID": "lazyaddiction",
 			"notecount": 647
 		},
 		"difficulty": "Present",
@@ -9682,7 +9682,7 @@
 	{
 		"chartID": "b2750052500c8749c86f6e4accf9abe8faea4322",
 		"data": {
-			"inGameID": "dazzlehop",
+			"inGameStrID": "dazzlehop",
 			"notecount": 1022
 		},
 		"difficulty": "Future",
@@ -9698,7 +9698,7 @@
 	{
 		"chartID": "cd868180d8310dc72d900af59cb52fcaccecc91f",
 		"data": {
-			"inGameID": "dazzlehop",
+			"inGameStrID": "dazzlehop",
 			"notecount": 561
 		},
 		"difficulty": "Past",
@@ -9714,7 +9714,7 @@
 	{
 		"chartID": "6143eb12383a98d77dc477b2ca32c8f95b868ea0",
 		"data": {
-			"inGameID": "dazzlehop",
+			"inGameStrID": "dazzlehop",
 			"notecount": 571
 		},
 		"difficulty": "Present",
@@ -9730,7 +9730,7 @@
 	{
 		"chartID": "a27879abfe48cc496edec85d79726c86e144bcf4",
 		"data": {
-			"inGameID": "viyellastears",
+			"inGameStrID": "viyellastears",
 			"notecount": 1403
 		},
 		"difficulty": "Future",
@@ -9746,7 +9746,7 @@
 	{
 		"chartID": "e66f55e356a43570aa8729923ab664159bfee2af",
 		"data": {
-			"inGameID": "viyellastears",
+			"inGameStrID": "viyellastears",
 			"notecount": 716
 		},
 		"difficulty": "Past",
@@ -9762,7 +9762,7 @@
 	{
 		"chartID": "bf2b3a34d4abb8edd179b11cd86e8752bbfb0652",
 		"data": {
-			"inGameID": "viyellastears",
+			"inGameStrID": "viyellastears",
 			"notecount": 942
 		},
 		"difficulty": "Present",
@@ -9778,7 +9778,7 @@
 	{
 		"chartID": "75712ebc8bdbc06dcc2243d291a76bf7db7bf384",
 		"data": {
-			"inGameID": "omegafour",
+			"inGameStrID": "omegafour",
 			"notecount": 1393
 		},
 		"difficulty": "Future",
@@ -9794,7 +9794,7 @@
 	{
 		"chartID": "9b6aa819b07fd43e05d03d03b3717aeee881cd48",
 		"data": {
-			"inGameID": "omegafour",
+			"inGameStrID": "omegafour",
 			"notecount": 816
 		},
 		"difficulty": "Past",
@@ -9810,7 +9810,7 @@
 	{
 		"chartID": "239c6b7c2fa10d3f0d7ba1103760622c87adac08",
 		"data": {
-			"inGameID": "omegafour",
+			"inGameStrID": "omegafour",
 			"notecount": 943
 		},
 		"difficulty": "Present",
@@ -9826,7 +9826,7 @@
 	{
 		"chartID": "ef163853809ef69a098f128be7328eaaa805d6d0",
 		"data": {
-			"inGameID": "aprilshowers",
+			"inGameStrID": "aprilshowers",
 			"notecount": 697
 		},
 		"difficulty": "Future",
@@ -9842,7 +9842,7 @@
 	{
 		"chartID": "23713878648cb94c48c3364e6e595a45ddd2607c",
 		"data": {
-			"inGameID": "aprilshowers",
+			"inGameStrID": "aprilshowers",
 			"notecount": 363
 		},
 		"difficulty": "Past",
@@ -9858,7 +9858,7 @@
 	{
 		"chartID": "b83814948099d938621e21b1cc54f6b1dafde9e7",
 		"data": {
-			"inGameID": "aprilshowers",
+			"inGameStrID": "aprilshowers",
 			"notecount": 544
 		},
 		"difficulty": "Present",
@@ -9874,7 +9874,7 @@
 	{
 		"chartID": "a9a8b19c73df3ffc43fc1592795a8916c1bcfc41",
 		"data": {
-			"inGameID": "seventhsense",
+			"inGameStrID": "seventhsense",
 			"notecount": 925
 		},
 		"difficulty": "Future",
@@ -9890,7 +9890,7 @@
 	{
 		"chartID": "eea22272c29ee8b55ae6b640015896d3a5d45cea",
 		"data": {
-			"inGameID": "seventhsense",
+			"inGameStrID": "seventhsense",
 			"notecount": 360
 		},
 		"difficulty": "Past",
@@ -9906,7 +9906,7 @@
 	{
 		"chartID": "b38483a75d382849adb1f7cf537e65a24e984f62",
 		"data": {
-			"inGameID": "seventhsense",
+			"inGameStrID": "seventhsense",
 			"notecount": 739
 		},
 		"difficulty": "Present",
@@ -9922,7 +9922,7 @@
 	{
 		"chartID": "69f883c06f11a4d5cff92eb527bbadbf599144d0",
 		"data": {
-			"inGameID": "oshamascramble",
+			"inGameStrID": "oshamascramble",
 			"notecount": 1073
 		},
 		"difficulty": "Future",
@@ -9938,7 +9938,7 @@
 	{
 		"chartID": "c0553220b2840e19ae2d4c22c26ac995a34fd81c",
 		"data": {
-			"inGameID": "oshamascramble",
+			"inGameStrID": "oshamascramble",
 			"notecount": 508
 		},
 		"difficulty": "Past",
@@ -9954,7 +9954,7 @@
 	{
 		"chartID": "5659cdf0999b9b2036fa9441bc3c4fd1c5c10459",
 		"data": {
-			"inGameID": "oshamascramble",
+			"inGameStrID": "oshamascramble",
 			"notecount": 568
 		},
 		"difficulty": "Present",
@@ -9970,7 +9970,7 @@
 	{
 		"chartID": "a8a7974f9a10e9e51f08a41604cb524054a302be",
 		"data": {
-			"inGameID": "amazingmightyyyy",
+			"inGameStrID": "amazingmightyyyy",
 			"notecount": 1249
 		},
 		"difficulty": "Future",
@@ -9986,7 +9986,7 @@
 	{
 		"chartID": "f86289955ad6e088f81bf31e4748a6434e9d10b9",
 		"data": {
-			"inGameID": "amazingmightyyyy",
+			"inGameStrID": "amazingmightyyyy",
 			"notecount": 624
 		},
 		"difficulty": "Past",
@@ -10002,7 +10002,7 @@
 	{
 		"chartID": "cbf523ff78c76c723bf344e21648cf3a6d11e051",
 		"data": {
-			"inGameID": "amazingmightyyyy",
+			"inGameStrID": "amazingmightyyyy",
 			"notecount": 776
 		},
 		"difficulty": "Present",
@@ -10018,7 +10018,7 @@
 	{
 		"chartID": "d782c20aa7ab6cc864463eeb7df962a635eb12ae",
 		"data": {
-			"inGameID": "climax",
+			"inGameStrID": "climax",
 			"notecount": 1367
 		},
 		"difficulty": "Future",
@@ -10034,7 +10034,7 @@
 	{
 		"chartID": "d386793567b5e9c0d344ea1afdd871dc06b5a017",
 		"data": {
-			"inGameID": "climax",
+			"inGameStrID": "climax",
 			"notecount": 773
 		},
 		"difficulty": "Past",
@@ -10050,7 +10050,7 @@
 	{
 		"chartID": "e681c2e8de639a26fb9b04eabf2b117a32078e4c",
 		"data": {
-			"inGameID": "climax",
+			"inGameStrID": "climax",
 			"notecount": 988
 		},
 		"difficulty": "Present",
@@ -10066,7 +10066,7 @@
 	{
 		"chartID": "887f4e22c8d47e209e480a01886611d133997a37",
 		"data": {
-			"inGameID": "lastcelebration",
+			"inGameStrID": "lastcelebration",
 			"notecount": 1475
 		},
 		"difficulty": "Future",
@@ -10082,7 +10082,7 @@
 	{
 		"chartID": "46c89a5fca1576c792d90427e99b52b35103a624",
 		"data": {
-			"inGameID": "lastcelebration",
+			"inGameStrID": "lastcelebration",
 			"notecount": 969
 		},
 		"difficulty": "Past",
@@ -10098,7 +10098,7 @@
 	{
 		"chartID": "9922f56fb808b7be130ad301ea73876ad14e3f44",
 		"data": {
-			"inGameID": "lastcelebration",
+			"inGameStrID": "lastcelebration",
 			"notecount": 994
 		},
 		"difficulty": "Present",
@@ -10114,7 +10114,7 @@
 	{
 		"chartID": "fcc35c153d759211ecd45b5dbe45f564138ae57d",
 		"data": {
-			"inGameID": "gou",
+			"inGameStrID": "gou",
 			"notecount": 1522
 		},
 		"difficulty": "Future",
@@ -10130,7 +10130,7 @@
 	{
 		"chartID": "0cc09f06675e0acc91aa10edc4216567c215d4b2",
 		"data": {
-			"inGameID": "gou",
+			"inGameStrID": "gou",
 			"notecount": 814
 		},
 		"difficulty": "Past",
@@ -10146,7 +10146,7 @@
 	{
 		"chartID": "0c577a207683c5928b8f8326ff2072c818a0619c",
 		"data": {
-			"inGameID": "gou",
+			"inGameStrID": "gou",
 			"notecount": 1070
 		},
 		"difficulty": "Present",
@@ -10162,7 +10162,7 @@
 	{
 		"chartID": "ac0646d46925700632ede09ae1296d54d301bbe7",
 		"data": {
-			"inGameID": "glow",
+			"inGameStrID": "glow",
 			"notecount": 916
 		},
 		"difficulty": "Future",
@@ -10178,7 +10178,7 @@
 	{
 		"chartID": "89c7f96b5c1ebdb6557e976904d21b82b98805f8",
 		"data": {
-			"inGameID": "glow",
+			"inGameStrID": "glow",
 			"notecount": 504
 		},
 		"difficulty": "Past",
@@ -10194,7 +10194,7 @@
 	{
 		"chartID": "dd98d347015868a44a2db928f94a86c41c95a888",
 		"data": {
-			"inGameID": "glow",
+			"inGameStrID": "glow",
 			"notecount": 666
 		},
 		"difficulty": "Present",
@@ -10210,7 +10210,7 @@
 	{
 		"chartID": "80563f73602f30c1765d65a82e216f72d27d98cf",
 		"data": {
-			"inGameID": "attraqtia",
+			"inGameStrID": "attraqtia",
 			"notecount": 1433
 		},
 		"difficulty": "Future",
@@ -10226,7 +10226,7 @@
 	{
 		"chartID": "fe503f516f07178606146ef6677c4b5642c22026",
 		"data": {
-			"inGameID": "attraqtia",
+			"inGameStrID": "attraqtia",
 			"notecount": 732
 		},
 		"difficulty": "Past",
@@ -10242,7 +10242,7 @@
 	{
 		"chartID": "93898c33dfbabf084ebb17db9a8e2d308cc110ca",
 		"data": {
-			"inGameID": "attraqtia",
+			"inGameStrID": "attraqtia",
 			"notecount": 1002
 		},
 		"difficulty": "Present",
@@ -10258,7 +10258,7 @@
 	{
 		"chartID": "e043b38fb1ee91a24d35e60e61daa1f2fd6e5d6e",
 		"data": {
-			"inGameID": "enchantedlove",
+			"inGameStrID": "enchantedlove",
 			"notecount": 759
 		},
 		"difficulty": "Future",
@@ -10274,7 +10274,7 @@
 	{
 		"chartID": "c866970dba98ce33f9cba8e5fc155eef41987531",
 		"data": {
-			"inGameID": "enchantedlove",
+			"inGameStrID": "enchantedlove",
 			"notecount": 436
 		},
 		"difficulty": "Past",
@@ -10290,7 +10290,7 @@
 	{
 		"chartID": "5ab7761497d0f9650d7d8f0a0118fd2b45936702",
 		"data": {
-			"inGameID": "enchantedlove",
+			"inGameStrID": "enchantedlove",
 			"notecount": 617
 		},
 		"difficulty": "Present",
@@ -10306,7 +10306,7 @@
 	{
 		"chartID": "7c11200b15282bc9f429a510faeab6fadb23376f",
 		"data": {
-			"inGameID": "take",
+			"inGameStrID": "take",
 			"notecount": 1050
 		},
 		"difficulty": "Future",
@@ -10322,7 +10322,7 @@
 	{
 		"chartID": "91d1a8dbfb1c3406e6b699af90290f2b6a61a5fa",
 		"data": {
-			"inGameID": "take",
+			"inGameStrID": "take",
 			"notecount": 499
 		},
 		"difficulty": "Past",
@@ -10338,7 +10338,7 @@
 	{
 		"chartID": "b5c158170a44bb5767000668d05426b84a3674de",
 		"data": {
-			"inGameID": "take",
+			"inGameStrID": "take",
 			"notecount": 631
 		},
 		"difficulty": "Present",
@@ -10354,7 +10354,7 @@
 	{
 		"chartID": "81cf834a1056d71928646fb0e427f6154254d01a",
 		"data": {
-			"inGameID": "gimmedablood",
+			"inGameStrID": "gimmedablood",
 			"notecount": 1093
 		},
 		"difficulty": "Future",
@@ -10370,7 +10370,7 @@
 	{
 		"chartID": "e54ab31d40acb2e0d3cc50ae365338975651b502",
 		"data": {
-			"inGameID": "gimmedablood",
+			"inGameStrID": "gimmedablood",
 			"notecount": 582
 		},
 		"difficulty": "Past",
@@ -10386,7 +10386,7 @@
 	{
 		"chartID": "2ff95448c314193cdbefec26be375aa7b8b781e0",
 		"data": {
-			"inGameID": "gimmedablood",
+			"inGameStrID": "gimmedablood",
 			"notecount": 737
 		},
 		"difficulty": "Present",
@@ -10402,7 +10402,7 @@
 	{
 		"chartID": "b3c3e37ed41d6592108ca28ef58911d7d9fe8632",
 		"data": {
-			"inGameID": "bassline",
+			"inGameStrID": "bassline",
 			"notecount": 861
 		},
 		"difficulty": "Future",
@@ -10418,7 +10418,7 @@
 	{
 		"chartID": "f850ab848deb09dd95c1504f64946b8f769a6f41",
 		"data": {
-			"inGameID": "bassline",
+			"inGameStrID": "bassline",
 			"notecount": 415
 		},
 		"difficulty": "Past",
@@ -10434,7 +10434,7 @@
 	{
 		"chartID": "37392e11069a019562bb444a24f36d5e7ff5945b",
 		"data": {
-			"inGameID": "bassline",
+			"inGameStrID": "bassline",
 			"notecount": 548
 		},
 		"difficulty": "Present",
@@ -10450,7 +10450,7 @@
 	{
 		"chartID": "2b38cfe273f665dfd1ed541110ca73230a6b00a8",
 		"data": {
-			"inGameID": "lifeispiano",
+			"inGameStrID": "lifeispiano",
 			"notecount": 674
 		},
 		"difficulty": "Future",
@@ -10466,7 +10466,7 @@
 	{
 		"chartID": "b9fb81450c616807b0b80a428b532db30c4c304f",
 		"data": {
-			"inGameID": "lifeispiano",
+			"inGameStrID": "lifeispiano",
 			"notecount": 398
 		},
 		"difficulty": "Past",
@@ -10482,7 +10482,7 @@
 	{
 		"chartID": "c1e8440fea0ecb4dbcbcee0fc908ba77d9dd99f9",
 		"data": {
-			"inGameID": "lifeispiano",
+			"inGameStrID": "lifeispiano",
 			"notecount": 437
 		},
 		"difficulty": "Present",
@@ -10498,7 +10498,7 @@
 	{
 		"chartID": "0466f093667f12d2c885efd92389a63bcbfa0d1f",
 		"data": {
-			"inGameID": "paperwitch",
+			"inGameStrID": "paperwitch",
 			"notecount": 793
 		},
 		"difficulty": "Future",
@@ -10514,7 +10514,7 @@
 	{
 		"chartID": "c281793fcc7b7120dcae8e5715fdeb412e0e67b7",
 		"data": {
-			"inGameID": "paperwitch",
+			"inGameStrID": "paperwitch",
 			"notecount": 348
 		},
 		"difficulty": "Past",
@@ -10530,7 +10530,7 @@
 	{
 		"chartID": "7c6e6f9cb2ae25d529a3038ebed2fd0bad10d187",
 		"data": {
-			"inGameID": "paperwitch",
+			"inGameStrID": "paperwitch",
 			"notecount": 487
 		},
 		"difficulty": "Present",
@@ -10546,7 +10546,7 @@
 	{
 		"chartID": "e4212621bddba4989348e182b72691fa25622966",
 		"data": {
-			"inGameID": "crystalgravity",
+			"inGameStrID": "crystalgravity",
 			"notecount": 872
 		},
 		"difficulty": "Future",
@@ -10562,7 +10562,7 @@
 	{
 		"chartID": "1744aafcf5ca2e62fffc6821817fecba451b11cd",
 		"data": {
-			"inGameID": "crystalgravity",
+			"inGameStrID": "crystalgravity",
 			"notecount": 571
 		},
 		"difficulty": "Past",
@@ -10578,7 +10578,7 @@
 	{
 		"chartID": "dc84cf286c46a9304f21b9ae9b8e994fbd13e5ba",
 		"data": {
-			"inGameID": "crystalgravity",
+			"inGameStrID": "crystalgravity",
 			"notecount": 653
 		},
 		"difficulty": "Present",
@@ -10594,7 +10594,7 @@
 	{
 		"chartID": "f6fe57e1dfe73dc555b10a4f3e2d48bf2dd399e0",
 		"data": {
-			"inGameID": "farawaylight",
+			"inGameStrID": "farawaylight",
 			"notecount": 1322
 		},
 		"difficulty": "Future",
@@ -10610,7 +10610,7 @@
 	{
 		"chartID": "a96009c303afbe1d4dc1fcd9e0d42c2cc462e509",
 		"data": {
-			"inGameID": "farawaylight",
+			"inGameStrID": "farawaylight",
 			"notecount": 656
 		},
 		"difficulty": "Past",
@@ -10626,7 +10626,7 @@
 	{
 		"chartID": "ad16ac3247d06a6ab31ae1d189b5948e3dfaeb91",
 		"data": {
-			"inGameID": "farawaylight",
+			"inGameStrID": "farawaylight",
 			"notecount": 769
 		},
 		"difficulty": "Present",
@@ -10642,7 +10642,7 @@
 	{
 		"chartID": "e069e3a79c8231d0e0ef20e92635e832b6a5b342",
 		"data": {
-			"inGameID": "loschen",
+			"inGameStrID": "loschen",
 			"notecount": 1235
 		},
 		"difficulty": "Future",
@@ -10658,7 +10658,7 @@
 	{
 		"chartID": "11f5b572471e5bc49c709de03c8a5211298bff8a",
 		"data": {
-			"inGameID": "loschen",
+			"inGameStrID": "loschen",
 			"notecount": 642
 		},
 		"difficulty": "Past",
@@ -10674,7 +10674,7 @@
 	{
 		"chartID": "b690d8eaa8332216df0f3986c1b23c8ed27e57fd",
 		"data": {
-			"inGameID": "loschen",
+			"inGameStrID": "loschen",
 			"notecount": 850
 		},
 		"difficulty": "Present",
@@ -10690,7 +10690,7 @@
 	{
 		"chartID": "436bf3f04adc6e82360c916e9670d6adc9a676b2",
 		"data": {
-			"inGameID": "aegleseeker",
+			"inGameStrID": "aegleseeker",
 			"notecount": 1568
 		},
 		"difficulty": "Future",
@@ -10706,7 +10706,7 @@
 	{
 		"chartID": "bc43a5276055bdd538aa97adb857a713f3ad5203",
 		"data": {
-			"inGameID": "aegleseeker",
+			"inGameStrID": "aegleseeker",
 			"notecount": 973
 		},
 		"difficulty": "Past",
@@ -10722,7 +10722,7 @@
 	{
 		"chartID": "fe09ce871d8d35f08972751ca5784703fd1acd32",
 		"data": {
-			"inGameID": "aegleseeker",
+			"inGameStrID": "aegleseeker",
 			"notecount": 1235
 		},
 		"difficulty": "Present",
@@ -10738,7 +10738,7 @@
 	{
 		"chartID": "74c5c96129d18c48bd8df479f29171d92b977afd",
 		"data": {
-			"inGameID": "coastalhighway",
+			"inGameStrID": "coastalhighway",
 			"notecount": 732
 		},
 		"difficulty": "Future",
@@ -10754,7 +10754,7 @@
 	{
 		"chartID": "85cd90e55f1543ed50a0de73f88dcb262c4c0f84",
 		"data": {
-			"inGameID": "coastalhighway",
+			"inGameStrID": "coastalhighway",
 			"notecount": 355
 		},
 		"difficulty": "Past",
@@ -10770,7 +10770,7 @@
 	{
 		"chartID": "356eff6d0912bd1f6f4d00fd143e0e6ddb46e053",
 		"data": {
-			"inGameID": "coastalhighway",
+			"inGameStrID": "coastalhighway",
 			"notecount": 479
 		},
 		"difficulty": "Present",
@@ -10786,7 +10786,7 @@
 	{
 		"chartID": "3fee46f0fde0ffa8e50428e98cb1c352ccb003f5",
 		"data": {
-			"inGameID": "odysseia",
+			"inGameStrID": "odysseia",
 			"notecount": 1092
 		},
 		"difficulty": "Future",
@@ -10802,7 +10802,7 @@
 	{
 		"chartID": "2e7f269278fd1da6e63258ec50f8887a91d8ee9c",
 		"data": {
-			"inGameID": "odysseia",
+			"inGameStrID": "odysseia",
 			"notecount": 717
 		},
 		"difficulty": "Past",
@@ -10818,7 +10818,7 @@
 	{
 		"chartID": "8fc4e679a2db819e428e9ceb3a9269dd73db3a93",
 		"data": {
-			"inGameID": "odysseia",
+			"inGameStrID": "odysseia",
 			"notecount": 909
 		},
 		"difficulty": "Present",
@@ -10834,7 +10834,7 @@
 	{
 		"chartID": "2c285b9bb196fe1765c5e8665b02aea8a48c9897",
 		"data": {
-			"inGameID": "overwhelm",
+			"inGameStrID": "overwhelm",
 			"notecount": 1251
 		},
 		"difficulty": "Future",
@@ -10850,7 +10850,7 @@
 	{
 		"chartID": "9d6ca549360544f4f53f34b3854417c10d35655c",
 		"data": {
-			"inGameID": "overwhelm",
+			"inGameStrID": "overwhelm",
 			"notecount": 854
 		},
 		"difficulty": "Past",
@@ -10866,7 +10866,7 @@
 	{
 		"chartID": "678d3dab4cd1e54b660a79125ede2a06afa674d1",
 		"data": {
-			"inGameID": "overwhelm",
+			"inGameStrID": "overwhelm",
 			"notecount": 1038
 		},
 		"difficulty": "Present",
@@ -10882,7 +10882,7 @@
 	{
 		"chartID": "25743741b4d355a702f3e3e8d97f0e580847e46c",
 		"data": {
-			"inGameID": "vandalism",
+			"inGameStrID": "vandalism",
 			"notecount": 1087
 		},
 		"difficulty": "Future",
@@ -10898,7 +10898,7 @@
 	{
 		"chartID": "239d41905a27a399e24d963e389756f14d02eab9",
 		"data": {
-			"inGameID": "vandalism",
+			"inGameStrID": "vandalism",
 			"notecount": 668
 		},
 		"difficulty": "Past",
@@ -10914,7 +10914,7 @@
 	{
 		"chartID": "042f8315f9544d775339880467b6dbf93b09adeb",
 		"data": {
-			"inGameID": "vandalism",
+			"inGameStrID": "vandalism",
 			"notecount": 685
 		},
 		"difficulty": "Present",
@@ -10930,7 +10930,7 @@
 	{
 		"chartID": "a83ac87c4c11c8b015cecb692e80f2b6873dec32",
 		"data": {
-			"inGameID": "turbocharger",
+			"inGameStrID": "turbocharger",
 			"notecount": 979
 		},
 		"difficulty": "Future",
@@ -10946,7 +10946,7 @@
 	{
 		"chartID": "4a1b36770b8a9167494e30946e53644fa3f5a0f4",
 		"data": {
-			"inGameID": "turbocharger",
+			"inGameStrID": "turbocharger",
 			"notecount": 419
 		},
 		"difficulty": "Past",
@@ -10962,7 +10962,7 @@
 	{
 		"chartID": "7f0420323cc9e94d8191e6830af56a1e82695cde",
 		"data": {
-			"inGameID": "turbocharger",
+			"inGameStrID": "turbocharger",
 			"notecount": 659
 		},
 		"difficulty": "Present",
@@ -10978,7 +10978,7 @@
 	{
 		"chartID": "0878d94d7c59aeb935a40ca690eeda9566c0466d",
 		"data": {
-			"inGameID": "theultimacy",
+			"inGameStrID": "theultimacy",
 			"notecount": 1304
 		},
 		"difficulty": "Future",
@@ -10994,7 +10994,7 @@
 	{
 		"chartID": "b9d14eb92aac77575b4af64cbd314813e224ba53",
 		"data": {
-			"inGameID": "theultimacy",
+			"inGameStrID": "theultimacy",
 			"notecount": 749
 		},
 		"difficulty": "Past",
@@ -11010,7 +11010,7 @@
 	{
 		"chartID": "cf4a3f0b8caf6d1dd293caf8656060f61eb7874a",
 		"data": {
-			"inGameID": "theultimacy",
+			"inGameStrID": "theultimacy",
 			"notecount": 919
 		},
 		"difficulty": "Present",
@@ -11026,7 +11026,7 @@
 	{
 		"chartID": "f15ab15f2f15008d1bb95e629689b48852d17529",
 		"data": {
-			"inGameID": "rekkaresonance",
+			"inGameStrID": "rekkaresonance",
 			"notecount": 1212
 		},
 		"difficulty": "Future",
@@ -11042,7 +11042,7 @@
 	{
 		"chartID": "9147ed51e9096b4d52bedfecca134f73db6f89d7",
 		"data": {
-			"inGameID": "rekkaresonance",
+			"inGameStrID": "rekkaresonance",
 			"notecount": 860
 		},
 		"difficulty": "Past",
@@ -11058,7 +11058,7 @@
 	{
 		"chartID": "f0d6d79d504cf50af11b48fa3020bf2dbda0ffbf",
 		"data": {
-			"inGameID": "rekkaresonance",
+			"inGameStrID": "rekkaresonance",
 			"notecount": 1051
 		},
 		"difficulty": "Present",
@@ -11074,7 +11074,7 @@
 	{
 		"chartID": "18a0e1aeae8e1d6944ef9b24c1a25f4ec9b814cf",
 		"data": {
-			"inGameID": "kyogenkigo",
+			"inGameStrID": "kyogenkigo",
 			"notecount": 969
 		},
 		"difficulty": "Future",
@@ -11090,7 +11090,7 @@
 	{
 		"chartID": "90f9520ba0304d31b773ee04742aa7fe59deb307",
 		"data": {
-			"inGameID": "kyogenkigo",
+			"inGameStrID": "kyogenkigo",
 			"notecount": 576
 		},
 		"difficulty": "Past",
@@ -11106,7 +11106,7 @@
 	{
 		"chartID": "60e7e89a3ed1cc3bf1dc73a33f82422c258f8220",
 		"data": {
-			"inGameID": "kyogenkigo",
+			"inGameStrID": "kyogenkigo",
 			"notecount": 684
 		},
 		"difficulty": "Present",
@@ -11122,7 +11122,7 @@
 	{
 		"chartID": "25a5a8d3a627a5de834e5aee53b002a5113eb080",
 		"data": {
-			"inGameID": "hivemind",
+			"inGameStrID": "hivemind",
 			"notecount": 1252
 		},
 		"difficulty": "Future",
@@ -11138,7 +11138,7 @@
 	{
 		"chartID": "18f7f852dbdba037fa62e6bae441a790b4fc0642",
 		"data": {
-			"inGameID": "hivemind",
+			"inGameStrID": "hivemind",
 			"notecount": 995
 		},
 		"difficulty": "Past",
@@ -11154,7 +11154,7 @@
 	{
 		"chartID": "8bbcb518f249ccbe612e36ef3a0e39ce238c3b08",
 		"data": {
-			"inGameID": "hivemind",
+			"inGameStrID": "hivemind",
 			"notecount": 988
 		},
 		"difficulty": "Present",
@@ -11170,7 +11170,7 @@
 	{
 		"chartID": "f675b044aedc81d780099b764774713960a6e2d6",
 		"data": {
-			"inGameID": "seclusion",
+			"inGameStrID": "seclusion",
 			"notecount": 1132
 		},
 		"difficulty": "Future",
@@ -11186,7 +11186,7 @@
 	{
 		"chartID": "6dd7fe7c973ec9d47ce61a755188ac8fac382ee7",
 		"data": {
-			"inGameID": "seclusion",
+			"inGameStrID": "seclusion",
 			"notecount": 544
 		},
 		"difficulty": "Past",
@@ -11202,7 +11202,7 @@
 	{
 		"chartID": "b55c98db99d927748e380ecff57662f0718b5e73",
 		"data": {
-			"inGameID": "seclusion",
+			"inGameStrID": "seclusion",
 			"notecount": 762
 		},
 		"difficulty": "Present",
@@ -11218,7 +11218,7 @@
 	{
 		"chartID": "ab7badf3dfc3b0998dfa39986f42f63792fb0f27",
 		"data": {
-			"inGameID": "smallcloud",
+			"inGameStrID": "smallcloud",
 			"notecount": 919
 		},
 		"difficulty": "Future",
@@ -11234,7 +11234,7 @@
 	{
 		"chartID": "a213669fb2fb1e8af59799c38791ba4e55acfbe8",
 		"data": {
-			"inGameID": "smallcloud",
+			"inGameStrID": "smallcloud",
 			"notecount": 548
 		},
 		"difficulty": "Past",
@@ -11250,7 +11250,7 @@
 	{
 		"chartID": "6b5e5440ffe2338ff76c8f38623e9d14e1f1b653",
 		"data": {
-			"inGameID": "smallcloud",
+			"inGameStrID": "smallcloud",
 			"notecount": 727
 		},
 		"difficulty": "Present",
@@ -11266,7 +11266,7 @@
 	{
 		"chartID": "797bf02a399dbcff809743a0bdbb9ac5c5640d8d",
 		"data": {
-			"inGameID": "alterale",
+			"inGameStrID": "alterale",
 			"notecount": 1277
 		},
 		"difficulty": "Future",
@@ -11282,7 +11282,7 @@
 	{
 		"chartID": "3730f57af163343d7000e6ea395804c563a5e09a",
 		"data": {
-			"inGameID": "alterale",
+			"inGameStrID": "alterale",
 			"notecount": 728
 		},
 		"difficulty": "Past",
@@ -11298,7 +11298,7 @@
 	{
 		"chartID": "ba1868fca0ef9d75b94014223e7f0c084b4e858d",
 		"data": {
-			"inGameID": "alterale",
+			"inGameStrID": "alterale",
 			"notecount": 881
 		},
 		"difficulty": "Present",
@@ -11314,7 +11314,7 @@
 	{
 		"chartID": "88b84f687175d4ff58af74d06886de284062e40c",
 		"data": {
-			"inGameID": "divinelight",
+			"inGameStrID": "divinelight",
 			"notecount": 1021
 		},
 		"difficulty": "Future",
@@ -11330,7 +11330,7 @@
 	{
 		"chartID": "18f3086fcfffe16d1342c53fb20fd5172e29b79f",
 		"data": {
-			"inGameID": "divinelight",
+			"inGameStrID": "divinelight",
 			"notecount": 798
 		},
 		"difficulty": "Past",
@@ -11346,7 +11346,7 @@
 	{
 		"chartID": "303aebf771a845a8fdc321f95f5c292f842b52a8",
 		"data": {
-			"inGameID": "divinelight",
+			"inGameStrID": "divinelight",
 			"notecount": 835
 		},
 		"difficulty": "Present",
@@ -11362,7 +11362,7 @@
 	{
 		"chartID": "18774248e1d9abfe123b85bbcc703397f34e555c",
 		"data": {
-			"inGameID": "mazymetroplex",
+			"inGameStrID": "mazymetroplex",
 			"notecount": 952
 		},
 		"difficulty": "Future",
@@ -11378,7 +11378,7 @@
 	{
 		"chartID": "f9831ca3f298d54fc4252eae6ba69f8821022a23",
 		"data": {
-			"inGameID": "mazymetroplex",
+			"inGameStrID": "mazymetroplex",
 			"notecount": 453
 		},
 		"difficulty": "Past",
@@ -11394,7 +11394,7 @@
 	{
 		"chartID": "be2c70f3d7ca12d4cecdf20bfda55eeb65b6c178",
 		"data": {
-			"inGameID": "mazymetroplex",
+			"inGameStrID": "mazymetroplex",
 			"notecount": 704
 		},
 		"difficulty": "Present",
@@ -11410,7 +11410,7 @@
 	{
 		"chartID": "4eb1e55f7195ccc4d068a46714e9577b5bee56a0",
 		"data": {
-			"inGameID": "quonwacca",
+			"inGameStrID": "quonwacca",
 			"notecount": 1044
 		},
 		"difficulty": "Beyond",
@@ -11426,7 +11426,7 @@
 	{
 		"chartID": "bb5342de8a740977c1bbd7ca8f66b16eefc974de",
 		"data": {
-			"inGameID": "quonwacca",
+			"inGameStrID": "quonwacca",
 			"notecount": 749
 		},
 		"difficulty": "Future",
@@ -11442,7 +11442,7 @@
 	{
 		"chartID": "07aff70cc9f38669c7cfe4dc99041d08aac6cf1b",
 		"data": {
-			"inGameID": "quonwacca",
+			"inGameStrID": "quonwacca",
 			"notecount": 425
 		},
 		"difficulty": "Past",
@@ -11458,7 +11458,7 @@
 	{
 		"chartID": "1eb9de344a1225549b3b8ad7dedeee86004c7a6a",
 		"data": {
-			"inGameID": "quonwacca",
+			"inGameStrID": "quonwacca",
 			"notecount": 496
 		},
 		"difficulty": "Present",
@@ -11474,7 +11474,7 @@
 	{
 		"chartID": "18bccfe1fc0d0a24e49f78b7e75a42554d0647cf",
 		"data": {
-			"inGameID": "withu",
+			"inGameStrID": "withu",
 			"notecount": 932
 		},
 		"difficulty": "Future",
@@ -11490,7 +11490,7 @@
 	{
 		"chartID": "595a1126ce239bc788b60a91125481bde0987069",
 		"data": {
-			"inGameID": "withu",
+			"inGameStrID": "withu",
 			"notecount": 448
 		},
 		"difficulty": "Past",
@@ -11506,7 +11506,7 @@
 	{
 		"chartID": "073b87102620470506e86f940aaa92782ad01ecc",
 		"data": {
-			"inGameID": "withu",
+			"inGameStrID": "withu",
 			"notecount": 649
 		},
 		"difficulty": "Present",
@@ -11522,7 +11522,7 @@
 	{
 		"chartID": "f8851952958ae718f84017e1819ea035eb443b18",
 		"data": {
-			"inGameID": "genocider",
+			"inGameStrID": "genocider",
 			"notecount": 1483
 		},
 		"difficulty": "Future",
@@ -11538,7 +11538,7 @@
 	{
 		"chartID": "4333887ed017982fb2f48ed7c078cbf063955a83",
 		"data": {
-			"inGameID": "genocider",
+			"inGameStrID": "genocider",
 			"notecount": 832
 		},
 		"difficulty": "Past",
@@ -11554,7 +11554,7 @@
 	{
 		"chartID": "472a413af5128525f56b144509ba5e6af4db98b4",
 		"data": {
-			"inGameID": "genocider",
+			"inGameStrID": "genocider",
 			"notecount": 1025
 		},
 		"difficulty": "Present",
@@ -11570,7 +11570,7 @@
 	{
 		"chartID": "ba260640ed7627d96405e37ff27c1923b258cc1d",
 		"data": {
-			"inGameID": "letyoudivermx",
+			"inGameStrID": "letyoudivermx",
 			"notecount": 1049
 		},
 		"difficulty": "Future",
@@ -11586,7 +11586,7 @@
 	{
 		"chartID": "30e2f541b5c2c8d12bcbeb2d8caa9faf65af86c6",
 		"data": {
-			"inGameID": "letyoudivermx",
+			"inGameStrID": "letyoudivermx",
 			"notecount": 608
 		},
 		"difficulty": "Past",
@@ -11602,7 +11602,7 @@
 	{
 		"chartID": "eb4e69a8694d06b552996bb077400e866c79f3ef",
 		"data": {
-			"inGameID": "letyoudivermx",
+			"inGameStrID": "letyoudivermx",
 			"notecount": 819
 		},
 		"difficulty": "Present",
@@ -11618,7 +11618,7 @@
 	{
 		"chartID": "1d7697eb60151e6dfc1a31e546a6919163ffe911",
 		"data": {
-			"inGameID": "sheriruthrmx",
+			"inGameStrID": "sheriruthrmx",
 			"notecount": 1134
 		},
 		"difficulty": "Future",
@@ -11634,7 +11634,7 @@
 	{
 		"chartID": "9455c2bb7424c2da70d696e40266e4677dd026cf",
 		"data": {
-			"inGameID": "sheriruthrmx",
+			"inGameStrID": "sheriruthrmx",
 			"notecount": 671
 		},
 		"difficulty": "Past",
@@ -11650,7 +11650,7 @@
 	{
 		"chartID": "674e596025062373a3e4847ad10b5c006a870d12",
 		"data": {
-			"inGameID": "sheriruthrmx",
+			"inGameStrID": "sheriruthrmx",
 			"notecount": 795
 		},
 		"difficulty": "Present",
@@ -11666,7 +11666,7 @@
 	{
 		"chartID": "2dd1f2dff88834afe02ecd3cec79246671f76208",
 		"data": {
-			"inGameID": "eveninginscarlet",
+			"inGameStrID": "eveninginscarlet",
 			"notecount": 922
 		},
 		"difficulty": "Future",
@@ -11682,7 +11682,7 @@
 	{
 		"chartID": "a918d6d56932d5b01cdf6362336cac9b1f534ffb",
 		"data": {
-			"inGameID": "eveninginscarlet",
+			"inGameStrID": "eveninginscarlet",
 			"notecount": 530
 		},
 		"difficulty": "Past",
@@ -11698,7 +11698,7 @@
 	{
 		"chartID": "2e844f71fe8ccaadda80536351d8ccff332d84f0",
 		"data": {
-			"inGameID": "eveninginscarlet",
+			"inGameStrID": "eveninginscarlet",
 			"notecount": 638
 		},
 		"difficulty": "Present",
@@ -11714,7 +11714,7 @@
 	{
 		"chartID": "db71969c07b36595852d36a1025a2012ae62a7af",
 		"data": {
-			"inGameID": "bluecomet",
+			"inGameStrID": "bluecomet",
 			"notecount": 776
 		},
 		"difficulty": "Future",
@@ -11730,7 +11730,7 @@
 	{
 		"chartID": "a58792173dffb049e72fc4d285398961c615bf89",
 		"data": {
-			"inGameID": "bluecomet",
+			"inGameStrID": "bluecomet",
 			"notecount": 494
 		},
 		"difficulty": "Past",
@@ -11746,7 +11746,7 @@
 	{
 		"chartID": "107a9e21f202f718b90985f9c1b42865a012247e",
 		"data": {
-			"inGameID": "bluecomet",
+			"inGameStrID": "bluecomet",
 			"notecount": 645
 		},
 		"difficulty": "Present",
@@ -11762,7 +11762,7 @@
 	{
 		"chartID": "b940f23bc509a8f3691b7d7054541994546189af",
 		"data": {
-			"inGameID": "energysynergymatrix",
+			"inGameStrID": "energysynergymatrix",
 			"notecount": 922
 		},
 		"difficulty": "Future",
@@ -11778,7 +11778,7 @@
 	{
 		"chartID": "34eb8910bc99698899853f0ba8f6c3429f62ad8f",
 		"data": {
-			"inGameID": "energysynergymatrix",
+			"inGameStrID": "energysynergymatrix",
 			"notecount": 471
 		},
 		"difficulty": "Past",
@@ -11794,7 +11794,7 @@
 	{
 		"chartID": "9af74a6966e786ea2383bd353e73e38d802bcee3",
 		"data": {
-			"inGameID": "energysynergymatrix",
+			"inGameStrID": "energysynergymatrix",
 			"notecount": 608
 		},
 		"difficulty": "Present",
@@ -11810,7 +11810,7 @@
 	{
 		"chartID": "6283d90bf5ead27b28792edc4bcb98e459c247ff",
 		"data": {
-			"inGameID": "gengaozo",
+			"inGameStrID": "gengaozo",
 			"notecount": 1353
 		},
 		"difficulty": "Future",
@@ -11826,7 +11826,7 @@
 	{
 		"chartID": "81daac9db3f5b1ae977be95336b9baac9baba24b",
 		"data": {
-			"inGameID": "gengaozo",
+			"inGameStrID": "gengaozo",
 			"notecount": 580
 		},
 		"difficulty": "Past",
@@ -11842,7 +11842,7 @@
 	{
 		"chartID": "259c5933dd74582bcb6e2022bdf58c777a7aabdb",
 		"data": {
-			"inGameID": "gengaozo",
+			"inGameStrID": "gengaozo",
 			"notecount": 870
 		},
 		"difficulty": "Present",
@@ -11858,7 +11858,7 @@
 	{
 		"chartID": "4389463e54c77a0dab851282242bebc3d1ae3138",
 		"data": {
-			"inGameID": "goldenslaughterer",
+			"inGameStrID": "goldenslaughterer",
 			"notecount": 1326
 		},
 		"difficulty": "Future",
@@ -11874,7 +11874,7 @@
 	{
 		"chartID": "066c05c8e8b3585d2318b4117e53b1789b2d0f18",
 		"data": {
-			"inGameID": "goldenslaughterer",
+			"inGameStrID": "goldenslaughterer",
 			"notecount": 864
 		},
 		"difficulty": "Past",
@@ -11890,7 +11890,7 @@
 	{
 		"chartID": "845634d29901a5e4be3aa76a1a63c081b4f31f88",
 		"data": {
-			"inGameID": "goldenslaughterer",
+			"inGameStrID": "goldenslaughterer",
 			"notecount": 880
 		},
 		"difficulty": "Present",
@@ -11906,7 +11906,7 @@
 	{
 		"chartID": "2fe2544c96b3e7ae433721fb07399d4ede2d9af2",
 		"data": {
-			"inGameID": "lastendconductor",
+			"inGameStrID": "lastendconductor",
 			"notecount": 1339
 		},
 		"difficulty": "Beyond",
@@ -11922,7 +11922,7 @@
 	{
 		"chartID": "44945a93e4a5df634a3e30622e4ed6461ff6c3d7",
 		"data": {
-			"inGameID": "lastendconductor",
+			"inGameStrID": "lastendconductor",
 			"notecount": 1209
 		},
 		"difficulty": "Future",
@@ -11938,7 +11938,7 @@
 	{
 		"chartID": "0cd629d30741a3aaf51364f327d3671cd641cabf",
 		"data": {
-			"inGameID": "lastendconductor",
+			"inGameStrID": "lastendconductor",
 			"notecount": 726
 		},
 		"difficulty": "Past",
@@ -11954,7 +11954,7 @@
 	{
 		"chartID": "c612c281341d4095442a6ed099b120cc0b63965a",
 		"data": {
-			"inGameID": "lastendconductor",
+			"inGameStrID": "lastendconductor",
 			"notecount": 901
 		},
 		"difficulty": "Present",
@@ -11970,7 +11970,7 @@
 	{
 		"chartID": "ee195df719246e213d754f931d841dd79bc125ae",
 		"data": {
-			"inGameID": "redolentshape",
+			"inGameStrID": "redolentshape",
 			"notecount": 1088
 		},
 		"difficulty": "Future",
@@ -11986,7 +11986,7 @@
 	{
 		"chartID": "ef8be8ddab28d132c994153c71c9dd63615fe342",
 		"data": {
-			"inGameID": "redolentshape",
+			"inGameStrID": "redolentshape",
 			"notecount": 570
 		},
 		"difficulty": "Past",
@@ -12002,7 +12002,7 @@
 	{
 		"chartID": "4f034d86940a8c2bc90233bbdd53be4191e00bfb",
 		"data": {
-			"inGameID": "redolentshape",
+			"inGameStrID": "redolentshape",
 			"notecount": 717
 		},
 		"difficulty": "Present",
@@ -12018,7 +12018,7 @@
 	{
 		"chartID": "526c7c52160bb7e5ec2dbda3698b6c64969629be",
 		"data": {
-			"inGameID": "cosmica",
+			"inGameStrID": "cosmica",
 			"notecount": 773
 		},
 		"difficulty": "Future",
@@ -12034,7 +12034,7 @@
 	{
 		"chartID": "59118362af0bbd3fa39608ca2bebc88a7f4cce15",
 		"data": {
-			"inGameID": "cosmica",
+			"inGameStrID": "cosmica",
 			"notecount": 428
 		},
 		"difficulty": "Past",
@@ -12050,7 +12050,7 @@
 	{
 		"chartID": "8de46cc1317636422ce47eebdf0bc83b965dfd75",
 		"data": {
-			"inGameID": "cosmica",
+			"inGameStrID": "cosmica",
 			"notecount": 566
 		},
 		"difficulty": "Present",
@@ -12066,7 +12066,7 @@
 	{
 		"chartID": "55076ef409517473d73ee365f0c37a22140ddd9f",
 		"data": {
-			"inGameID": "ascent",
+			"inGameStrID": "ascent",
 			"notecount": 1023
 		},
 		"difficulty": "Future",
@@ -12082,7 +12082,7 @@
 	{
 		"chartID": "68bfc797c4b5a0c733934c721f4141b23c2802b2",
 		"data": {
-			"inGameID": "ascent",
+			"inGameStrID": "ascent",
 			"notecount": 455
 		},
 		"difficulty": "Past",
@@ -12098,7 +12098,7 @@
 	{
 		"chartID": "abeed2fe9893cc31e4c19dbcb0693a13decbec13",
 		"data": {
-			"inGameID": "ascent",
+			"inGameStrID": "ascent",
 			"notecount": 626
 		},
 		"difficulty": "Present",
@@ -12114,7 +12114,7 @@
 	{
 		"chartID": "6f54609d786ffaa963e466aac5125a4d85dc5a40",
 		"data": {
-			"inGameID": "livefastdieyoung",
+			"inGameStrID": "livefastdieyoung",
 			"notecount": 1292
 		},
 		"difficulty": "Future",
@@ -12130,7 +12130,7 @@
 	{
 		"chartID": "36a980f745f858625fdefc1e4b5711e3bd976f76",
 		"data": {
-			"inGameID": "livefastdieyoung",
+			"inGameStrID": "livefastdieyoung",
 			"notecount": 565
 		},
 		"difficulty": "Past",
@@ -12146,7 +12146,7 @@
 	{
 		"chartID": "3d09fc8bf8b6c05be4442b4e3edf9c58ecaf5bae",
 		"data": {
-			"inGameID": "livefastdieyoung",
+			"inGameStrID": "livefastdieyoung",
 			"notecount": 837
 		},
 		"difficulty": "Present",
@@ -12162,7 +12162,7 @@
 	{
 		"chartID": "8ef0099e9cce1340bb6413c7f3684ca747a75c17",
 		"data": {
-			"inGameID": "summerfireworks",
+			"inGameStrID": "summerfireworks",
 			"notecount": 1088
 		},
 		"difficulty": "Future",
@@ -12178,7 +12178,7 @@
 	{
 		"chartID": "b184a0ce7dbeb3e86f1748c94b9936df1eb14afb",
 		"data": {
-			"inGameID": "summerfireworks",
+			"inGameStrID": "summerfireworks",
 			"notecount": 478
 		},
 		"difficulty": "Past",
@@ -12194,7 +12194,7 @@
 	{
 		"chartID": "c085e35bf3a88db2698a6227e7caa9d6ab770adf",
 		"data": {
-			"inGameID": "summerfireworks",
+			"inGameStrID": "summerfireworks",
 			"notecount": 641
 		},
 		"difficulty": "Present",
@@ -12210,7 +12210,7 @@
 	{
 		"chartID": "1dc4312cae15863315b72aedbad76a0b5b99f071",
 		"data": {
-			"inGameID": "firstsnow",
+			"inGameStrID": "firstsnow",
 			"notecount": 578
 		},
 		"difficulty": "Future",
@@ -12226,7 +12226,7 @@
 	{
 		"chartID": "39ea1bec773409c491498341f62fa37e1e79e213",
 		"data": {
-			"inGameID": "firstsnow",
+			"inGameStrID": "firstsnow",
 			"notecount": 366
 		},
 		"difficulty": "Past",
@@ -12242,7 +12242,7 @@
 	{
 		"chartID": "78f7d85c3f424b23b0a1f814a569d49bc4e9a3fa",
 		"data": {
-			"inGameID": "firstsnow",
+			"inGameStrID": "firstsnow",
 			"notecount": 442
 		},
 		"difficulty": "Present",
@@ -12258,7 +12258,7 @@
 	{
 		"chartID": "0e8b3d16f4384f6882bb77dd060a65f4908e5689",
 		"data": {
-			"inGameID": "bluerose",
+			"inGameStrID": "bluerose",
 			"notecount": 955
 		},
 		"difficulty": "Future",
@@ -12274,7 +12274,7 @@
 	{
 		"chartID": "385d4cdf3b23625890690f8ecb7b9d7252fd02d8",
 		"data": {
-			"inGameID": "bluerose",
+			"inGameStrID": "bluerose",
 			"notecount": 595
 		},
 		"difficulty": "Past",
@@ -12290,7 +12290,7 @@
 	{
 		"chartID": "ec1ea52407dba2a28fdb754e358e557c1fda0635",
 		"data": {
-			"inGameID": "bluerose",
+			"inGameStrID": "bluerose",
 			"notecount": 669
 		},
 		"difficulty": "Present",
@@ -12306,7 +12306,7 @@
 	{
 		"chartID": "467fbcb9b730b9046f1545cfc1a10291c9db7bef",
 		"data": {
-			"inGameID": "blockedlibrary",
+			"inGameStrID": "blockedlibrary",
 			"notecount": 850
 		},
 		"difficulty": "Future",
@@ -12322,7 +12322,7 @@
 	{
 		"chartID": "20447a44a677cc0ec06bbbd23bc060e5508c1bc4",
 		"data": {
-			"inGameID": "blockedlibrary",
+			"inGameStrID": "blockedlibrary",
 			"notecount": 449
 		},
 		"difficulty": "Past",
@@ -12338,7 +12338,7 @@
 	{
 		"chartID": "c15c0f6ef030603dcec6a2c610fc77b26f80cc6b",
 		"data": {
-			"inGameID": "blockedlibrary",
+			"inGameStrID": "blockedlibrary",
 			"notecount": 622
 		},
 		"difficulty": "Present",
@@ -12354,7 +12354,7 @@
 	{
 		"chartID": "7ece3fc725ef330fb48ec94256c0beee998c138f",
 		"data": {
-			"inGameID": "neokosmo",
+			"inGameStrID": "neokosmo",
 			"notecount": 979
 		},
 		"difficulty": "Future",
@@ -12370,7 +12370,7 @@
 	{
 		"chartID": "2183e5151add8a9f96aee286ac5759aa24515ff3",
 		"data": {
-			"inGameID": "neokosmo",
+			"inGameStrID": "neokosmo",
 			"notecount": 603
 		},
 		"difficulty": "Past",
@@ -12386,7 +12386,7 @@
 	{
 		"chartID": "7b11323524485b3b0204cf35e93fbd966917f3b8",
 		"data": {
-			"inGameID": "neokosmo",
+			"inGameStrID": "neokosmo",
 			"notecount": 791
 		},
 		"difficulty": "Present",
@@ -12402,7 +12402,7 @@
 	{
 		"chartID": "dcfd6bedf827d2269fb4ec172cd9255677653423",
 		"data": {
-			"inGameID": "lightningscrew",
+			"inGameStrID": "lightningscrew",
 			"notecount": 1192
 		},
 		"difficulty": "Future",
@@ -12418,7 +12418,7 @@
 	{
 		"chartID": "57daa356a90136581589fa121540e26cc078bd7e",
 		"data": {
-			"inGameID": "lightningscrew",
+			"inGameStrID": "lightningscrew",
 			"notecount": 611
 		},
 		"difficulty": "Past",
@@ -12434,7 +12434,7 @@
 	{
 		"chartID": "0a558e0df2e4e19ca0938df31c607b8621899ce0",
 		"data": {
-			"inGameID": "lightningscrew",
+			"inGameStrID": "lightningscrew",
 			"notecount": 811
 		},
 		"difficulty": "Present",
@@ -12450,7 +12450,7 @@
 	{
 		"chartID": "6f23edc3907e92a3461def445ea8230b5d34688c",
 		"data": {
-			"inGameID": "lightsofmuse",
+			"inGameStrID": "lightsofmuse",
 			"notecount": 580
 		},
 		"difficulty": "Future",
@@ -12466,7 +12466,7 @@
 	{
 		"chartID": "5a9adbc48a85b01aa05d4e0f8ed3e302ce14f374",
 		"data": {
-			"inGameID": "lightsofmuse",
+			"inGameStrID": "lightsofmuse",
 			"notecount": 333
 		},
 		"difficulty": "Past",
@@ -12482,7 +12482,7 @@
 	{
 		"chartID": "b69b635c4c0942b6692cb0ab219f6c0037997a36",
 		"data": {
-			"inGameID": "lightsofmuse",
+			"inGameStrID": "lightsofmuse",
 			"notecount": 438
 		},
 		"difficulty": "Present",
@@ -12498,7 +12498,7 @@
 	{
 		"chartID": "6735b974f775eab7dd33cdeea29a182dda7946ee",
 		"data": {
-			"inGameID": "finalstep",
+			"inGameStrID": "finalstep",
 			"notecount": 1056
 		},
 		"difficulty": "Future",
@@ -12514,7 +12514,7 @@
 	{
 		"chartID": "35fd52b159ceb5b88ab392700f8a3a724c9ef1e5",
 		"data": {
-			"inGameID": "finalstep",
+			"inGameStrID": "finalstep",
 			"notecount": 625
 		},
 		"difficulty": "Past",
@@ -12530,7 +12530,7 @@
 	{
 		"chartID": "8a081c2366433d948c21b9969d15cf74e43bc234",
 		"data": {
-			"inGameID": "finalstep",
+			"inGameStrID": "finalstep",
 			"notecount": 684
 		},
 		"difficulty": "Present",
@@ -12546,7 +12546,7 @@
 	{
 		"chartID": "f1d15f622ca099689aa90c5668f0d61f0eaa12be",
 		"data": {
-			"inGameID": "akinokagerou",
+			"inGameStrID": "akinokagerou",
 			"notecount": 1077
 		},
 		"difficulty": "Future",
@@ -12562,7 +12562,7 @@
 	{
 		"chartID": "d2d42b42eea08910caeef7a8303dedbfeb42bfe8",
 		"data": {
-			"inGameID": "akinokagerou",
+			"inGameStrID": "akinokagerou",
 			"notecount": 533
 		},
 		"difficulty": "Past",
@@ -12578,7 +12578,7 @@
 	{
 		"chartID": "b213cbe63460a63dc379cfa20e5711f3ef36be91",
 		"data": {
-			"inGameID": "akinokagerou",
+			"inGameStrID": "akinokagerou",
 			"notecount": 733
 		},
 		"difficulty": "Present",
@@ -12594,7 +12594,7 @@
 	{
 		"chartID": "6a674f9454f8ff825032ff61e4139143db39756b",
 		"data": {
-			"inGameID": "medusa",
+			"inGameStrID": "medusa",
 			"notecount": 931
 		},
 		"difficulty": "Future",
@@ -12610,7 +12610,7 @@
 	{
 		"chartID": "4cc90674cbdec5af1909197848493db038258027",
 		"data": {
-			"inGameID": "medusa",
+			"inGameStrID": "medusa",
 			"notecount": 550
 		},
 		"difficulty": "Past",
@@ -12626,7 +12626,7 @@
 	{
 		"chartID": "e0a84ae67b20bfb0a03e2c9a29e33388a51485df",
 		"data": {
-			"inGameID": "medusa",
+			"inGameStrID": "medusa",
 			"notecount": 645
 		},
 		"difficulty": "Present",
@@ -12642,7 +12642,7 @@
 	{
 		"chartID": "7b52f88872d86e2866fba9866a59bd564368d6f7",
 		"data": {
-			"inGameID": "init",
+			"inGameStrID": "init",
 			"notecount": 1204
 		},
 		"difficulty": "Future",
@@ -12658,7 +12658,7 @@
 	{
 		"chartID": "4c44b14683fdd1337688bb64a8420febc6f04b2c",
 		"data": {
-			"inGameID": "init",
+			"inGameStrID": "init",
 			"notecount": 713
 		},
 		"difficulty": "Past",
@@ -12674,7 +12674,7 @@
 	{
 		"chartID": "92565ec7924a9140fd19297f65b60c5f76870f08",
 		"data": {
-			"inGameID": "init",
+			"inGameStrID": "init",
 			"notecount": 957
 		},
 		"difficulty": "Present",
@@ -12690,7 +12690,7 @@
 	{
 		"chartID": "00b7a1d04d3ccd995e2ef49fb9fd9bb2c86cc5f0",
 		"data": {
-			"inGameID": "internetoverdose",
+			"inGameStrID": "internetoverdose",
 			"notecount": 657
 		},
 		"difficulty": "Future",
@@ -12706,7 +12706,7 @@
 	{
 		"chartID": "427a8d8588d8618e61957a1d513d6e17bad1802f",
 		"data": {
-			"inGameID": "internetoverdose",
+			"inGameStrID": "internetoverdose",
 			"notecount": 430
 		},
 		"difficulty": "Past",
@@ -12722,7 +12722,7 @@
 	{
 		"chartID": "8b54b31715e9413cb5fda8e2eb1b2ded460a0e8d",
 		"data": {
-			"inGameID": "internetoverdose",
+			"inGameStrID": "internetoverdose",
 			"notecount": 578
 		},
 		"difficulty": "Present",
@@ -12738,7 +12738,7 @@
 	{
 		"chartID": "45c3ab551003430d5c9cf9f7d610eda33d82770a",
 		"data": {
-			"inGameID": "sakurafubuki",
+			"inGameStrID": "sakurafubuki",
 			"notecount": 837
 		},
 		"difficulty": "Future",
@@ -12754,7 +12754,7 @@
 	{
 		"chartID": "874efdf1a3366f53746da969a9bd2b921491601e",
 		"data": {
-			"inGameID": "sakurafubuki",
+			"inGameStrID": "sakurafubuki",
 			"notecount": 526
 		},
 		"difficulty": "Past",
@@ -12770,7 +12770,7 @@
 	{
 		"chartID": "1b707081e543d6618e45708d5c74128698742951",
 		"data": {
-			"inGameID": "sakurafubuki",
+			"inGameStrID": "sakurafubuki",
 			"notecount": 571
 		},
 		"difficulty": "Present",
@@ -12786,7 +12786,7 @@
 	{
 		"chartID": "42d742f1addc7f714cfe36bd7bf44ef5dff2e45d",
 		"data": {
-			"inGameID": "nulctrl",
+			"inGameStrID": "nulctrl",
 			"notecount": 715
 		},
 		"difficulty": "Future",
@@ -12802,7 +12802,7 @@
 	{
 		"chartID": "686bd56fa8e37d98cceb8bdace1b385c58fb8cf7",
 		"data": {
-			"inGameID": "nulctrl",
+			"inGameStrID": "nulctrl",
 			"notecount": 407
 		},
 		"difficulty": "Past",
@@ -12818,7 +12818,7 @@
 	{
 		"chartID": "6412519986c784dc86a5372bc93eb196fe35f415",
 		"data": {
-			"inGameID": "nulctrl",
+			"inGameStrID": "nulctrl",
 			"notecount": 410
 		},
 		"difficulty": "Present",
@@ -12834,7 +12834,7 @@
 	{
 		"chartID": "131f0b22826d1b9fae2c06dce0b9548b28b00e9d",
 		"data": {
-			"inGameID": "macromod",
+			"inGameStrID": "macromod",
 			"notecount": 1117
 		},
 		"difficulty": "Future",
@@ -12850,7 +12850,7 @@
 	{
 		"chartID": "0d60771bfc4a03217546add66eaff13ed351d7d3",
 		"data": {
-			"inGameID": "macromod",
+			"inGameStrID": "macromod",
 			"notecount": 608
 		},
 		"difficulty": "Past",
@@ -12866,7 +12866,7 @@
 	{
 		"chartID": "71a7c8061bc41b9b576cf5011403203f98fc5b4e",
 		"data": {
-			"inGameID": "macromod",
+			"inGameStrID": "macromod",
 			"notecount": 794
 		},
 		"difficulty": "Present",
@@ -12882,7 +12882,7 @@
 	{
 		"chartID": "7a5aca338a7f07d10d02f7b0b7d93bd655fa93f5",
 		"data": {
-			"inGameID": "neowings",
+			"inGameStrID": "neowings",
 			"notecount": 1328
 		},
 		"difficulty": "Future",
@@ -12898,7 +12898,7 @@
 	{
 		"chartID": "51e16702c12aa6052123a9c1b7654f255f01ff3c",
 		"data": {
-			"inGameID": "neowings",
+			"inGameStrID": "neowings",
 			"notecount": 591
 		},
 		"difficulty": "Past",
@@ -12914,7 +12914,7 @@
 	{
 		"chartID": "f4f4e714fec39ca2b82c2b6e364ac6e3e8b9833c",
 		"data": {
-			"inGameID": "neowings",
+			"inGameStrID": "neowings",
 			"notecount": 840
 		},
 		"difficulty": "Present",
@@ -12930,7 +12930,7 @@
 	{
 		"chartID": "ab4848eaa6cc86bb9166c070594f413c6c7a7b46",
 		"data": {
-			"inGameID": "kissinglucifer",
+			"inGameStrID": "kissinglucifer",
 			"notecount": 1183
 		},
 		"difficulty": "Future",
@@ -12946,7 +12946,7 @@
 	{
 		"chartID": "79e6e164b97e5c40d0eafc1ed7009f2c4813e7fe",
 		"data": {
-			"inGameID": "kissinglucifer",
+			"inGameStrID": "kissinglucifer",
 			"notecount": 639
 		},
 		"difficulty": "Past",
@@ -12962,7 +12962,7 @@
 	{
 		"chartID": "5bff81145147b4a9c7c389dd091422e6b4359468",
 		"data": {
-			"inGameID": "kissinglucifer",
+			"inGameStrID": "kissinglucifer",
 			"notecount": 770
 		},
 		"difficulty": "Present",
@@ -12978,7 +12978,7 @@
 	{
 		"chartID": "7a6bad91ae19e99a9bf66c806e4f6cac25066d6b",
 		"data": {
-			"inGameID": "avril",
+			"inGameStrID": "avril",
 			"notecount": 851
 		},
 		"difficulty": "Future",
@@ -12994,7 +12994,7 @@
 	{
 		"chartID": "6c9c8df938d9d55ae05508ef8ded496161486563",
 		"data": {
-			"inGameID": "avril",
+			"inGameStrID": "avril",
 			"notecount": 459
 		},
 		"difficulty": "Past",
@@ -13010,7 +13010,7 @@
 	{
 		"chartID": "1f55a29b1935ef5a07fa0a1ed36499c25882e43d",
 		"data": {
-			"inGameID": "avril",
+			"inGameStrID": "avril",
 			"notecount": 607
 		},
 		"difficulty": "Present",
@@ -13026,7 +13026,7 @@
 	{
 		"chartID": "6eaddeea7785e39e94cc73eb4cbe8894abc77b00",
 		"data": {
-			"inGameID": "aurgelmir",
+			"inGameStrID": "aurgelmir",
 			"notecount": 1100
 		},
 		"difficulty": "Future",
@@ -13042,7 +13042,7 @@
 	{
 		"chartID": "72ee50bdf927ea9babd3f86af4d7cf2d59d99cd8",
 		"data": {
-			"inGameID": "aurgelmir",
+			"inGameStrID": "aurgelmir",
 			"notecount": 540
 		},
 		"difficulty": "Past",
@@ -13058,7 +13058,7 @@
 	{
 		"chartID": "d10f82ebfcac32cf17fd111e3e69251b3f6b2b1f",
 		"data": {
-			"inGameID": "aurgelmir",
+			"inGameStrID": "aurgelmir",
 			"notecount": 765
 		},
 		"difficulty": "Present",
@@ -13074,7 +13074,7 @@
 	{
 		"chartID": "4835b228350ee2658ae191e839f97da8e0ef4650",
 		"data": {
-			"inGameID": "headbonkache",
+			"inGameStrID": "headbonkache",
 			"notecount": 1061
 		},
 		"difficulty": "Future",
@@ -13090,7 +13090,7 @@
 	{
 		"chartID": "1195b764930c533816c964847203c136328c0eb5",
 		"data": {
-			"inGameID": "headbonkache",
+			"inGameStrID": "headbonkache",
 			"notecount": 570
 		},
 		"difficulty": "Past",
@@ -13106,7 +13106,7 @@
 	{
 		"chartID": "c132347e09ca816eae2f50177454f1fb7ee61e53",
 		"data": {
-			"inGameID": "headbonkache",
+			"inGameStrID": "headbonkache",
 			"notecount": 725
 		},
 		"difficulty": "Present",
@@ -13122,7 +13122,7 @@
 	{
 		"chartID": "fbc65111314a3dcd33b3065a8fc42a817ed9befd",
 		"data": {
-			"inGameID": "ddd",
+			"inGameStrID": "ddd",
 			"notecount": 653
 		},
 		"difficulty": "Future",
@@ -13138,7 +13138,7 @@
 	{
 		"chartID": "c9fada9172d90a3f2505987ffe0f72570fa90339",
 		"data": {
-			"inGameID": "ddd",
+			"inGameStrID": "ddd",
 			"notecount": 363
 		},
 		"difficulty": "Past",
@@ -13154,7 +13154,7 @@
 	{
 		"chartID": "b3acf6b09fe35b8179a823deedf59817c910ab8e",
 		"data": {
-			"inGameID": "ddd",
+			"inGameStrID": "ddd",
 			"notecount": 484
 		},
 		"difficulty": "Present",
@@ -13170,7 +13170,7 @@
 	{
 		"chartID": "803a774a4d313f812d193d086246b9de4091590b",
 		"data": {
-			"inGameID": "prism",
+			"inGameStrID": "prism",
 			"notecount": 785
 		},
 		"difficulty": "Future",
@@ -13186,7 +13186,7 @@
 	{
 		"chartID": "ad2df53476d5342e348f53429ab34f1abc88effd",
 		"data": {
-			"inGameID": "prism",
+			"inGameStrID": "prism",
 			"notecount": 476
 		},
 		"difficulty": "Past",
@@ -13202,7 +13202,7 @@
 	{
 		"chartID": "a99bb20888cfefdf6ebdf65db3e314c95c248176",
 		"data": {
-			"inGameID": "prism",
+			"inGameStrID": "prism",
 			"notecount": 544
 		},
 		"difficulty": "Present",
@@ -13218,7 +13218,7 @@
 	{
 		"chartID": "86c2db9a0e35d8cbab79d60ea6404615fec2e549",
 		"data": {
-			"inGameID": "protoflicker",
+			"inGameStrID": "protoflicker",
 			"notecount": 1042
 		},
 		"difficulty": "Future",
@@ -13234,7 +13234,7 @@
 	{
 		"chartID": "9809ac5f99edb25f351eab0bdb7b65ce6b7c8718",
 		"data": {
-			"inGameID": "protoflicker",
+			"inGameStrID": "protoflicker",
 			"notecount": 510
 		},
 		"difficulty": "Past",
@@ -13250,7 +13250,7 @@
 	{
 		"chartID": "901c4359439c19bcb924dc672136f5907afbaeeb",
 		"data": {
-			"inGameID": "protoflicker",
+			"inGameStrID": "protoflicker",
 			"notecount": 633
 		},
 		"difficulty": "Present",
@@ -13266,7 +13266,7 @@
 	{
 		"chartID": "1b991aa03bbd35439976e509acc6f34dad9188be",
 		"data": {
-			"inGameID": "stasis",
+			"inGameStrID": "stasis",
 			"notecount": 1521
 		},
 		"difficulty": "Future",
@@ -13282,7 +13282,7 @@
 	{
 		"chartID": "cd66ddb33073a32c22f89ac69feb8c9d5d290baa",
 		"data": {
-			"inGameID": "stasis",
+			"inGameStrID": "stasis",
 			"notecount": 848
 		},
 		"difficulty": "Past",
@@ -13298,7 +13298,7 @@
 	{
 		"chartID": "1b013b098694623f6e91ac8ba3d4d64fb38858b0",
 		"data": {
-			"inGameID": "stasis",
+			"inGameStrID": "stasis",
 			"notecount": 935
 		},
 		"difficulty": "Present",
@@ -13314,7 +13314,7 @@
 	{
 		"chartID": "105b97efd6e172d6f80ab0d6abbb2ddc2138663b",
 		"data": {
-			"inGameID": "picopicotranslation",
+			"inGameStrID": "picopicotranslation",
 			"notecount": 1049
 		},
 		"difficulty": "Future",
@@ -13330,7 +13330,7 @@
 	{
 		"chartID": "f455a34d92771b71f5157535625be1451792df5f",
 		"data": {
-			"inGameID": "picopicotranslation",
+			"inGameStrID": "picopicotranslation",
 			"notecount": 543
 		},
 		"difficulty": "Past",
@@ -13346,7 +13346,7 @@
 	{
 		"chartID": "daf08b0b40794bc01dff1db04f2c3bd38a1b8f9c",
 		"data": {
-			"inGameID": "picopicotranslation",
+			"inGameStrID": "picopicotranslation",
 			"notecount": 723
 		},
 		"difficulty": "Present",
@@ -13362,7 +13362,7 @@
 	{
 		"chartID": "7c2ddd2caabc57c3b8629c869619519b18812cd0",
 		"data": {
-			"inGameID": "nekonote",
+			"inGameStrID": "nekonote",
 			"notecount": 891
 		},
 		"difficulty": "Future",
@@ -13378,7 +13378,7 @@
 	{
 		"chartID": "e566274738b32561e0998361a995140cc87146cd",
 		"data": {
-			"inGameID": "nekonote",
+			"inGameStrID": "nekonote",
 			"notecount": 417
 		},
 		"difficulty": "Past",
@@ -13394,7 +13394,7 @@
 	{
 		"chartID": "7e9dc15424c3fc8774b2beac6241f897afdc8fd1",
 		"data": {
-			"inGameID": "nekonote",
+			"inGameStrID": "nekonote",
 			"notecount": 593
 		},
 		"difficulty": "Present",
@@ -13410,7 +13410,7 @@
 	{
 		"chartID": "6a485834aecbfef9200c89ef6d8f568bcef4ad4c",
 		"data": {
-			"inGameID": "mu",
+			"inGameStrID": "mu",
 			"notecount": 1256
 		},
 		"difficulty": "Future",
@@ -13426,7 +13426,7 @@
 	{
 		"chartID": "86d9ccb44e1f573c286a3ce72d90742d128a1658",
 		"data": {
-			"inGameID": "mu",
+			"inGameStrID": "mu",
 			"notecount": 825
 		},
 		"difficulty": "Past",
@@ -13442,7 +13442,7 @@
 	{
 		"chartID": "f1f2ff1a24a1ca6a5ea6cd344ff56a11192002b5",
 		"data": {
-			"inGameID": "mu",
+			"inGameStrID": "mu",
 			"notecount": 986
 		},
 		"difficulty": "Present",
@@ -13458,7 +13458,7 @@
 	{
 		"chartID": "ca69b6d3b1643ff017790b263d8a820c46fb285e",
 		"data": {
-			"inGameID": "sanskia",
+			"inGameStrID": "sanskia",
 			"notecount": 1046
 		},
 		"difficulty": "Future",
@@ -13474,7 +13474,7 @@
 	{
 		"chartID": "aab3f30f3e068c2b45aa961c516599857ebf6bfe",
 		"data": {
-			"inGameID": "sanskia",
+			"inGameStrID": "sanskia",
 			"notecount": 670
 		},
 		"difficulty": "Past",
@@ -13490,7 +13490,7 @@
 	{
 		"chartID": "5e8b4da3f318f123a29e6eacf6c161e7f5ad2cee",
 		"data": {
-			"inGameID": "sanskia",
+			"inGameStrID": "sanskia",
 			"notecount": 783
 		},
 		"difficulty": "Present",
@@ -13506,7 +13506,7 @@
 	{
 		"chartID": "12ea52e66aa2c7162e0cc6c33939cbaf9d093666",
 		"data": {
-			"inGameID": "altair",
+			"inGameStrID": "altair",
 			"notecount": 830
 		},
 		"difficulty": "Future",
@@ -13522,7 +13522,7 @@
 	{
 		"chartID": "1b213b89eb3857175bc56c99ef729da8d3695933",
 		"data": {
-			"inGameID": "altair",
+			"inGameStrID": "altair",
 			"notecount": 670
 		},
 		"difficulty": "Past",
@@ -13538,7 +13538,7 @@
 	{
 		"chartID": "bdeaaa38de40a242a70216de32649c84f956f763",
 		"data": {
-			"inGameID": "altair",
+			"inGameStrID": "altair",
 			"notecount": 828
 		},
 		"difficulty": "Present",
@@ -13554,7 +13554,7 @@
 	{
 		"chartID": "863b0eb03f13e904990efaf62de1f6f353e4c0e0",
 		"data": {
-			"inGameID": "mukishitsu",
+			"inGameStrID": "mukishitsu",
 			"notecount": 886
 		},
 		"difficulty": "Future",
@@ -13570,7 +13570,7 @@
 	{
 		"chartID": "e73f7afb625626f0d38c1375c2a507627633fef6",
 		"data": {
-			"inGameID": "mukishitsu",
+			"inGameStrID": "mukishitsu",
 			"notecount": 568
 		},
 		"difficulty": "Past",
@@ -13586,7 +13586,7 @@
 	{
 		"chartID": "331320a9cc5e98e4b4e2bad035703a80ffcd8e50",
 		"data": {
-			"inGameID": "mukishitsu",
+			"inGameStrID": "mukishitsu",
 			"notecount": 680
 		},
 		"difficulty": "Present",
@@ -13602,7 +13602,7 @@
 	{
 		"chartID": "0ba71fc9c24c8e096082da373eb03a69449beb4e",
 		"data": {
-			"inGameID": "trapcrow",
+			"inGameStrID": "trapcrow",
 			"notecount": 1074
 		},
 		"difficulty": "Future",
@@ -13618,7 +13618,7 @@
 	{
 		"chartID": "832df549dcf3e8f495581b95e76246c8b76a4ad4",
 		"data": {
-			"inGameID": "trapcrow",
+			"inGameStrID": "trapcrow",
 			"notecount": 876
 		},
 		"difficulty": "Past",
@@ -13634,7 +13634,7 @@
 	{
 		"chartID": "7fa4a7b14487f9b8e9a898c7c56c0fe31e71619a",
 		"data": {
-			"inGameID": "trapcrow",
+			"inGameStrID": "trapcrow",
 			"notecount": 898
 		},
 		"difficulty": "Present",
@@ -13650,7 +13650,7 @@
 	{
 		"chartID": "8105ab6a4b4b3673d00171a9139a30945a77e700",
 		"data": {
-			"inGameID": "pupa",
+			"inGameStrID": "pupa",
 			"notecount": 1099
 		},
 		"difficulty": "Future",
@@ -13666,7 +13666,7 @@
 	{
 		"chartID": "dccd71b7fd3ac5ea60be6342dace7ffcf732679b",
 		"data": {
-			"inGameID": "pupa",
+			"inGameStrID": "pupa",
 			"notecount": 374
 		},
 		"difficulty": "Past",
@@ -13682,7 +13682,7 @@
 	{
 		"chartID": "0f882f15f911690d33b8a8db28c22c20d9cb8db3",
 		"data": {
-			"inGameID": "pupa",
+			"inGameStrID": "pupa",
 			"notecount": 684
 		},
 		"difficulty": "Present",
@@ -13698,7 +13698,7 @@
 	{
 		"chartID": "9fac724408b1930c74debeddaa719660628e3fbe",
 		"data": {
-			"inGameID": "defection",
+			"inGameStrID": "defection",
 			"notecount": 1141
 		},
 		"difficulty": "Future",
@@ -13714,7 +13714,7 @@
 	{
 		"chartID": "45e2ef8151e78a7d672648a6585f176e2c7ea5b7",
 		"data": {
-			"inGameID": "defection",
+			"inGameStrID": "defection",
 			"notecount": 588
 		},
 		"difficulty": "Past",
@@ -13730,7 +13730,7 @@
 	{
 		"chartID": "b8d67541234cb44f95c870adb3fdea8d9e2d5902",
 		"data": {
-			"inGameID": "defection",
+			"inGameStrID": "defection",
 			"notecount": 800
 		},
 		"difficulty": "Present",
@@ -13746,7 +13746,7 @@
 	{
 		"chartID": "e093d41973f562c5cde40619227f70d0ad12aba3",
 		"data": {
-			"inGameID": "infinitestrife",
+			"inGameStrID": "infinitestrife",
 			"notecount": 1633
 		},
 		"difficulty": "Beyond",
@@ -13762,7 +13762,7 @@
 	{
 		"chartID": "21a0fd98feb369b077f82fd3a907b0ca89a738c4",
 		"data": {
-			"inGameID": "infinitestrife",
+			"inGameStrID": "infinitestrife",
 			"notecount": 1511
 		},
 		"difficulty": "Future",
@@ -13778,7 +13778,7 @@
 	{
 		"chartID": "13cb067f9f3c52c7235fe031186975f8d6f87faa",
 		"data": {
-			"inGameID": "infinitestrife",
+			"inGameStrID": "infinitestrife",
 			"notecount": 888
 		},
 		"difficulty": "Past",
@@ -13794,7 +13794,7 @@
 	{
 		"chartID": "23ff8550a45c05eabd712223387db3b22c926767",
 		"data": {
-			"inGameID": "infinitestrife",
+			"inGameStrID": "infinitestrife",
 			"notecount": 1081
 		},
 		"difficulty": "Present",
@@ -13810,7 +13810,7 @@
 	{
 		"chartID": "22d02e197046fa43f4011633b8414118c4f6c816",
 		"data": {
-			"inGameID": "worldender",
+			"inGameStrID": "worldender",
 			"notecount": 1661
 		},
 		"difficulty": "Beyond",
@@ -13826,7 +13826,7 @@
 	{
 		"chartID": "151cf04ca64ba0d69285799de1935dab968a9ff4",
 		"data": {
-			"inGameID": "worldender",
+			"inGameStrID": "worldender",
 			"notecount": 1225
 		},
 		"difficulty": "Future",
@@ -13842,7 +13842,7 @@
 	{
 		"chartID": "d525bc360e6036884d439272f2122a2770512dbe",
 		"data": {
-			"inGameID": "worldender",
+			"inGameStrID": "worldender",
 			"notecount": 616
 		},
 		"difficulty": "Past",
@@ -13858,7 +13858,7 @@
 	{
 		"chartID": "4cfd31761eed6beaaa5fd30b36205b7badd70683",
 		"data": {
-			"inGameID": "worldender",
+			"inGameStrID": "worldender",
 			"notecount": 850
 		},
 		"difficulty": "Present",
@@ -13874,7 +13874,7 @@
 	{
 		"chartID": "da372c5cd1a527d25126b996bfbc66fae4bc1c68",
 		"data": {
-			"inGameID": "pentiment",
+			"inGameStrID": "pentiment",
 			"notecount": 1741
 		},
 		"difficulty": "Beyond",
@@ -13890,7 +13890,7 @@
 	{
 		"chartID": "25508b93bccc10a404bfeca12de99e450057370c",
 		"data": {
-			"inGameID": "pentiment",
+			"inGameStrID": "pentiment",
 			"notecount": 1345
 		},
 		"difficulty": "Future",
@@ -13906,7 +13906,7 @@
 	{
 		"chartID": "25406f8dc70f19193970b1f05c239690eb1e5c2a",
 		"data": {
-			"inGameID": "pentiment",
+			"inGameStrID": "pentiment",
 			"notecount": 911
 		},
 		"difficulty": "Past",
@@ -13922,7 +13922,7 @@
 	{
 		"chartID": "497eb3fbf59ee992f2add5d4c8a7fd8ff8387e17",
 		"data": {
-			"inGameID": "pentiment",
+			"inGameStrID": "pentiment",
 			"notecount": 1055
 		},
 		"difficulty": "Present",
@@ -13938,7 +13938,7 @@
 	{
 		"chartID": "bc17fb16a9cb95e6a95291d7993bf00427ed2b2a",
 		"data": {
-			"inGameID": "arcanaeden",
+			"inGameStrID": "arcanaeden",
 			"notecount": 2134
 		},
 		"difficulty": "Beyond",
@@ -13954,7 +13954,7 @@
 	{
 		"chartID": "43bcc557e89019ca2ffa6e9e5e68cfdc8bd1f8f3",
 		"data": {
-			"inGameID": "arcanaeden",
+			"inGameStrID": "arcanaeden",
 			"notecount": 1792
 		},
 		"difficulty": "Future",
@@ -13970,7 +13970,7 @@
 	{
 		"chartID": "88bf4ca3d4831ac250a18577ea256b3a12e0a090",
 		"data": {
-			"inGameID": "arcanaeden",
+			"inGameStrID": "arcanaeden",
 			"notecount": 1097
 		},
 		"difficulty": "Past",
@@ -13986,7 +13986,7 @@
 	{
 		"chartID": "3a1c0beb28cef567d497e37e0082a102a9b23e66",
 		"data": {
-			"inGameID": "arcanaeden",
+			"inGameStrID": "arcanaeden",
 			"notecount": 1310
 		},
 		"difficulty": "Present",
@@ -14002,7 +14002,7 @@
 	{
 		"chartID": "2052e86e358f83df39608d31224f4b9a43376bb5",
 		"data": {
-			"inGameID": "testify",
+			"inGameStrID": "testify",
 			"notecount": 2221
 		},
 		"difficulty": "Beyond",
@@ -14018,7 +14018,7 @@
 	{
 		"chartID": "f0fcaaacdcf2055dbbe7dbca09666d0c8358ecd4",
 		"data": {
-			"inGameID": "testify",
+			"inGameStrID": "testify",
 			"notecount": 1766
 		},
 		"difficulty": "Future",
@@ -14034,7 +14034,7 @@
 	{
 		"chartID": "ffabdfa34c79b739fb5e566dd76cc0a9d1f41c22",
 		"data": {
-			"inGameID": "testify",
+			"inGameStrID": "testify",
 			"notecount": 1001
 		},
 		"difficulty": "Past",
@@ -14050,7 +14050,7 @@
 	{
 		"chartID": "0ce240d9233d76927b101b7b74a57212d9a6a5d4",
 		"data": {
-			"inGameID": "testify",
+			"inGameStrID": "testify",
 			"notecount": 1225
 		},
 		"difficulty": "Present",
@@ -14066,7 +14066,7 @@
 	{
 		"chartID": "311cb20e3079c748521b0f614fdb6b27c21a100b",
 		"data": {
-			"inGameID": "lovelessdress",
+			"inGameStrID": "lovelessdress",
 			"notecount": 850
 		},
 		"difficulty": "Future",
@@ -14082,7 +14082,7 @@
 	{
 		"chartID": "7c644eccfea88a66067b64c4f9f8424796812895",
 		"data": {
-			"inGameID": "lovelessdress",
+			"inGameStrID": "lovelessdress",
 			"notecount": 537
 		},
 		"difficulty": "Past",
@@ -14098,7 +14098,7 @@
 	{
 		"chartID": "33462a38262a8698eea088ffa80e91efa4b838b0",
 		"data": {
-			"inGameID": "lovelessdress",
+			"inGameStrID": "lovelessdress",
 			"notecount": 630
 		},
 		"difficulty": "Present",
@@ -14114,7 +14114,7 @@
 	{
 		"chartID": "325d0c3fd2c59e8866599bdaf01ada9e84ada896",
 		"data": {
-			"inGameID": "last",
+			"inGameStrID": "last",
 			"notecount": 831
 		},
 		"difficulty": "Future",
@@ -14130,7 +14130,7 @@
 	{
 		"chartID": "d0b40faaea1600c0f1517763c98006ba5093c687",
 		"data": {
-			"inGameID": "last",
+			"inGameStrID": "last",
 			"notecount": 680
 		},
 		"difficulty": "Past",
@@ -14146,7 +14146,7 @@
 	{
 		"chartID": "087d2cbffb0d76886f51d2a0b053f129665bc497",
 		"data": {
-			"inGameID": "last",
+			"inGameStrID": "last",
 			"notecount": 781
 		},
 		"difficulty": "Present",
@@ -14162,7 +14162,7 @@
 	{
 		"chartID": "5b010cb0c3af735e7b9e4c61cdf82e0dd0beee3e",
 		"data": {
-			"inGameID": "last",
+			"inGameStrID": "last",
 			"notecount": 888
 		},
 		"difficulty": "Beyond",
@@ -14178,7 +14178,7 @@
 	{
 		"chartID": "5557c5fb0293a60daa3527960c97ad7b6a04afe1",
 		"data": {
-			"inGameID": "lasteternity",
+			"inGameStrID": "lasteternity",
 			"notecount": 790
 		},
 		"difficulty": "Beyond",
@@ -14194,7 +14194,7 @@
 	{
 		"chartID": "b0edea3adb8d3a83553f994f6f726b696e83fd72",
 		"data": {
-			"inGameID": "callimakarma",
+			"inGameStrID": "callimakarma",
 			"notecount": 1222
 		},
 		"difficulty": "Future",
@@ -14210,7 +14210,7 @@
 	{
 		"chartID": "85d534cef633d420e8ae5dcbd56020163bf7b91c",
 		"data": {
-			"inGameID": "callimakarma",
+			"inGameStrID": "callimakarma",
 			"notecount": 1024
 		},
 		"difficulty": "Past",
@@ -14226,7 +14226,7 @@
 	{
 		"chartID": "06f3a72762ba0563bc89f96272aa04c1ca88d58c",
 		"data": {
-			"inGameID": "callimakarma",
+			"inGameStrID": "callimakarma",
 			"notecount": 989
 		},
 		"difficulty": "Present",
@@ -14242,7 +14242,7 @@
 	{
 		"chartID": "79106c976c7eb488837e8b8b4cd7856aa3d74d55",
 		"data": {
-			"inGameID": "kokoro",
+			"inGameStrID": "kokoro",
 			"notecount": 872
 		},
 		"difficulty": "Future",
@@ -14258,7 +14258,7 @@
 	{
 		"chartID": "b1e95f81e4660ad651556b6e4a1a6fc2484de3e5",
 		"data": {
-			"inGameID": "kokoro",
+			"inGameStrID": "kokoro",
 			"notecount": 428
 		},
 		"difficulty": "Past",
@@ -14274,7 +14274,7 @@
 	{
 		"chartID": "e10231fbb6b014622c9202a1d83b8dc2fbba0823",
 		"data": {
-			"inGameID": "kokoro",
+			"inGameStrID": "kokoro",
 			"notecount": 575
 		},
 		"difficulty": "Present",
@@ -14290,7 +14290,7 @@
 	{
 		"chartID": "4b20d66bc5f54478a0f8c2d6fe456ba2594b11be",
 		"data": {
-			"inGameID": "aidrew",
+			"inGameStrID": "aidrew",
 			"notecount": 1066
 		},
 		"difficulty": "Future",
@@ -14306,7 +14306,7 @@
 	{
 		"chartID": "4e23bfffd4020e2c77446bf445eedbb4308d7348",
 		"data": {
-			"inGameID": "aidrew",
+			"inGameStrID": "aidrew",
 			"notecount": 694
 		},
 		"difficulty": "Past",
@@ -14322,7 +14322,7 @@
 	{
 		"chartID": "750f6565d33d987937c623e2bd0d50ae161302c1",
 		"data": {
-			"inGameID": "aidrew",
+			"inGameStrID": "aidrew",
 			"notecount": 732
 		},
 		"difficulty": "Present",
@@ -14338,7 +14338,7 @@
 	{
 		"chartID": "284cb474cb4af2487b7a28832ffa4a829d0cdb88",
 		"data": {
-			"inGameID": "fluffyflash",
+			"inGameStrID": "fluffyflash",
 			"notecount": 1329
 		},
 		"difficulty": "Future",
@@ -14354,7 +14354,7 @@
 	{
 		"chartID": "5e348fbd6b2621bcf590b8b0051da0b7ac24b0a2",
 		"data": {
-			"inGameID": "fluffyflash",
+			"inGameStrID": "fluffyflash",
 			"notecount": 787
 		},
 		"difficulty": "Past",
@@ -14370,7 +14370,7 @@
 	{
 		"chartID": "9e2642c21c3c5dc644d292e664771a232cca84f1",
 		"data": {
-			"inGameID": "fluffyflash",
+			"inGameStrID": "fluffyflash",
 			"notecount": 946
 		},
 		"difficulty": "Present",
@@ -14386,7 +14386,7 @@
 	{
 		"chartID": "58bb12dc3ca044ae47a773a1e47f326f88bd93bb",
 		"data": {
-			"inGameID": "goodbyemerry",
+			"inGameStrID": "goodbyemerry",
 			"notecount": 1084
 		},
 		"difficulty": "Future",
@@ -14402,7 +14402,7 @@
 	{
 		"chartID": "eff921bb2b1ffd4f57b21da98b538e731bae73fa",
 		"data": {
-			"inGameID": "goodbyemerry",
+			"inGameStrID": "goodbyemerry",
 			"notecount": 679
 		},
 		"difficulty": "Past",
@@ -14418,7 +14418,7 @@
 	{
 		"chartID": "8bf822428f2dfe230e4df4cd6f991befb4c213b4",
 		"data": {
-			"inGameID": "goodbyemerry",
+			"inGameStrID": "goodbyemerry",
 			"notecount": 696
 		},
 		"difficulty": "Present",
@@ -14434,7 +14434,7 @@
 	{
 		"chartID": "a9b91c2a89e49dc54ff2c280b4242b9dee4fa32e",
 		"data": {
-			"inGameID": "lamia",
+			"inGameStrID": "lamia",
 			"notecount": 1385
 		},
 		"difficulty": "Future",
@@ -14450,7 +14450,7 @@
 	{
 		"chartID": "d661032b648dabdb913b2fd603e54961d768875d",
 		"data": {
-			"inGameID": "lamia",
+			"inGameStrID": "lamia",
 			"notecount": 826
 		},
 		"difficulty": "Past",
@@ -14466,7 +14466,7 @@
 	{
 		"chartID": "9b02238c5c231feb458f7cd522a4b1aedb24af29",
 		"data": {
-			"inGameID": "lamia",
+			"inGameStrID": "lamia",
 			"notecount": 885
 		},
 		"difficulty": "Present",
@@ -14482,7 +14482,7 @@
 	{
 		"chartID": "4d76a6d7e2c0111f6184e6b00d4fac3678dcc88a",
 		"data": {
-			"inGameID": "freemyself",
+			"inGameStrID": "freemyself",
 			"notecount": 1132
 		},
 		"difficulty": "Future",
@@ -14498,7 +14498,7 @@
 	{
 		"chartID": "66b73d2ff08619c328949de57082b41842ce4eb0",
 		"data": {
-			"inGameID": "freemyself",
+			"inGameStrID": "freemyself",
 			"notecount": 662
 		},
 		"difficulty": "Past",
@@ -14514,7 +14514,7 @@
 	{
 		"chartID": "b01f095ef8382695e319196f3f2df3f04a1bf78d",
 		"data": {
-			"inGameID": "freemyself",
+			"inGameStrID": "freemyself",
 			"notecount": 785
 		},
 		"difficulty": "Present",
@@ -14530,7 +14530,7 @@
 	{
 		"chartID": "c768e3e5d362973fb55a029004005645a7568416",
 		"data": {
-			"inGameID": "cocorocosmetic",
+			"inGameStrID": "cocorocosmetic",
 			"notecount": 1025
 		},
 		"difficulty": "Future",
@@ -14546,7 +14546,7 @@
 	{
 		"chartID": "9468110eaa17e16c49ef0e9546006360b97b78f0",
 		"data": {
-			"inGameID": "cocorocosmetic",
+			"inGameStrID": "cocorocosmetic",
 			"notecount": 525
 		},
 		"difficulty": "Past",
@@ -14562,7 +14562,7 @@
 	{
 		"chartID": "eabb7a0f709485bc2ff2caadbbcd6e00e8fcee05",
 		"data": {
-			"inGameID": "cocorocosmetic",
+			"inGameStrID": "cocorocosmetic",
 			"notecount": 687
 		},
 		"difficulty": "Present",
@@ -14578,7 +14578,7 @@
 	{
 		"chartID": "943d501afbf9ee14b6f62127c558d950c92de5a9",
 		"data": {
-			"inGameID": "capella",
+			"inGameStrID": "capella",
 			"notecount": 1159
 		},
 		"difficulty": "Future",
@@ -14594,7 +14594,7 @@
 	{
 		"chartID": "03888986f6379d7e79885b5b178519a8096e2eac",
 		"data": {
-			"inGameID": "capella",
+			"inGameStrID": "capella",
 			"notecount": 884
 		},
 		"difficulty": "Past",
@@ -14610,7 +14610,7 @@
 	{
 		"chartID": "d8a2860e47cdc4ea94330d5573fca421cc0196dd",
 		"data": {
-			"inGameID": "capella",
+			"inGameStrID": "capella",
 			"notecount": 904
 		},
 		"difficulty": "Present",
@@ -14626,7 +14626,7 @@
 	{
 		"chartID": "0acf2b1d82e9e559f156890ef17c17e6bdba9014",
 		"data": {
-			"inGameID": "dialnote",
+			"inGameStrID": "dialnote",
 			"notecount": 684
 		},
 		"difficulty": "Future",
@@ -14642,7 +14642,7 @@
 	{
 		"chartID": "7c726041b118025c93392a9846f56fca3d9da0c2",
 		"data": {
-			"inGameID": "dialnote",
+			"inGameStrID": "dialnote",
 			"notecount": 393
 		},
 		"difficulty": "Past",
@@ -14658,7 +14658,7 @@
 	{
 		"chartID": "85b39fcb4f620f954cf7e22e2e5fe3656b1175c5",
 		"data": {
-			"inGameID": "dialnote",
+			"inGameStrID": "dialnote",
 			"notecount": 548
 		},
 		"difficulty": "Present",
@@ -14674,7 +14674,7 @@
 	{
 		"chartID": "37175f52f54158f1be8069c6e303720650aa12af",
 		"data": {
-			"inGameID": "tsukinimurakumo",
+			"inGameStrID": "tsukinimurakumo",
 			"notecount": 740
 		},
 		"difficulty": "Future",
@@ -14690,7 +14690,7 @@
 	{
 		"chartID": "441e72670c64586c14a26959b29f9638cb285ec6",
 		"data": {
-			"inGameID": "tsukinimurakumo",
+			"inGameStrID": "tsukinimurakumo",
 			"notecount": 468
 		},
 		"difficulty": "Past",
@@ -14706,7 +14706,7 @@
 	{
 		"chartID": "7083cc5691cfda2375dd4ee164521dc03e2699fe",
 		"data": {
-			"inGameID": "tsukinimurakumo",
+			"inGameStrID": "tsukinimurakumo",
 			"notecount": 610
 		},
 		"difficulty": "Present",
@@ -14722,7 +14722,7 @@
 	{
 		"chartID": "516fca5729bf19f6fd5dd63d5920ea4d9466a79e",
 		"data": {
-			"inGameID": "mantis",
+			"inGameStrID": "mantis",
 			"notecount": 1014
 		},
 		"difficulty": "Future",
@@ -14738,7 +14738,7 @@
 	{
 		"chartID": "37b2b136af9d0b2cde37a371faa8d72d5e7fde11",
 		"data": {
-			"inGameID": "mantis",
+			"inGameStrID": "mantis",
 			"notecount": 575
 		},
 		"difficulty": "Past",
@@ -14754,7 +14754,7 @@
 	{
 		"chartID": "afe599dd10d688b126808250b4f5b0aa889f7839",
 		"data": {
-			"inGameID": "mantis",
+			"inGameStrID": "mantis",
 			"notecount": 760
 		},
 		"difficulty": "Present",
@@ -14770,7 +14770,7 @@
 	{
 		"chartID": "91faedf155042a6f12509e0fba50615b7d5f75f7",
 		"data": {
-			"inGameID": "worldfragments",
+			"inGameStrID": "worldfragments",
 			"notecount": 1387
 		},
 		"difficulty": "Future",
@@ -14786,7 +14786,7 @@
 	{
 		"chartID": "f1a693b0aa160dc16154aae3f4060b0b78b53fc1",
 		"data": {
-			"inGameID": "worldfragments",
+			"inGameStrID": "worldfragments",
 			"notecount": 777
 		},
 		"difficulty": "Past",
@@ -14802,7 +14802,7 @@
 	{
 		"chartID": "e2089498a19906b2260cfd013327f84ce575fac0",
 		"data": {
-			"inGameID": "worldfragments",
+			"inGameStrID": "worldfragments",
 			"notecount": 999
 		},
 		"difficulty": "Present",
@@ -14818,7 +14818,7 @@
 	{
 		"chartID": "d1ca3251562f261db3ceb4ac19992a95aaae3b20",
 		"data": {
-			"inGameID": "astrawalkthrough",
+			"inGameStrID": "astrawalkthrough",
 			"notecount": 1191
 		},
 		"difficulty": "Future",
@@ -14834,7 +14834,7 @@
 	{
 		"chartID": "23e894f819e9ee3dfa22df9d2cbf845579823a98",
 		"data": {
-			"inGameID": "astrawalkthrough",
+			"inGameStrID": "astrawalkthrough",
 			"notecount": 769
 		},
 		"difficulty": "Past",
@@ -14850,7 +14850,7 @@
 	{
 		"chartID": "cad5628fd21e6d030be4c59967b61a648ccdcbb4",
 		"data": {
-			"inGameID": "astrawalkthrough",
+			"inGameStrID": "astrawalkthrough",
 			"notecount": 886
 		},
 		"difficulty": "Present",
@@ -14866,7 +14866,7 @@
 	{
 		"chartID": "3f90f0b2e37e3210d9375ec2e29dc35da90a66c4",
 		"data": {
-			"inGameID": "chronicle",
+			"inGameStrID": "chronicle",
 			"notecount": 1264
 		},
 		"difficulty": "Future",
@@ -14882,7 +14882,7 @@
 	{
 		"chartID": "73bf1ca06de2e105e38128ab0ecf5bdb82da4844",
 		"data": {
-			"inGameID": "chronicle",
+			"inGameStrID": "chronicle",
 			"notecount": 928
 		},
 		"difficulty": "Past",
@@ -14898,7 +14898,7 @@
 	{
 		"chartID": "8c11fcc1b3f5567115d3d45030069298ea1daa4b",
 		"data": {
-			"inGameID": "chronicle",
+			"inGameStrID": "chronicle",
 			"notecount": 1077
 		},
 		"difficulty": "Present",
@@ -14914,7 +14914,7 @@
 	{
 		"chartID": "d4ccdebdeea81ffcb6b17785bd43a0daadb8b250",
 		"data": {
-			"inGameID": "nullapophenia",
+			"inGameStrID": "nullapophenia",
 			"notecount": 1299
 		},
 		"difficulty": "Future",
@@ -14930,7 +14930,7 @@
 	{
 		"chartID": "5098883ed96734bf941ad3331fc373454350f2a0",
 		"data": {
-			"inGameID": "nullapophenia",
+			"inGameStrID": "nullapophenia",
 			"notecount": 990
 		},
 		"difficulty": "Past",
@@ -14946,7 +14946,7 @@
 	{
 		"chartID": "9d87891cc17d249e2f50f23d268d180a6c6cb513",
 		"data": {
-			"inGameID": "nullapophenia",
+			"inGameStrID": "nullapophenia",
 			"notecount": 1098
 		},
 		"difficulty": "Present",
@@ -14962,7 +14962,7 @@
 	{
 		"chartID": "447a2bb4f31faa82f9347b850b23870286ed4ba1",
 		"data": {
-			"inGameID": "crimsonthrone",
+			"inGameStrID": "crimsonthrone",
 			"notecount": 1313
 		},
 		"difficulty": "Future",
@@ -14978,7 +14978,7 @@
 	{
 		"chartID": "21a49165924a4bb7da53cfdc91ccce6e2d69b1d0",
 		"data": {
-			"inGameID": "crimsonthrone",
+			"inGameStrID": "crimsonthrone",
 			"notecount": 727
 		},
 		"difficulty": "Past",
@@ -14994,7 +14994,7 @@
 	{
 		"chartID": "58c742e1b21b1e9dc708750df9fdebb4ab79a1c8",
 		"data": {
-			"inGameID": "crimsonthrone",
+			"inGameStrID": "crimsonthrone",
 			"notecount": 1079
 		},
 		"difficulty": "Present",
@@ -15010,7 +15010,7 @@
 	{
 		"chartID": "f3703b1fe7bafe84be79882a4e35e7f466b2098f",
 		"data": {
-			"inGameID": "manicjeer",
+			"inGameStrID": "manicjeer",
 			"notecount": 1286
 		},
 		"difficulty": "Future",
@@ -15026,7 +15026,7 @@
 	{
 		"chartID": "c1feea30c665e422ebe9ac4c7ab7b011f9eb5831",
 		"data": {
-			"inGameID": "manicjeer",
+			"inGameStrID": "manicjeer",
 			"notecount": 698
 		},
 		"difficulty": "Past",
@@ -15042,7 +15042,7 @@
 	{
 		"chartID": "f5460df49ea9163b24bc507c940795e77e5015fb",
 		"data": {
-			"inGameID": "manicjeer",
+			"inGameStrID": "manicjeer",
 			"notecount": 875
 		},
 		"difficulty": "Present",
@@ -15058,7 +15058,7 @@
 	{
 		"chartID": "74311611ea56f44759b55e5d14dcd0b1b678b6d8",
 		"data": {
-			"inGameID": "hiirogekka",
+			"inGameStrID": "hiirogekka",
 			"notecount": 1126
 		},
 		"difficulty": "Future",
@@ -15074,7 +15074,7 @@
 	{
 		"chartID": "c5f462edb29721c65154889ee5739b8c9c540356",
 		"data": {
-			"inGameID": "hiirogekka",
+			"inGameStrID": "hiirogekka",
 			"notecount": 719
 		},
 		"difficulty": "Past",
@@ -15090,7 +15090,7 @@
 	{
 		"chartID": "171e3456d723354d5020b423551a218718234fd7",
 		"data": {
-			"inGameID": "hiirogekka",
+			"inGameStrID": "hiirogekka",
 			"notecount": 709
 		},
 		"difficulty": "Present",
@@ -15106,7 +15106,7 @@
 	{
 		"chartID": "1fb1dfe6c12d8b62ee5e3e85e0573f2409d625e4",
 		"data": {
-			"inGameID": "letsrock",
+			"inGameStrID": "letsrock",
 			"notecount": 1177
 		},
 		"difficulty": "Future",
@@ -15122,7 +15122,7 @@
 	{
 		"chartID": "e21e415c122ba67c4fe3ce91286cf73e9d901a5f",
 		"data": {
-			"inGameID": "letsrock",
+			"inGameStrID": "letsrock",
 			"notecount": 541
 		},
 		"difficulty": "Past",
@@ -15138,7 +15138,7 @@
 	{
 		"chartID": "271abe7f103291618da1c56ba9a819a9e53cdd0e",
 		"data": {
-			"inGameID": "letsrock",
+			"inGameStrID": "letsrock",
 			"notecount": 963
 		},
 		"difficulty": "Present",
@@ -15154,7 +15154,7 @@
 	{
 		"chartID": "6b21c62ff692a78a621fa754dfeb43e7a0b77d5e",
 		"data": {
-			"inGameID": "cycles",
+			"inGameStrID": "cycles",
 			"notecount": 695
 		},
 		"difficulty": "Future",
@@ -15170,7 +15170,7 @@
 	{
 		"chartID": "15e6cf4baad3bac50ae30c41d83be05ea2ad8451",
 		"data": {
-			"inGameID": "cycles",
+			"inGameStrID": "cycles",
 			"notecount": 389
 		},
 		"difficulty": "Past",
@@ -15186,7 +15186,7 @@
 	{
 		"chartID": "c90d185d14faae9073be5f79a87fffcbe15115c8",
 		"data": {
-			"inGameID": "cycles",
+			"inGameStrID": "cycles",
 			"notecount": 430
 		},
 		"difficulty": "Present",
@@ -15202,7 +15202,7 @@
 	{
 		"chartID": "e4957916690090f8c2b0b572083a38f0bcc7d34f",
 		"data": {
-			"inGameID": "maxrage",
+			"inGameStrID": "maxrage",
 			"notecount": 1184
 		},
 		"difficulty": "Future",
@@ -15218,7 +15218,7 @@
 	{
 		"chartID": "d3a905423a5a4ebc6439e7a27335b5c17d1ac911",
 		"data": {
-			"inGameID": "maxrage",
+			"inGameStrID": "maxrage",
 			"notecount": 696
 		},
 		"difficulty": "Past",
@@ -15234,7 +15234,7 @@
 	{
 		"chartID": "13b9ec94b9c8059aaf9f3d45c515a36ca0824b62",
 		"data": {
-			"inGameID": "maxrage",
+			"inGameStrID": "maxrage",
 			"notecount": 760
 		},
 		"difficulty": "Present",
@@ -15250,7 +15250,7 @@
 	{
 		"chartID": "ee4eb892a9449f2e25fd7efc27f6294d3f93af6c",
 		"data": {
-			"inGameID": "infinity",
+			"inGameStrID": "infinity",
 			"notecount": 1190
 		},
 		"difficulty": "Future",
@@ -15266,7 +15266,7 @@
 	{
 		"chartID": "1de5d5977c75f8e3e692b77acfbd7e5d58316770",
 		"data": {
-			"inGameID": "infinity",
+			"inGameStrID": "infinity",
 			"notecount": 594
 		},
 		"difficulty": "Past",
@@ -15282,7 +15282,7 @@
 	{
 		"chartID": "ec03cd272672a2add729aa269284df7af3acac5d",
 		"data": {
-			"inGameID": "infinity",
+			"inGameStrID": "infinity",
 			"notecount": 782
 		},
 		"difficulty": "Present",
@@ -15298,7 +15298,7 @@
 	{
 		"chartID": "fc6d042c9a7b710a33dd62d0d4f7e3310afeea1e",
 		"data": {
-			"inGameID": "temptation",
+			"inGameStrID": "temptation",
 			"notecount": 1099
 		},
 		"difficulty": "Future",
@@ -15314,7 +15314,7 @@
 	{
 		"chartID": "c343961521ad8ed02b1ecc4ab86bb13c931105dc",
 		"data": {
-			"inGameID": "temptation",
+			"inGameStrID": "temptation",
 			"notecount": 627
 		},
 		"difficulty": "Past",
@@ -15330,7 +15330,7 @@
 	{
 		"chartID": "9d7eed16de72db39ba5fafb4face2d48ca72f66f",
 		"data": {
-			"inGameID": "temptation",
+			"inGameStrID": "temptation",
 			"notecount": 768
 		},
 		"difficulty": "Present",
@@ -15346,7 +15346,7 @@
 	{
 		"chartID": "137ab3202588a8f8eb4ac594f45539d640942fa6",
 		"data": {
-			"inGameID": "primitivelights",
+			"inGameStrID": "primitivelights",
 			"notecount": 1524
 		},
 		"difficulty": "Future",
@@ -15362,7 +15362,7 @@
 	{
 		"chartID": "418dbfdc877221b9457259bf442a41fdfa008b0b",
 		"data": {
-			"inGameID": "primitivelights",
+			"inGameStrID": "primitivelights",
 			"notecount": 785
 		},
 		"difficulty": "Past",
@@ -15378,7 +15378,7 @@
 	{
 		"chartID": "8e7bd9b6252b7930de7bbf7f1d8424db43393b18",
 		"data": {
-			"inGameID": "primitivelights",
+			"inGameStrID": "primitivelights",
 			"notecount": 1073
 		},
 		"difficulty": "Present",
@@ -15394,7 +15394,7 @@
 	{
 		"chartID": "a3575b8196764a660b0df4bd3ef1e82140f9361f",
 		"data": {
-			"inGameID": "cosmopop",
+			"inGameStrID": "cosmopop",
 			"notecount": 809
 		},
 		"difficulty": "Future",
@@ -15410,7 +15410,7 @@
 	{
 		"chartID": "e8443683090b74e834b13456221023aa71a4402b",
 		"data": {
-			"inGameID": "cosmopop",
+			"inGameStrID": "cosmopop",
 			"notecount": 352
 		},
 		"difficulty": "Past",
@@ -15426,7 +15426,7 @@
 	{
 		"chartID": "500799db61de27844cbd7592952e7fccbc63c6f5",
 		"data": {
-			"inGameID": "cosmopop",
+			"inGameStrID": "cosmopop",
 			"notecount": 591
 		},
 		"difficulty": "Present",
@@ -15442,7 +15442,7 @@
 	{
 		"chartID": "e0d3a77536c9d646eec6985bdf386c3e2ebb84f5",
 		"data": {
-			"inGameID": "impact",
+			"inGameStrID": "impact",
 			"notecount": 1392
 		},
 		"difficulty": "Beyond",
@@ -15458,7 +15458,7 @@
 	{
 		"chartID": "4eb6da92a3b889528dd20e55810b425dbc5da7f6",
 		"data": {
-			"inGameID": "impact",
+			"inGameStrID": "impact",
 			"notecount": 1231
 		},
 		"difficulty": "Future",
@@ -15474,7 +15474,7 @@
 	{
 		"chartID": "5a3d0ce5a2261bd87ba26c7613c8d966172dee87",
 		"data": {
-			"inGameID": "impact",
+			"inGameStrID": "impact",
 			"notecount": 723
 		},
 		"difficulty": "Past",
@@ -15490,7 +15490,7 @@
 	{
 		"chartID": "aa34ae1bf6f441c6d5a1fb83c86c1a5f8aff6dcc",
 		"data": {
-			"inGameID": "impact",
+			"inGameStrID": "impact",
 			"notecount": 913
 		},
 		"difficulty": "Present",
@@ -15506,7 +15506,7 @@
 	{
 		"chartID": "38f71daca5e94d0295f83302923b43c8a46143da",
 		"data": {
-			"inGameID": "genesischunithm",
+			"inGameStrID": "genesischunithm",
 			"notecount": 867
 		},
 		"difficulty": "Future",
@@ -15522,7 +15522,7 @@
 	{
 		"chartID": "62668c8a9b9da88fb74f487222e9efa5835b9653",
 		"data": {
-			"inGameID": "genesischunithm",
+			"inGameStrID": "genesischunithm",
 			"notecount": 587
 		},
 		"difficulty": "Past",
@@ -15538,7 +15538,7 @@
 	{
 		"chartID": "311092fb6c24c8cc85d76e308926ef718d7d9fa7",
 		"data": {
-			"inGameID": "genesischunithm",
+			"inGameStrID": "genesischunithm",
 			"notecount": 838
 		},
 		"difficulty": "Present",
@@ -15554,7 +15554,7 @@
 	{
 		"chartID": "008132b3e5a3c203c04e34b8477acfd1cf4f4ec4",
 		"data": {
-			"inGameID": "trrricksters",
+			"inGameStrID": "trrricksters",
 			"notecount": 1183
 		},
 		"difficulty": "Future",
@@ -15570,7 +15570,7 @@
 	{
 		"chartID": "d094b356af14196aa16a73993f5265cfd5ef35da",
 		"data": {
-			"inGameID": "trrricksters",
+			"inGameStrID": "trrricksters",
 			"notecount": 561
 		},
 		"difficulty": "Past",
@@ -15586,7 +15586,7 @@
 	{
 		"chartID": "0001967a4f712232b6931966e81749ef10ba7616",
 		"data": {
-			"inGameID": "trrricksters",
+			"inGameStrID": "trrricksters",
 			"notecount": 784
 		},
 		"difficulty": "Present",
@@ -15602,7 +15602,7 @@
 	{
 		"chartID": "1b52d18c8f05948b4dab92e08d5ca94e2a65e553",
 		"data": {
-			"inGameID": "spidersthread",
+			"inGameStrID": "spidersthread",
 			"notecount": 1203
 		},
 		"difficulty": "Future",
@@ -15618,7 +15618,7 @@
 	{
 		"chartID": "fdcca2d34939b708040d6f04b706194ea212bd06",
 		"data": {
-			"inGameID": "spidersthread",
+			"inGameStrID": "spidersthread",
 			"notecount": 794
 		},
 		"difficulty": "Past",
@@ -15634,7 +15634,7 @@
 	{
 		"chartID": "cc28d1b405d6d7ba3acc5ad3f25f50729d3f5e31",
 		"data": {
-			"inGameID": "spidersthread",
+			"inGameStrID": "spidersthread",
 			"notecount": 764
 		},
 		"difficulty": "Present",
@@ -15650,7 +15650,7 @@
 	{
 		"chartID": "7a6369497d7c05e6ef15f5098fe1d50f0bf5316a",
 		"data": {
-			"inGameID": "lostemotion",
+			"inGameStrID": "lostemotion",
 			"notecount": 1123
 		},
 		"difficulty": "Future",
@@ -15666,7 +15666,7 @@
 	{
 		"chartID": "a940bd588702eaf88af80d78d2617169223d6e72",
 		"data": {
-			"inGameID": "lostemotion",
+			"inGameStrID": "lostemotion",
 			"notecount": 602
 		},
 		"difficulty": "Past",
@@ -15682,7 +15682,7 @@
 	{
 		"chartID": "9fbd511e4f0255e62f347d5e5278f3164028f3f3",
 		"data": {
-			"inGameID": "lostemotion",
+			"inGameStrID": "lostemotion",
 			"notecount": 780
 		},
 		"difficulty": "Present",
@@ -15698,7 +15698,7 @@
 	{
 		"chartID": "756fc962a518e0cf912540341ad18bd831fa4854",
 		"data": {
-			"inGameID": "gimmick",
+			"inGameStrID": "gimmick",
 			"notecount": 733
 		},
 		"difficulty": "Future",
@@ -15714,7 +15714,7 @@
 	{
 		"chartID": "fba0b7dd45841bf1c371c136595857d0275423d2",
 		"data": {
-			"inGameID": "gimmick",
+			"inGameStrID": "gimmick",
 			"notecount": 421
 		},
 		"difficulty": "Past",
@@ -15730,7 +15730,7 @@
 	{
 		"chartID": "6f3b167716888329e3ddfce9c4a25c1b03e2b251",
 		"data": {
-			"inGameID": "gimmick",
+			"inGameStrID": "gimmick",
 			"notecount": 598
 		},
 		"difficulty": "Present",
@@ -15746,7 +15746,7 @@
 	{
 		"chartID": "6de0e7d40adfe3fd8f4d8630e9fdb20644d4aac5",
 		"data": {
-			"inGameID": "thesurvivor",
+			"inGameStrID": "thesurvivor",
 			"notecount": 1100
 		},
 		"difficulty": "Future",
@@ -15762,7 +15762,7 @@
 	{
 		"chartID": "8136dbb7c1806bcd604170ae8fd860c2c4268540",
 		"data": {
-			"inGameID": "thesurvivor",
+			"inGameStrID": "thesurvivor",
 			"notecount": 817
 		},
 		"difficulty": "Past",
@@ -15778,7 +15778,7 @@
 	{
 		"chartID": "779da1721d51579d2883ada41dc34f227ace85e7",
 		"data": {
-			"inGameID": "thesurvivor",
+			"inGameStrID": "thesurvivor",
 			"notecount": 750
 		},
 		"difficulty": "Present",
@@ -15794,7 +15794,7 @@
 	{
 		"chartID": "e0d86ae0d904ae039fd743075579c709822228f0",
 		"data": {
-			"inGameID": "newyorkbackraise",
+			"inGameStrID": "newyorkbackraise",
 			"notecount": 1091
 		},
 		"difficulty": "Future",
@@ -15810,7 +15810,7 @@
 	{
 		"chartID": "0d8a6b0644abb2c098343f2c32199458a5f41892",
 		"data": {
-			"inGameID": "newyorkbackraise",
+			"inGameStrID": "newyorkbackraise",
 			"notecount": 762
 		},
 		"difficulty": "Past",
@@ -15826,7 +15826,7 @@
 	{
 		"chartID": "b694f7eebf2516af97e2b00ed43f50f91371e1cb",
 		"data": {
-			"inGameID": "newyorkbackraise",
+			"inGameStrID": "newyorkbackraise",
 			"notecount": 803
 		},
 		"difficulty": "Present",
@@ -15842,7 +15842,7 @@
 	{
 		"chartID": "07b30ca4a57c64cc0f199546013684c3aba1acc9",
 		"data": {
-			"inGameID": "galacticlove",
+			"inGameStrID": "galacticlove",
 			"notecount": 813
 		},
 		"difficulty": "Future",
@@ -15858,7 +15858,7 @@
 	{
 		"chartID": "abd94b1cdc37432ce116dcb08f0a7b4512900cfa",
 		"data": {
-			"inGameID": "galacticlove",
+			"inGameStrID": "galacticlove",
 			"notecount": 513
 		},
 		"difficulty": "Past",
@@ -15874,7 +15874,7 @@
 	{
 		"chartID": "e6700b6d9a1f4017972571144ad7c11c33cf29ea",
 		"data": {
-			"inGameID": "galacticlove",
+			"inGameStrID": "galacticlove",
 			"notecount": 694
 		},
 		"difficulty": "Present",
@@ -15890,7 +15890,7 @@
 	{
 		"chartID": "d01bb96c295572a48e372684b19b989e16cc4e13",
 		"data": {
-			"inGameID": "lawlesspoint",
+			"inGameStrID": "lawlesspoint",
 			"notecount": 838
 		},
 		"difficulty": "Future",
@@ -15906,7 +15906,7 @@
 	{
 		"chartID": "8f8f25afd7457bfbfabc8e37893d094d9a23f5f8",
 		"data": {
-			"inGameID": "lawlesspoint",
+			"inGameStrID": "lawlesspoint",
 			"notecount": 476
 		},
 		"difficulty": "Past",
@@ -15922,7 +15922,7 @@
 	{
 		"chartID": "01421df2884b567f1c6395b956aee231fc316b88",
 		"data": {
-			"inGameID": "lawlesspoint",
+			"inGameStrID": "lawlesspoint",
 			"notecount": 630
 		},
 		"difficulty": "Present",
@@ -15938,7 +15938,7 @@
 	{
 		"chartID": "ae8be30b84e687de3aa090e64a0054c51b08fdac",
 		"data": {
-			"inGameID": "lostintheabyss",
+			"inGameStrID": "lostintheabyss",
 			"notecount": 1179
 		},
 		"difficulty": "Future",
@@ -15954,7 +15954,7 @@
 	{
 		"chartID": "b4a66963eb05699b36bbe35dd4bf07478ee44bba",
 		"data": {
-			"inGameID": "lostintheabyss",
+			"inGameStrID": "lostintheabyss",
 			"notecount": 907
 		},
 		"difficulty": "Past",
@@ -15970,7 +15970,7 @@
 	{
 		"chartID": "db6370daed516ddf2701f16842590d64ce7e379a",
 		"data": {
-			"inGameID": "lostintheabyss",
+			"inGameStrID": "lostintheabyss",
 			"notecount": 908
 		},
 		"difficulty": "Present",
@@ -15986,7 +15986,7 @@
 	{
 		"chartID": "25de7673c828a7cfdf67163789551ce2282b4b8e",
 		"data": {
-			"inGameID": "hybris",
+			"inGameStrID": "hybris",
 			"notecount": 1196
 		},
 		"difficulty": "Future",
@@ -16002,7 +16002,7 @@
 	{
 		"chartID": "dba1d1d3fd899bc2b08a85cec6fd35a128058db6",
 		"data": {
-			"inGameID": "hybris",
+			"inGameStrID": "hybris",
 			"notecount": 757
 		},
 		"difficulty": "Past",
@@ -16018,7 +16018,7 @@
 	{
 		"chartID": "96921e2319fdaceddb874f9fa1430fb6e4598788",
 		"data": {
-			"inGameID": "hybris",
+			"inGameStrID": "hybris",
 			"notecount": 973
 		},
 		"difficulty": "Present",
@@ -16034,7 +16034,7 @@
 	{
 		"chartID": "fa60d74688c45b6d6feb8c03976a445d04169e31",
 		"data": {
-			"inGameID": "tothemilkyway",
+			"inGameStrID": "tothemilkyway",
 			"notecount": 1392
 		},
 		"difficulty": "Future",
@@ -16050,7 +16050,7 @@
 	{
 		"chartID": "2e5fe3175e0f2cf918a7784760c0392db09d0f5f",
 		"data": {
-			"inGameID": "tothemilkyway",
+			"inGameStrID": "tothemilkyway",
 			"notecount": 928
 		},
 		"difficulty": "Past",
@@ -16066,7 +16066,7 @@
 	{
 		"chartID": "82707b3bfdb18931c6568e4de123388938fa6d3d",
 		"data": {
-			"inGameID": "tothemilkyway",
+			"inGameStrID": "tothemilkyway",
 			"notecount": 1154
 		},
 		"difficulty": "Present",
@@ -16082,7 +16082,7 @@
 	{
 		"chartID": "c7d7f290e2c8f1b4a2b99039d968dbdee5af2515",
 		"data": {
-			"inGameID": "internetyamero",
+			"inGameStrID": "internetyamero",
 			"notecount": 1222
 		},
 		"difficulty": "Future",
@@ -16098,7 +16098,7 @@
 	{
 		"chartID": "8d1314041bc84e6ef613dbc59ef103bae614d22a",
 		"data": {
-			"inGameID": "internetyamero",
+			"inGameStrID": "internetyamero",
 			"notecount": 677
 		},
 		"difficulty": "Past",
@@ -16114,7 +16114,7 @@
 	{
 		"chartID": "18e00019cca55bd4d95485424b4b2ca492eaa36e",
 		"data": {
-			"inGameID": "internetyamero",
+			"inGameStrID": "internetyamero",
 			"notecount": 987
 		},
 		"difficulty": "Present",
@@ -16130,7 +16130,7 @@
 	{
 		"chartID": "e3acd0acec5797fbeb669ab671205695dc2b7424",
 		"data": {
-			"inGameID": "bulletwaiting",
+			"inGameStrID": "bulletwaiting",
 			"notecount": 701
 		},
 		"difficulty": "Future",
@@ -16146,7 +16146,7 @@
 	{
 		"chartID": "b02d483d425d3742b3585f08f5fca495c49e1baa",
 		"data": {
-			"inGameID": "bulletwaiting",
+			"inGameStrID": "bulletwaiting",
 			"notecount": 325
 		},
 		"difficulty": "Past",
@@ -16162,7 +16162,7 @@
 	{
 		"chartID": "2f23d32490da6f7284185385826b54b6cca04b1b",
 		"data": {
-			"inGameID": "bulletwaiting",
+			"inGameStrID": "bulletwaiting",
 			"notecount": 390
 		},
 		"difficulty": "Present",
@@ -16178,7 +16178,7 @@
 	{
 		"chartID": "26fce5d81e7dc0f926ffff5cb205826d31878e1d",
 		"data": {
-			"inGameID": "devillicsphere",
+			"inGameStrID": "devillicsphere",
 			"notecount": 1129
 		},
 		"difficulty": "Future",
@@ -16194,7 +16194,7 @@
 	{
 		"chartID": "ded93fa66436f7edca4f0a09599c947decaa8221",
 		"data": {
-			"inGameID": "devillicsphere",
+			"inGameStrID": "devillicsphere",
 			"notecount": 490
 		},
 		"difficulty": "Past",
@@ -16210,7 +16210,7 @@
 	{
 		"chartID": "4b5273cd735649944a46b93747cf4a64bb7041ac",
 		"data": {
-			"inGameID": "devillicsphere",
+			"inGameStrID": "devillicsphere",
 			"notecount": 692
 		},
 		"difficulty": "Present",
@@ -16226,7 +16226,7 @@
 	{
 		"chartID": "49f1ca38a139e824c4e5e79bef82d6ea929561d6",
 		"data": {
-			"inGameID": "lucidtraveler",
+			"inGameStrID": "lucidtraveler",
 			"notecount": 1341
 		},
 		"difficulty": "Future",
@@ -16242,7 +16242,7 @@
 	{
 		"chartID": "ecc0b5977f386e7663082650874ded35df36c4de",
 		"data": {
-			"inGameID": "lucidtraveler",
+			"inGameStrID": "lucidtraveler",
 			"notecount": 634
 		},
 		"difficulty": "Past",
@@ -16258,7 +16258,7 @@
 	{
 		"chartID": "c7c41d9798b0f1f71a647dcf824c43683c8a4ca2",
 		"data": {
-			"inGameID": "lucidtraveler",
+			"inGameStrID": "lucidtraveler",
 			"notecount": 1006
 		},
 		"difficulty": "Present",
@@ -16274,7 +16274,7 @@
 	{
 		"chartID": "3b160feb054ca91168c3300ec076b214cc14859b",
 		"data": {
-			"inGameID": "chaos",
+			"inGameStrID": "chaos",
 			"notecount": 1369
 		},
 		"difficulty": "Future",
@@ -16290,7 +16290,7 @@
 	{
 		"chartID": "0076bcb0257e6f83ee0573d084582360df21d88d",
 		"data": {
-			"inGameID": "chaos",
+			"inGameStrID": "chaos",
 			"notecount": 646
 		},
 		"difficulty": "Past",
@@ -16306,7 +16306,7 @@
 	{
 		"chartID": "965c97abb9dafd3ee73a784c9d443abaeb078a7d",
 		"data": {
-			"inGameID": "chaos",
+			"inGameStrID": "chaos",
 			"notecount": 848
 		},
 		"difficulty": "Present",
@@ -16322,7 +16322,7 @@
 	{
 		"chartID": "422eab1698fddcdb71805b0807ad18b7b03d2cdb",
 		"data": {
-			"inGameID": "usedtobe",
+			"inGameStrID": "usedtobe",
 			"notecount": 799
 		},
 		"difficulty": "Future",
@@ -16338,7 +16338,7 @@
 	{
 		"chartID": "d033dcd6f0f1cac90a66bb23d3ce67bafc5573f3",
 		"data": {
-			"inGameID": "usedtobe",
+			"inGameStrID": "usedtobe",
 			"notecount": 537
 		},
 		"difficulty": "Past",
@@ -16354,7 +16354,7 @@
 	{
 		"chartID": "88e0b5fff54900407a17c2444c35ad1fcacd9403",
 		"data": {
-			"inGameID": "usedtobe",
+			"inGameStrID": "usedtobe",
 			"notecount": 675
 		},
 		"difficulty": "Present",
@@ -16370,7 +16370,7 @@
 	{
 		"chartID": "101f460a312bc1f872111c1682cf652f1b02e8ae",
 		"data": {
-			"inGameID": "ultimatetaste",
+			"inGameStrID": "ultimatetaste",
 			"notecount": 1405
 		},
 		"difficulty": "Future",
@@ -16386,7 +16386,7 @@
 	{
 		"chartID": "4a14a6d31852d633747351994e242473a9ad903b",
 		"data": {
-			"inGameID": "ultimatetaste",
+			"inGameStrID": "ultimatetaste",
 			"notecount": 828
 		},
 		"difficulty": "Past",
@@ -16402,7 +16402,7 @@
 	{
 		"chartID": "074c874568a9a76402f2ce1ec4a99f1ace1d5318",
 		"data": {
-			"inGameID": "ultimatetaste",
+			"inGameStrID": "ultimatetaste",
 			"notecount": 1008
 		},
 		"difficulty": "Present",
@@ -16418,7 +16418,7 @@
 	{
 		"chartID": "b1ea95514f83d9481dd3ef9b0b38efc9da1a8224",
 		"data": {
-			"inGameID": "syuten",
+			"inGameStrID": "syuten",
 			"notecount": 592
 		},
 		"difficulty": "Future",
@@ -16434,7 +16434,7 @@
 	{
 		"chartID": "d43fb20bfb9b6099be1a683302d14fdc808032c0",
 		"data": {
-			"inGameID": "syuten",
+			"inGameStrID": "syuten",
 			"notecount": 395
 		},
 		"difficulty": "Past",
@@ -16450,7 +16450,7 @@
 	{
 		"chartID": "9113886bfe82d433104fed36bc780a5d736039da",
 		"data": {
-			"inGameID": "syuten",
+			"inGameStrID": "syuten",
 			"notecount": 446
 		},
 		"difficulty": "Present",
@@ -16466,7 +16466,7 @@
 	{
 		"chartID": "5fdd6809df78810d28435bfacb98a265b007bd39",
 		"data": {
-			"inGameID": "drg",
+			"inGameStrID": "drg",
 			"notecount": 892
 		},
 		"difficulty": "Future",
@@ -16482,7 +16482,7 @@
 	{
 		"chartID": "8864a83a03082d622ce8d936d0b939b66ec5afec",
 		"data": {
-			"inGameID": "drg",
+			"inGameStrID": "drg",
 			"notecount": 380
 		},
 		"difficulty": "Past",
@@ -16498,7 +16498,7 @@
 	{
 		"chartID": "c40fc60758c83dd777070d5fb1efbbde109fa3ca",
 		"data": {
-			"inGameID": "drg",
+			"inGameStrID": "drg",
 			"notecount": 624
 		},
 		"difficulty": "Present",
@@ -16514,7 +16514,7 @@
 	{
 		"chartID": "c14be516bd759f7dfb759f4e8a8d4ffef78e7e25",
 		"data": {
-			"inGameID": "nnglooms",
+			"inGameStrID": "nnglooms",
 			"notecount": 1294
 		},
 		"difficulty": "Future",
@@ -16530,7 +16530,7 @@
 	{
 		"chartID": "df44cb07921a6e2d9e0707c006b7257006d76a99",
 		"data": {
-			"inGameID": "nnglooms",
+			"inGameStrID": "nnglooms",
 			"notecount": 637
 		},
 		"difficulty": "Past",
@@ -16546,7 +16546,7 @@
 	{
 		"chartID": "64fce263366f047ccdffdd1bd4de14ac69df5eae",
 		"data": {
-			"inGameID": "nnglooms",
+			"inGameStrID": "nnglooms",
 			"notecount": 774
 		},
 		"difficulty": "Present",
@@ -16562,7 +16562,7 @@
 	{
 		"chartID": "c7fea67cdab48ad7fdc3598a38dce9c9b9c53bf7",
 		"data": {
-			"inGameID": "ii",
+			"inGameStrID": "ii",
 			"notecount": 1051
 		},
 		"difficulty": "Future",
@@ -16578,7 +16578,7 @@
 	{
 		"chartID": "9b310ef733f0258823c785caa7585b90060274dd",
 		"data": {
-			"inGameID": "ii",
+			"inGameStrID": "ii",
 			"notecount": 690
 		},
 		"difficulty": "Past",
@@ -16594,7 +16594,7 @@
 	{
 		"chartID": "e59849e910a41ba849e5aea772fdc72d43951c71",
 		"data": {
-			"inGameID": "ii",
+			"inGameStrID": "ii",
 			"notecount": 816
 		},
 		"difficulty": "Present",
@@ -16610,7 +16610,7 @@
 	{
 		"chartID": "d8b6e47fcc07691f3107d199a114d40669298528",
 		"data": {
-			"inGameID": "magnolia",
+			"inGameStrID": "magnolia",
 			"notecount": 895
 		},
 		"difficulty": "Future",
@@ -16626,7 +16626,7 @@
 	{
 		"chartID": "6aba7df4944fe46a289bfa885f115c390783916c",
 		"data": {
-			"inGameID": "magnolia",
+			"inGameStrID": "magnolia",
 			"notecount": 625
 		},
 		"difficulty": "Past",
@@ -16642,7 +16642,7 @@
 	{
 		"chartID": "ac14f5dfbac218db2073b0d4e3977e5ecccc9d51",
 		"data": {
-			"inGameID": "magnolia",
+			"inGameStrID": "magnolia",
 			"notecount": 726
 		},
 		"difficulty": "Present",
@@ -16658,7 +16658,7 @@
 	{
 		"chartID": "6faff9237578f1c6018de001a617524e58146ee1",
 		"data": {
-			"inGameID": "sacrifice",
+			"inGameStrID": "sacrifice",
 			"notecount": 958
 		},
 		"difficulty": "Future",
@@ -16674,7 +16674,7 @@
 	{
 		"chartID": "492798a76aa2a1eb56ce16ec02c372568f412856",
 		"data": {
-			"inGameID": "sacrifice",
+			"inGameStrID": "sacrifice",
 			"notecount": 548
 		},
 		"difficulty": "Past",
@@ -16690,7 +16690,7 @@
 	{
 		"chartID": "41702b4e625976d51cbd6810f0b2312cdbfcddf8",
 		"data": {
-			"inGameID": "sacrifice",
+			"inGameStrID": "sacrifice",
 			"notecount": 779
 		},
 		"difficulty": "Present",
@@ -16706,7 +16706,7 @@
 	{
 		"chartID": "b777e7d0ba49943b2f16e2b45f49c7aa9c661c7e",
 		"data": {
-			"inGameID": "rgb",
+			"inGameStrID": "rgb",
 			"notecount": 1131
 		},
 		"difficulty": "Future",
@@ -16722,7 +16722,7 @@
 	{
 		"chartID": "439a42d4fd1423d0a1d6b4673eef9d2fab6d3a28",
 		"data": {
-			"inGameID": "rgb",
+			"inGameStrID": "rgb",
 			"notecount": 652
 		},
 		"difficulty": "Past",
@@ -16738,7 +16738,7 @@
 	{
 		"chartID": "e93f850fd0cea2de962c098308f25c8d7a4db97e",
 		"data": {
-			"inGameID": "rgb",
+			"inGameStrID": "rgb",
 			"notecount": 803
 		},
 		"difficulty": "Present",
@@ -16754,7 +16754,7 @@
 	{
 		"chartID": "4a0054d768b3f3ce6742eb6579b1a0f91750ff37",
 		"data": {
-			"inGameID": "waitfordawn",
+			"inGameStrID": "waitfordawn",
 			"notecount": 861
 		},
 		"difficulty": "Future",
@@ -16770,7 +16770,7 @@
 	{
 		"chartID": "2a036100109a574c1fe19d865b2708c2c9f0a25f",
 		"data": {
-			"inGameID": "waitfordawn",
+			"inGameStrID": "waitfordawn",
 			"notecount": 596
 		},
 		"difficulty": "Past",
@@ -16786,7 +16786,7 @@
 	{
 		"chartID": "f74fa4279bf38eb3e342a263e2f6b2ffec90a4e0",
 		"data": {
-			"inGameID": "waitfordawn",
+			"inGameStrID": "waitfordawn",
 			"notecount": 636
 		},
 		"difficulty": "Present",
@@ -16802,7 +16802,7 @@
 	{
 		"chartID": "ac6b314bb59185cd824962a63c78a27ea4235ae4",
 		"data": {
-			"inGameID": "ravenspride",
+			"inGameStrID": "ravenspride",
 			"notecount": 1030
 		},
 		"difficulty": "Future",
@@ -16818,7 +16818,7 @@
 	{
 		"chartID": "32ffa721a2a1e9fad12bf6437f5a2d4a1c35a192",
 		"data": {
-			"inGameID": "ravenspride",
+			"inGameStrID": "ravenspride",
 			"notecount": 697
 		},
 		"difficulty": "Past",
@@ -16834,7 +16834,7 @@
 	{
 		"chartID": "40c1171c4e04d7b57fec86e823cadcb05b6dfdb9",
 		"data": {
-			"inGameID": "ravenspride",
+			"inGameStrID": "ravenspride",
 			"notecount": 797
 		},
 		"difficulty": "Present",
@@ -16850,7 +16850,7 @@
 	{
 		"chartID": "4f42ee77ed92d24a5956dc9fdc041a3a5cb15d59",
 		"data": {
-			"inGameID": "riseoftheworld",
+			"inGameStrID": "riseoftheworld",
 			"notecount": 1176
 		},
 		"difficulty": "Future",
@@ -16866,7 +16866,7 @@
 	{
 		"chartID": "d72d64176b14c9a8186d0c1ef0ee5681393eb66b",
 		"data": {
-			"inGameID": "riseoftheworld",
+			"inGameStrID": "riseoftheworld",
 			"notecount": 722
 		},
 		"difficulty": "Past",
@@ -16882,7 +16882,7 @@
 	{
 		"chartID": "e98bec9f020959b2db539e5f73425695a3278011",
 		"data": {
-			"inGameID": "riseoftheworld",
+			"inGameStrID": "riseoftheworld",
 			"notecount": 843
 		},
 		"difficulty": "Present",
@@ -16898,7 +16898,7 @@
 	{
 		"chartID": "e4c01b2e9afc8524c041870c1ed4c87216fac933",
 		"data": {
-			"inGameID": "unknownlevels",
+			"inGameStrID": "unknownlevels",
 			"notecount": 1149
 		},
 		"difficulty": "Future",
@@ -16914,7 +16914,7 @@
 	{
 		"chartID": "34664c57218a6e41b5c4fa706ef0acee2e3d40f8",
 		"data": {
-			"inGameID": "unknownlevels",
+			"inGameStrID": "unknownlevels",
 			"notecount": 591
 		},
 		"difficulty": "Past",
@@ -16930,7 +16930,7 @@
 	{
 		"chartID": "23a41b793c38de28b5e468197c1eeefa2d718cd4",
 		"data": {
-			"inGameID": "unknownlevels",
+			"inGameStrID": "unknownlevels",
 			"notecount": 771
 		},
 		"difficulty": "Present",
@@ -16946,7 +16946,7 @@
 	{
 		"chartID": "6a877f46d9457650ef239601a81427d9bc01f41d",
 		"data": {
-			"inGameID": "abstrusedilemma",
+			"inGameStrID": "abstrusedilemma",
 			"notecount": 1467
 		},
 		"difficulty": "Future",
@@ -16962,7 +16962,7 @@
 	{
 		"chartID": "e01c185c712db314a78c63e9a25f82b67fbc67de",
 		"data": {
-			"inGameID": "abstrusedilemma",
+			"inGameStrID": "abstrusedilemma",
 			"notecount": 983
 		},
 		"difficulty": "Past",
@@ -16978,7 +16978,7 @@
 	{
 		"chartID": "952465cf983ebc862751c6c5979f88488d8a7d36",
 		"data": {
-			"inGameID": "abstrusedilemma",
+			"inGameStrID": "abstrusedilemma",
 			"notecount": 1127
 		},
 		"difficulty": "Present",
@@ -16994,7 +16994,7 @@
 	{
 		"chartID": "f7bee2f27dbac9f9dd1b61d2f9b09d62d0039730",
 		"data": {
-			"inGameID": "matenrou",
+			"inGameStrID": "matenrou",
 			"notecount": 1294
 		},
 		"difficulty": "Future",
@@ -17010,7 +17010,7 @@
 	{
 		"chartID": "b29bbc938397e915f8e4b7f62039690d1e0394d0",
 		"data": {
-			"inGameID": "matenrou",
+			"inGameStrID": "matenrou",
 			"notecount": 736
 		},
 		"difficulty": "Past",
@@ -17026,7 +17026,7 @@
 	{
 		"chartID": "7a32dd82749ad2903fa3ea9b98d5a30a794d7fc2",
 		"data": {
-			"inGameID": "matenrou",
+			"inGameStrID": "matenrou",
 			"notecount": 929
 		},
 		"difficulty": "Present",
@@ -17042,7 +17042,7 @@
 	{
 		"chartID": "3e18bf752d2d725f703b9b301fa6de98ba22d3f9",
 		"data": {
-			"inGameID": "tothefurthestdream",
+			"inGameStrID": "tothefurthestdream",
 			"notecount": 1102
 		},
 		"difficulty": "Future",
@@ -17058,7 +17058,7 @@
 	{
 		"chartID": "4ca6164c75764334355a28c252447c7e17362777",
 		"data": {
-			"inGameID": "tothefurthestdream",
+			"inGameStrID": "tothefurthestdream",
 			"notecount": 836
 		},
 		"difficulty": "Past",
@@ -17074,7 +17074,7 @@
 	{
 		"chartID": "2b15a06ce955a338002e94e642523875891496c8",
 		"data": {
-			"inGameID": "tothefurthestdream",
+			"inGameStrID": "tothefurthestdream",
 			"notecount": 994
 		},
 		"difficulty": "Present",
@@ -17090,7 +17090,7 @@
 	{
 		"chartID": "b930db4525f13fd072d13a25ae6454c9cdf5b53f",
 		"data": {
-			"inGameID": "remindthesouls",
+			"inGameStrID": "remindthesouls",
 			"notecount": 945
 		},
 		"difficulty": "Future",
@@ -17106,7 +17106,7 @@
 	{
 		"chartID": "a7631da12bdc136d7d2ec19d0f8275a1659cce3e",
 		"data": {
-			"inGameID": "remindthesouls",
+			"inGameStrID": "remindthesouls",
 			"notecount": 561
 		},
 		"difficulty": "Past",
@@ -17122,7 +17122,7 @@
 	{
 		"chartID": "6244c1a105e735d0e8444c375b0e7d4d334ff19d",
 		"data": {
-			"inGameID": "remindthesouls",
+			"inGameStrID": "remindthesouls",
 			"notecount": 756
 		},
 		"difficulty": "Present",
@@ -17138,7 +17138,7 @@
 	{
 		"chartID": "fcbc438957219968011a68c13af676e7611661a7",
 		"data": {
-			"inGameID": "dynitikos",
+			"inGameStrID": "dynitikos",
 			"notecount": 986
 		},
 		"difficulty": "Future",
@@ -17154,7 +17154,7 @@
 	{
 		"chartID": "9d4d28849034ceebcb17f6736d5554b13610d0a3",
 		"data": {
-			"inGameID": "dynitikos",
+			"inGameStrID": "dynitikos",
 			"notecount": 683
 		},
 		"difficulty": "Past",
@@ -17170,7 +17170,7 @@
 	{
 		"chartID": "75ec60439a1d40f0b217b769a51e692033b08bf2",
 		"data": {
-			"inGameID": "dynitikos",
+			"inGameStrID": "dynitikos",
 			"notecount": 894
 		},
 		"difficulty": "Present",
@@ -17186,7 +17186,7 @@
 	{
 		"chartID": "f47d197a7dc990c663277a497c148764735a8fe4",
 		"data": {
-			"inGameID": "amekagura",
+			"inGameStrID": "amekagura",
 			"notecount": 1076
 		},
 		"difficulty": "Future",
@@ -17202,7 +17202,7 @@
 	{
 		"chartID": "76232e6b252fbfa45cf647043580a638dc236c58",
 		"data": {
-			"inGameID": "amekagura",
+			"inGameStrID": "amekagura",
 			"notecount": 741
 		},
 		"difficulty": "Past",
@@ -17218,7 +17218,7 @@
 	{
 		"chartID": "f6fa17a7e4ef02efb2f105af4d0f900a88346b4a",
 		"data": {
-			"inGameID": "amekagura",
+			"inGameStrID": "amekagura",
 			"notecount": 851
 		},
 		"difficulty": "Present",
@@ -17234,7 +17234,7 @@
 	{
 		"chartID": "18587325d7a0ba069b5b5264062c4f1e0c091a14",
 		"data": {
-			"inGameID": "bbkkbkk",
+			"inGameStrID": "bbkkbkk",
 			"notecount": 976
 		},
 		"difficulty": "Future",
@@ -17250,7 +17250,7 @@
 	{
 		"chartID": "5ea66342997f62fabc88ac7ac17c89ccfa988e6e",
 		"data": {
-			"inGameID": "bbkkbkk",
+			"inGameStrID": "bbkkbkk",
 			"notecount": 669
 		},
 		"difficulty": "Past",
@@ -17266,7 +17266,7 @@
 	{
 		"chartID": "6ba49a1238a654e12b7bbe312120beda7e20fed1",
 		"data": {
-			"inGameID": "bbkkbkk",
+			"inGameStrID": "bbkkbkk",
 			"notecount": 708
 		},
 		"difficulty": "Present",
@@ -17282,7 +17282,7 @@
 	{
 		"chartID": "deae076418474cca094df668633ad034e37aa9f6",
 		"data": {
-			"inGameID": "primevaltexture",
+			"inGameStrID": "primevaltexture",
 			"notecount": 810
 		},
 		"difficulty": "Future",
@@ -17298,7 +17298,7 @@
 	{
 		"chartID": "c7be6951ee48b3aa5e5499f128d854baafa3a20c",
 		"data": {
-			"inGameID": "primevaltexture",
+			"inGameStrID": "primevaltexture",
 			"notecount": 387
 		},
 		"difficulty": "Past",
@@ -17314,7 +17314,7 @@
 	{
 		"chartID": "0adc4622c09328ce7e1fb7158ce9f02cb754a1ab",
 		"data": {
-			"inGameID": "primevaltexture",
+			"inGameStrID": "primevaltexture",
 			"notecount": 525
 		},
 		"difficulty": "Present",
@@ -17330,7 +17330,7 @@
 	{
 		"chartID": "59ec26fb84646b9b36b4e8d30a724b9594344ce3",
 		"data": {
-			"inGameID": "technicolour",
+			"inGameStrID": "technicolour",
 			"notecount": 1140
 		},
 		"difficulty": "Future",
@@ -17346,7 +17346,7 @@
 	{
 		"chartID": "19d152f882341a6bb5d56a97312b1da8a3f7053c",
 		"data": {
-			"inGameID": "technicolour",
+			"inGameStrID": "technicolour",
 			"notecount": 644
 		},
 		"difficulty": "Past",
@@ -17362,7 +17362,7 @@
 	{
 		"chartID": "bf6b3516c62dbea12d978cf7243b63371605cc96",
 		"data": {
-			"inGameID": "technicolour",
+			"inGameStrID": "technicolour",
 			"notecount": 812
 		},
 		"difficulty": "Present",
@@ -17378,7 +17378,7 @@
 	{
 		"chartID": "0b1b1a7f8f4e2a7e84e5175977a9c2691702db55",
 		"data": {
-			"inGameID": "logos",
+			"inGameStrID": "logos",
 			"notecount": 1040
 		},
 		"difficulty": "Future",
@@ -17394,7 +17394,7 @@
 	{
 		"chartID": "2dd557c07af3391fee206fb830158992a7b5ac4f",
 		"data": {
-			"inGameID": "logos",
+			"inGameStrID": "logos",
 			"notecount": 697
 		},
 		"difficulty": "Past",
@@ -17410,7 +17410,7 @@
 	{
 		"chartID": "cb14bb3b844e352ec8e0e6035ba4004781cbafb6",
 		"data": {
-			"inGameID": "logos",
+			"inGameStrID": "logos",
 			"notecount": 798
 		},
 		"difficulty": "Present",
@@ -17426,7 +17426,7 @@
 	{
 		"chartID": "69fa9693c8447a5dc5eed3fc261c0c66a4cb9031",
 		"data": {
-			"inGameID": "egoeimi",
+			"inGameStrID": "egoeimi",
 			"notecount": 1223
 		},
 		"difficulty": "Future",
@@ -17442,7 +17442,7 @@
 	{
 		"chartID": "dc9826e3b744134b09b96f4e346bc5541434d612",
 		"data": {
-			"inGameID": "egoeimi",
+			"inGameStrID": "egoeimi",
 			"notecount": 801
 		},
 		"difficulty": "Past",
@@ -17458,7 +17458,7 @@
 	{
 		"chartID": "e64f0a3b63f8882c6b2cb49fbd0bf10c699d75fc",
 		"data": {
-			"inGameID": "egoeimi",
+			"inGameStrID": "egoeimi",
 			"notecount": 937
 		},
 		"difficulty": "Present",
@@ -17474,7 +17474,7 @@
 	{
 		"chartID": "847b857a208da8a647a58e71c9a45f579faface6",
 		"data": {
-			"inGameID": "arghena",
+			"inGameStrID": "arghena",
 			"notecount": 1444
 		},
 		"difficulty": "Future",
@@ -17490,7 +17490,7 @@
 	{
 		"chartID": "7bc99b59208c727798e2835ee40eed958028d673",
 		"data": {
-			"inGameID": "arghena",
+			"inGameStrID": "arghena",
 			"notecount": 883
 		},
 		"difficulty": "Past",
@@ -17506,7 +17506,7 @@
 	{
 		"chartID": "b50ae6359f4c8aa16f4989a7bc353300a18948ac",
 		"data": {
-			"inGameID": "arghena",
+			"inGameStrID": "arghena",
 			"notecount": 1082
 		},
 		"difficulty": "Present",

--- a/database-seeds/scripts/test/match-type.test.ts
+++ b/database-seeds/scripts/test/match-type.test.ts
@@ -45,6 +45,7 @@ const MATCH_TYPE_CHECKS: Record<
 		fn: (c: ChartDocument<"bms:7K" | "bms:14K">) => [c.data.hashMD5, c.data.hashSHA256],
 	},
 	inGameID: { type: "CHARTS", fn: (c) => `${c.data.inGameID}-${c.difficulty}` },
+	inGameStrID: { type: "CHARTS", fn: (c) => `${c.data.inGameStrID}-${c.difficulty}` },
 	itgChartHash: { type: "CHARTS", fn: (c) => c.data.hashGSv3 },
 	popnChartHash: { type: "CHARTS", fn: (c) => c.data.hashSHA256 },
 	sdvxInGameID: {


### PR DESCRIPTION
Like the branch name suggests, this was introduced because Arcaea uses string IDs and not numeric IDs like many other games, making it incompatible with `inGameID`, which needs a numeric ID.

Since maimai FiNALE chart seeds already stored `inGameStrID`s, adding the match type to the game was a nice bonus.