### PR TITLE
fix: extra validator for maimai DX score verification

### DIFF
--- a/server/src/game-implementations/games/maimaidx.ts
+++ b/server/src/game-implementations/games/maimaidx.ts
@@ -146,6 +146,10 @@ export const MAIMAIDX_IMPL: GPTServerImplementation<"maimaidx:Single"> = {
 			if (s.scoreData.lamp !== "ALL PERFECT+" && s.scoreData.percent === 101) {
 				return "A score of 101% should be an ALL PERFECT+";
 			}
+
+			if (s.scoreData.lamp === "ALL PERFECT" && s.scoreData.percent < 100.5) {
+				return "Cannot have an ALL PERFECT without at least 100.5%.";
+			}
 		},
 	],
 };


### PR DESCRIPTION
checked up with a few friends and 100.5% seems to be the minimum for an ALL PERFECT score, so adding it as a validator for scores.

there isn't a validator for the other way around since scores higher than 100.5% can be not ALL PERFECT.