### PR TITLE
[iidx] resident final and minor script change

### DIFF
--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -24395,5 +24395,643 @@
 		"id": 2206,
 		"searchTerms": [],
 		"title": "Vector"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Dustup Vs. L.E.D.-G\"",
+		"data": {
+			"displayVersion": "30",
+			"genre": "MASSIVE MIXTURE"
+		},
+		"id": 2207,
+		"searchTerms": [],
+		"title": "LOUDER ROLLING THUNDER"
+	},
+	{
+		"altTitles": [],
+		"artist": "三代目 ADULTIC TEACHERS feat. BEMANI Sound Team \"スコーピオン志村\"",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ハードコア"
+		},
+		"id": 2208,
+		"searchTerms": [],
+		"title": "mathematical good-bye"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"HuΣeR\"",
+		"data": {
+			"displayVersion": "30",
+			"genre": "FORTUNE OVERTURE"
+		},
+		"id": 2209,
+		"searchTerms": [],
+		"title": "[ ]DENTITY"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Darker Vs. JUSTICE\"",
+		"data": {
+			"displayVersion": "30",
+			"genre": "EXTREME EXPERIMENTAL"
+		},
+		"id": 2210,
+		"searchTerms": [],
+		"title": "VØID"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"dj TAKA\" Vs SOUND HOLIC",
+		"data": {
+			"displayVersion": "30",
+			"genre": "BPL S3 THEME"
+		},
+		"id": 2211,
+		"searchTerms": [],
+		"title": "FLARE -炎舞- ft.Nana Takahashi"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"dj TAKA\"",
+		"data": {
+			"displayVersion": "30",
+			"genre": "SPIRITUAL CORE"
+		},
+		"id": 2212,
+		"searchTerms": [],
+		"title": "輪廻の鴉"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Expander\" feat. Starbitz",
+		"data": {
+			"displayVersion": "30",
+			"genre": "COLOUR BASS BREAKS"
+		},
+		"id": 2213,
+		"searchTerms": [],
+		"title": "STRAIGHT TO THE STARS"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"ZAQUVA\"",
+		"data": {
+			"displayVersion": "30",
+			"genre": "HAPPY HARDCORE"
+		},
+		"id": 2214,
+		"searchTerms": [],
+		"title": "Xerulean"
+	},
+	{
+		"altTitles": [],
+		"artist": "しのりゅー",
+		"data": {
+			"displayVersion": "30",
+			"genre": "BEMANI 8BIT COLLECTION"
+		},
+		"id": 2215,
+		"searchTerms": [],
+		"title": "サヨナラ・ヘヴン-Celtic Chip Dance Mix-"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"DJ TOTTO VS 兎々\"",
+		"data": {
+			"displayVersion": "30",
+			"genre": "EMPYREAL HYDRO ARTCORE"
+		},
+		"id": 2216,
+		"searchTerms": [],
+		"title": "VOLAQUAS"
+	},
+	{
+		"altTitles": [],
+		"artist": "kors k feat.吉河順央",
+		"data": {
+			"displayVersion": "30",
+			"genre": "PRISM EURO"
+		},
+		"id": 2217,
+		"searchTerms": [],
+		"title": "7 Colors"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"PHQUASE\" feat.紫崎 雪",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ALTERNATIVE SHIBUYA E-POP"
+		},
+		"id": 2218,
+		"searchTerms": [],
+		"title": "■□模様"
+	},
+	{
+		"altTitles": [],
+		"artist": "Hekatoncheir",
+		"data": {
+			"displayVersion": "30",
+			"genre": "CULMINATION"
+		},
+		"id": 2219,
+		"searchTerms": [],
+		"title": "Beyond Evolution"
+	},
+	{
+		"altTitles": [],
+		"artist": "kors k",
+		"data": {
+			"displayVersion": "30",
+			"genre": "CHANNEL K"
+		},
+		"id": 2220,
+		"searchTerms": [],
+		"title": "kors k's How to make OTOGE CORE 「LONG」"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"猫叉Master VS dj TAKA\"",
+		"data": {
+			"displayVersion": "30",
+			"genre": "JAZZ CORE"
+		},
+		"id": 2221,
+		"searchTerms": [],
+		"title": "suspicions"
+	},
+	{
+		"altTitles": [],
+		"artist": "BlackY",
+		"data": {
+			"displayVersion": "30",
+			"genre": "STARRY BASS HOUSE"
+		},
+		"id": 2222,
+		"searchTerms": [],
+		"title": "Caldwell 99"
+	},
+	{
+		"altTitles": [],
+		"artist": "Xceon",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ELECTRO FUSION"
+		},
+		"id": 2223,
+		"searchTerms": [],
+		"title": "Ambush Ace"
+	},
+	{
+		"altTitles": [],
+		"artist": "らっぷびと Prod. by RoughSketch & NUE",
+		"data": {
+			"displayVersion": "30",
+			"genre": "RAPCORE"
+		},
+		"id": 2224,
+		"searchTerms": [],
+		"title": "Peaktime Booster"
+	},
+	{
+		"altTitles": [],
+		"artist": "nora2r",
+		"data": {
+			"displayVersion": "30",
+			"genre": "EMOTIONAL HAPPY EUPHORIA"
+		},
+		"id": 2225,
+		"searchTerms": [],
+		"title": "Always We Trust In You"
+	},
+	{
+		"altTitles": [],
+		"artist": "Nhato",
+		"data": {
+			"displayVersion": "30",
+			"genre": "TRANCE"
+		},
+		"id": 2226,
+		"searchTerms": [],
+		"title": "Fading Stars"
+	},
+	{
+		"altTitles": [],
+		"artist": "lapix",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ULTRA JAZZFUNKTION"
+		},
+		"id": 2227,
+		"searchTerms": [],
+		"title": "Swing My Wonderland"
+	},
+	{
+		"altTitles": [],
+		"artist": "Akira Complex",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ENIGMATIC BASS HARDCORE"
+		},
+		"id": 2228,
+		"searchTerms": [],
+		"title": "DIAMOND JACKAL"
+	},
+	{
+		"altTitles": [],
+		"artist": "夢路 歩",
+		"data": {
+			"displayVersion": "30",
+			"genre": "SUBCONSCIOUS FRAGMENT"
+		},
+		"id": 2229,
+		"searchTerms": [],
+		"title": "Somnidiscotheque"
+	},
+	{
+		"altTitles": [],
+		"artist": "OSTER project",
+		"data": {
+			"displayVersion": "30",
+			"genre": "TRIUMPHAL MARCH"
+		},
+		"id": 2230,
+		"searchTerms": [],
+		"title": "栄冠のカンパネラ"
+	},
+	{
+		"altTitles": [],
+		"artist": "REMO-CON",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ACID RAVE"
+		},
+		"id": 2231,
+		"searchTerms": [],
+		"title": "dica dica"
+	},
+	{
+		"altTitles": [],
+		"artist": "Hommarju",
+		"data": {
+			"displayVersion": "30",
+			"genre": "HARDCORE"
+		},
+		"id": 2232,
+		"searchTerms": [],
+		"title": "Super Freak"
+	},
+	{
+		"altTitles": [],
+		"artist": "中山真斗 feat. CHAN",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ALTERNATIVE"
+		},
+		"id": 2233,
+		"searchTerms": [],
+		"title": "楽園追放"
+	},
+	{
+		"altTitles": [],
+		"artist": "Qlarabelle",
+		"data": {
+			"displayVersion": "30",
+			"genre": "HARD TRIBAL"
+		},
+		"id": 2234,
+		"searchTerms": [],
+		"title": "#CMFLG"
+	},
+	{
+		"altTitles": [],
+		"artist": "AJURIKA",
+		"data": {
+			"displayVersion": "30",
+			"genre": "MELODIC DUBSTEP"
+		},
+		"id": 2235,
+		"searchTerms": [],
+		"title": "神のシナリオ"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ TOTTO",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ARTCORE"
+		},
+		"id": 2236,
+		"searchTerms": [],
+		"title": "glacia"
+	},
+	{
+		"altTitles": [],
+		"artist": "Blacklolita",
+		"data": {
+			"displayVersion": "30",
+			"genre": "TEAROUT BREAKS"
+		},
+		"id": 2237,
+		"searchTerms": [],
+		"title": "EXODUS SIGN"
+	},
+	{
+		"altTitles": [],
+		"artist": "ちよこ & 一ノ瀬 月琉 Prod. by RoughSketch & NUE",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ウラシュダイカ"
+		},
+		"id": 2238,
+		"searchTerms": [],
+		"title": "チェイスチェイスジョーカーズのうた (オニスタイルリミックス)"
+	},
+	{
+		"altTitles": [],
+		"artist": "BlackY",
+		"data": {
+			"displayVersion": "30",
+			"genre": "EMOTIONAL HARDCORE SUMMERS"
+		},
+		"id": 2239,
+		"searchTerms": [],
+		"title": "BIGWAVERS"
+	},
+	{
+		"altTitles": [],
+		"artist": "MK feat. 紫咲ほたる",
+		"data": {
+			"displayVersion": "30",
+			"genre": "DANCE POP"
+		},
+		"id": 2240,
+		"searchTerms": [],
+		"title": "Dreaming Dream"
+	},
+	{
+		"altTitles": [],
+		"artist": "Yuta Imai",
+		"data": {
+			"displayVersion": "30",
+			"genre": "RAVE IN THE GAME"
+		},
+		"id": 2241,
+		"searchTerms": [],
+		"title": "ONE AND ONLY"
+	},
+	{
+		"altTitles": [],
+		"artist": "ヒゲドライバー",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ピコピコ電波ソング"
+		},
+		"id": 2242,
+		"searchTerms": [],
+		"title": "あるビー！ feat.ころねぽち"
+	},
+	{
+		"altTitles": [],
+		"artist": "Yu_Asahina",
+		"data": {
+			"displayVersion": "30",
+			"genre": "DISSOCIATIVE IDENTITY DISORDER"
+		},
+		"id": 2243,
+		"searchTerms": [],
+		"title": "The Clown of 24stairs"
+	},
+	{
+		"altTitles": [],
+		"artist": "Ashrount vs polysha",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ARCADE CORE"
+		},
+		"id": 2244,
+		"searchTerms": [],
+		"title": "ZEИITH"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ SHARPNEL feat. みらい",
+		"data": {
+			"displayVersion": "30",
+			"genre": "バーチャルマルチコア"
+		},
+		"id": 2245,
+		"searchTerms": [],
+		"title": "ぞうしょく！？マイデンティティ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Yamato",
+		"data": {
+			"displayVersion": "30",
+			"genre": "DnB"
+		},
+		"id": 2246,
+		"searchTerms": [],
+		"title": "Level 4"
+	},
+	{
+		"altTitles": [],
+		"artist": "Feryquitous",
+		"data": {
+			"displayVersion": "30",
+			"genre": "HELETIC BREAK D'n'B"
+		},
+		"id": 2247,
+		"searchTerms": [],
+		"title": "Chaotoxin"
+	},
+	{
+		"altTitles": [],
+		"artist": "arcane feat.rionos",
+		"data": {
+			"displayVersion": "30",
+			"genre": "FANTASIA"
+		},
+		"id": 2248,
+		"searchTerms": [],
+		"title": "昏き甲鉄のヴェルガ"
+	},
+	{
+		"altTitles": [],
+		"artist": "黒魔",
+		"data": {
+			"displayVersion": "30",
+			"genre": "CHIP ELECTRO"
+		},
+		"id": 2249,
+		"searchTerms": [],
+		"title": "I"
+	},
+	{
+		"altTitles": [],
+		"artist": "GeMiNioИ",
+		"data": {
+			"displayVersion": "30",
+			"genre": "SYMPHONIC SAVIOR"
+		},
+		"id": 2250,
+		"searchTerms": [],
+		"title": "RINИE"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"PON\" feat.かなたん",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ROCK"
+		},
+		"id": 2251,
+		"searchTerms": [],
+		"title": "パーフェクトイーター"
+	},
+	{
+		"altTitles": [],
+		"artist": "立秋 vs. BEMANI Sound Team \"L.E.D.-G\" feat.ちょこ＆ななひら",
+		"data": {
+			"displayVersion": "30",
+			"genre": "HARDCORE×ソフラン×変拍子×萌え"
+		},
+		"id": 2252,
+		"searchTerms": [],
+		"title": "恋愛＝精度×認識力"
+	},
+	{
+		"altTitles": [],
+		"artist": "Snail's House",
+		"data": {
+			"displayVersion": "30",
+			"genre": "BOSSA NA NOKA"
+		},
+		"id": 2253,
+		"searchTerms": [],
+		"title": "AWA AWA"
+	},
+	{
+		"altTitles": [],
+		"artist": "Pizuya's Cell",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ROCK"
+		},
+		"id": 2254,
+		"searchTerms": [],
+		"title": "ちょえちょえまぎか"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by uno(IOSYS) & NUE feat. Chiyoko",
+		"data": {
+			"displayVersion": "30",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2255,
+		"searchTerms": [],
+		"title": "神っぽいな"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by SOUND HOLIC feat. はるの",
+		"data": {
+			"displayVersion": "30",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2256,
+		"searchTerms": [],
+		"title": "KING"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by Nhato feat. 花たん",
+		"data": {
+			"displayVersion": "30",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2257,
+		"searchTerms": [],
+		"title": "新時代"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by Ryu☆ feat. BEMANI Sound Team \"ショッチョー\" ＆ イオシスコーラス隊",
+		"data": {
+			"displayVersion": "30",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2258,
+		"searchTerms": [],
+		"title": "マツケンサンバII"
+	},
+	{
+		"altTitles": [],
+		"artist": "Shiron",
+		"data": {
+			"displayVersion": "30",
+			"genre": "NRG SCHRANZ"
+		},
+		"id": 2259,
+		"searchTerms": [],
+		"title": "CODE -CRiMSON-"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"[x]\"",
+		"data": {
+			"displayVersion": "30",
+			"genre": "HARDCORE TECHNO"
+		},
+		"id": 2260,
+		"searchTerms": [],
+		"title": "MAX 360"
+	},
+	{
+		"altTitles": [],
+		"artist": "天土",
+		"data": {
+			"displayVersion": "30",
+			"genre": "EUROBEAT"
+		},
+		"id": 2261,
+		"searchTerms": [],
+		"title": "異心前進♪ぴょんぴょんぴょん "
+	},
+	{
+		"altTitles": [],
+		"artist": "SOUND HOLIC feat. Nana Takahashi",
+		"data": {
+			"displayVersion": "30",
+			"genre": "ANIMTRIBE POP"
+		},
+		"id": 2262,
+		"searchTerms": [],
+		"title": "惑星☆ロリポップ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Blacklolita",
+		"data": {
+			"displayVersion": "30",
+			"genre": "G-HOUSE"
+		},
+		"id": 2263,
+		"searchTerms": [],
+		"title": "Shamshir"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"HuΣeR\"",
+		"data": {
+			"displayVersion": "30",
+			"genre": "STYLISH ELECTRO"
+		},
+		"id": 2264,
+		"searchTerms": [],
+		"title": "Stylus"
 	}
 ]

--- a/database-seeds/scripts/rerunners/iidx/iidx-mdb-parse/convert.ts
+++ b/database-seeds/scripts/rerunners/iidx/iidx-mdb-parse/convert.ts
@@ -20,7 +20,7 @@ mkdirSync(ifsOUT, { recursive: true });
  */
 function ifsExtract(ifsPath: string) {
 	logger.info(`Extracting ${ifsPath}...`);
-	execSync(`ifstools "${ifsPath}" -o "${ifsOUT}" -y`, { stdio: "ignore" });
+	execSync(`ifstools "${ifsPath}" -o "${ifsOUT}" -y --super-disable`, { stdio: "ignore" });
 }
 
 // @optimisable


### PR DESCRIPTION
Updates seed data to 20230905.

The change to convert.ts should make it easier to import new leggendaria charts.  The flag allows partial IFS files to be extracted without their parent, this should be safe because the new .1, which contains all charts, will always be in the new partial file (-p0.ifs files).