### PR TITLE
[chunithm] Update seeds to 2023-10-28, add search terms for most songs

### DIFF
--- a/database-seeds/collections/charts-chunithm.json
+++ b/database-seeds/collections/charts-chunithm.json
@@ -23595,6 +23595,21 @@
 		]
 	},
 	{
+		"chartID": "0166ce32bfdb951f95cec51242b1fc6f18dff38b",
+		"data": {
+			"inGameID": 331
+		},
+		"difficulty": "ULTIMA",
+		"isPrimary": true,
+		"level": "14+",
+		"levelNum": 14.6,
+		"playtype": "Single",
+		"songID": 331,
+		"versions": [
+			"sunplus"
+		]
+	},
+	{
 		"chartID": "c582791b09c12e35f27c0b2dbf55ce47b3779fa1",
 		"data": {
 			"inGameID": 332
@@ -99676,6 +99691,7 @@
 		"songID": 2297,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99692,6 +99708,7 @@
 		"songID": 2297,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99708,6 +99725,7 @@
 		"songID": 2297,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99724,6 +99742,7 @@
 		"songID": 2297,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99740,6 +99759,7 @@
 		"songID": 2298,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99756,6 +99776,7 @@
 		"songID": 2298,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99772,6 +99793,7 @@
 		"songID": 2298,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99788,6 +99810,7 @@
 		"songID": 2298,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99804,6 +99827,7 @@
 		"songID": 2299,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99820,6 +99844,7 @@
 		"songID": 2299,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99836,6 +99861,7 @@
 		"songID": 2299,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99852,6 +99878,7 @@
 		"songID": 2299,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99868,6 +99895,7 @@
 		"songID": 2300,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99884,6 +99912,7 @@
 		"songID": 2300,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99900,6 +99929,7 @@
 		"songID": 2300,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99916,6 +99946,7 @@
 		"songID": 2300,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99932,6 +99963,7 @@
 		"songID": 2301,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99948,6 +99980,7 @@
 		"songID": 2301,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99964,6 +99997,7 @@
 		"songID": 2301,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -99980,6 +100014,7 @@
 		"songID": 2301,
 		"versions": [
 			"sun-omni",
+			"sunplus",
 			"sunplus-intl"
 		]
 	},
@@ -107418,7 +107453,8 @@
 		"playtype": "Single",
 		"songID": 2417,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107433,7 +107469,8 @@
 		"playtype": "Single",
 		"songID": 2417,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107448,7 +107485,8 @@
 		"playtype": "Single",
 		"songID": 2417,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107463,7 +107501,8 @@
 		"playtype": "Single",
 		"songID": 2417,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107478,7 +107517,8 @@
 		"playtype": "Single",
 		"songID": 2418,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107493,7 +107533,8 @@
 		"playtype": "Single",
 		"songID": 2418,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107508,7 +107549,8 @@
 		"playtype": "Single",
 		"songID": 2418,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107523,7 +107565,8 @@
 		"playtype": "Single",
 		"songID": 2418,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107718,7 +107761,8 @@
 		"playtype": "Single",
 		"songID": 2422,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107733,7 +107777,8 @@
 		"playtype": "Single",
 		"songID": 2422,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107748,7 +107793,8 @@
 		"playtype": "Single",
 		"songID": 2422,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107763,7 +107809,8 @@
 		"playtype": "Single",
 		"songID": 2422,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107778,7 +107825,8 @@
 		"playtype": "Single",
 		"songID": 2425,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107793,7 +107841,8 @@
 		"playtype": "Single",
 		"songID": 2425,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107808,7 +107857,8 @@
 		"playtype": "Single",
 		"songID": 2425,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107823,7 +107873,8 @@
 		"playtype": "Single",
 		"songID": 2425,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107838,7 +107889,8 @@
 		"playtype": "Single",
 		"songID": 2426,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107853,7 +107905,8 @@
 		"playtype": "Single",
 		"songID": 2426,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107868,7 +107921,8 @@
 		"playtype": "Single",
 		"songID": 2426,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107883,7 +107937,8 @@
 		"playtype": "Single",
 		"songID": 2426,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110105,7 +110160,7 @@
 		"difficulty": "MASTER",
 		"isPrimary": true,
 		"level": "12+",
-		"levelNum": 12.5,
+		"levelNum": 12.9,
 		"playtype": "Single",
 		"songID": 2464,
 		"versions": [
@@ -110173,7 +110228,7 @@
 		"difficulty": "MASTER",
 		"isPrimary": true,
 		"level": "12+",
-		"levelNum": 12.5,
+		"levelNum": 12.7,
 		"playtype": "Single",
 		"songID": 2465,
 		"versions": [
@@ -110220,7 +110275,7 @@
 		"difficulty": "EXPERT",
 		"isPrimary": true,
 		"level": "10",
-		"levelNum": 10,
+		"levelNum": 10.1,
 		"playtype": "Single",
 		"songID": 2466,
 		"versions": [
@@ -110235,7 +110290,7 @@
 		"difficulty": "MASTER",
 		"isPrimary": true,
 		"level": "14",
-		"levelNum": 14,
+		"levelNum": 14.2,
 		"playtype": "Single",
 		"songID": 2466,
 		"versions": [
@@ -110280,7 +110335,7 @@
 		"difficulty": "EXPERT",
 		"isPrimary": true,
 		"level": "12",
-		"levelNum": 12,
+		"levelNum": 12.1,
 		"playtype": "Single",
 		"songID": 2467,
 		"versions": [
@@ -110295,7 +110350,7 @@
 		"difficulty": "MASTER",
 		"isPrimary": true,
 		"level": "14",
-		"levelNum": 14,
+		"levelNum": 14.4,
 		"playtype": "Single",
 		"songID": 2467,
 		"versions": [
@@ -110355,7 +110410,7 @@
 		"difficulty": "MASTER",
 		"isPrimary": true,
 		"level": "12+",
-		"levelNum": 12.5,
+		"levelNum": 12.6,
 		"playtype": "Single",
 		"songID": 2468,
 		"versions": [
@@ -110415,9 +110470,129 @@
 		"difficulty": "MASTER",
 		"isPrimary": true,
 		"level": "12",
-		"levelNum": 12,
+		"levelNum": 12.4,
 		"playtype": "Single",
 		"songID": 2469,
+		"versions": [
+			"sunplus"
+		]
+	},
+	{
+		"chartID": "f668fa08ea11d3c102d610dc9ba534a9ec5274f1",
+		"data": {
+			"inGameID": 2475
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "11",
+		"levelNum": 11.3,
+		"playtype": "Single",
+		"songID": 2475,
+		"versions": [
+			"sunplus"
+		]
+	},
+	{
+		"chartID": "d26c5a87fae6d2b35dbcad35e2e4cf6bbc9410fa",
+		"data": {
+			"inGameID": 2475
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"songID": 2475,
+		"versions": [
+			"sunplus"
+		]
+	},
+	{
+		"chartID": "4519a8bdea0da93d48fc6588e50bf0246dde2c5b",
+		"data": {
+			"inGameID": 2475
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14.3,
+		"playtype": "Single",
+		"songID": 2475,
+		"versions": [
+			"sunplus"
+		]
+	},
+	{
+		"chartID": "158e8cc1749bddb7a949484f831789badfcb1716",
+		"data": {
+			"inGameID": 2475
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15.4,
+		"playtype": "Single",
+		"songID": 2475,
+		"versions": [
+			"sunplus"
+		]
+	},
+	{
+		"chartID": "b42472fda0d680ee02095a2a0ae13846128aaa30",
+		"data": {
+			"inGameID": 2476
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"songID": 2476,
+		"versions": [
+			"sunplus"
+		]
+	},
+	{
+		"chartID": "e4971b8f1578e0a492745f7b55128237ca711ecd",
+		"data": {
+			"inGameID": 2476
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"songID": 2476,
+		"versions": [
+			"sunplus"
+		]
+	},
+	{
+		"chartID": "68a469f358ef37e788c353380c86920d062163f7",
+		"data": {
+			"inGameID": 2476
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"songID": 2476,
+		"versions": [
+			"sunplus"
+		]
+	},
+	{
+		"chartID": "86c138f1fa87e2740d70ae8ddd04fd9cb04377b4",
+		"data": {
+			"inGameID": 2476
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12.1,
+		"playtype": "Single",
+		"songID": 2476,
 		"versions": [
 			"sunplus"
 		]

--- a/database-seeds/collections/songs-chunithm.json
+++ b/database-seeds/collections/songs-chunithm.json
@@ -3756,7 +3756,8 @@
 		"id": 331,
 		"searchTerms": [
 			"Mo-shin Soliste Life!",
-			"soliste"
+			"soliste",
+			"a fast-paced soloist life!"
 		],
 		"title": "猛進ソリストライフ！"
 	},

--- a/database-seeds/collections/songs-chunithm.json
+++ b/database-seeds/collections/songs-chunithm.json
@@ -7,7 +7,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 0,
-		"searchTerms": [],
+		"searchTerms": [
+			"tentai kansoku"
+		],
 		"title": "天体観測"
 	},
 	{
@@ -40,7 +42,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 6,
-		"searchTerms": [],
+		"searchTerms": [
+			"rfts"
+		],
 		"title": "Reach for the Stars"
 	},
 	{
@@ -65,7 +69,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 9,
-		"searchTerms": [],
+		"searchTerms": [
+			"jonetsu tairiku"
+		],
 		"title": "情熱大陸"
 	},
 	{
@@ -87,7 +93,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 12,
-		"searchTerms": [],
+		"searchTerms": [
+			"guren no yumiya"
+		],
 		"title": "紅蓮の弓矢"
 	},
 	{
@@ -98,7 +106,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 14,
-		"searchTerms": [],
+		"searchTerms": [
+			"connect"
+		],
 		"title": "コネクト"
 	},
 	{
@@ -109,7 +119,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 17,
-		"searchTerms": [],
+		"searchTerms": [
+			"sorairo days"
+		],
 		"title": "空色デイズ"
 	},
 	{
@@ -239,7 +251,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 34,
-		"searchTerms": [],
+		"searchTerms": [
+			"bokokukakusei catharsis"
+		],
 		"title": "亡國覚醒カタルシス"
 	},
 	{
@@ -261,7 +275,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 36,
-		"searchTerms": [],
+		"searchTerms": [
+			"todokanai koi '13"
+		],
 		"title": "届かない恋 '13"
 	},
 	{
@@ -298,7 +314,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 39,
-		"searchTerms": [],
+		"searchTerms": [
+			"1/3 no junjona kanjou"
+		],
 		"title": "1/3の純情な感情"
 	},
 	{
@@ -331,7 +349,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 43,
-		"searchTerms": [],
+		"searchTerms": [
+			"taiyou iwaku moeyo kaosu"
+		],
 		"title": "太陽曰く燃えよカオス"
 	},
 	{
@@ -452,7 +472,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 54,
-		"searchTerms": [],
+		"searchTerms": [
+			"bluebird"
+		],
 		"title": "ブルーバード"
 	},
 	{
@@ -463,7 +485,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 55,
-		"searchTerms": [],
+		"searchTerms": [
+			"natsumasuri",
+			"summer festival"
+		],
 		"title": "夏祭り"
 	},
 	{
@@ -474,7 +499,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 56,
-		"searchTerms": [],
+		"searchTerms": [
+			"sobakasu"
+		],
 		"title": "そばかす"
 	},
 	{
@@ -496,7 +523,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 58,
-		"searchTerms": [],
+		"searchTerms": [
+			"tamashi no refrain",
+			"soul's refrain"
+		],
 		"title": "魂のルフラン"
 	},
 	{
@@ -819,7 +849,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 85,
-		"searchTerms": [],
+		"searchTerms": [
+			"suiren hana"
+		],
 		"title": "睡蓮花"
 	},
 	{
@@ -830,7 +862,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 86,
-		"searchTerms": [],
+		"searchTerms": [
+			"killer ball"
+		],
 		"title": "キラーボール"
 	},
 	{
@@ -1148,7 +1182,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 112,
-		"searchTerms": [],
+		"searchTerms": [
+			"maji love1000%"
+		],
 		"title": "マジLOVE1000%"
 	},
 	{
@@ -1194,7 +1230,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 116,
-		"searchTerms": [],
+		"searchTerms": [
+			"kimi no shiranai monogatari",
+			"the story you don't know"
+		],
 		"title": "君の知らない物語"
 	},
 	{
@@ -1270,7 +1309,10 @@
 			"genre": "東方Project"
 		},
 		"id": 122,
-		"searchTerms": [],
+		"searchTerms": [
+			"shoujo maboroshisou senritsu kyoku ~ necro fantasia",
+			"necro fantasia"
+		],
 		"title": "少女幻葬戦慄曲　～　Necro Fantasia"
 	},
 	{
@@ -1294,7 +1336,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 124,
-		"searchTerms": [],
+		"searchTerms": [
+			"natsukage"
+		],
 		"title": "夏影"
 	},
 	{
@@ -1349,7 +1393,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 130,
-		"searchTerms": [],
+		"searchTerms": [
+			"sky clad no kansokusha",
+			"sky-clad observer"
+		],
 		"title": "スカイクラッドの観測者"
 	},
 	{
@@ -1628,7 +1675,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 155,
-		"searchTerms": [],
+		"searchTerms": [
+			"blue field"
+		],
 		"title": "ブルー・フィールド"
 	},
 	{
@@ -1945,7 +1994,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 185,
-		"searchTerms": [],
+		"searchTerms": [
+			"rakuen no tsubasa"
+		],
 		"title": "楽園の翼"
 	},
 	{
@@ -1956,7 +2007,9 @@
 			"genre": "東方Project"
 		},
 		"id": 186,
-		"searchTerms": [],
+		"searchTerms": [
+			"ttewi! eentei ver"
+		],
 		"title": "ってゐ！　～えいえんてゐVer～"
 	},
 	{
@@ -2226,7 +2279,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 209,
-		"searchTerms": [],
+		"searchTerms": [
+			"kimiiro signal"
+		],
 		"title": "君色シグナル"
 	},
 	{
@@ -2293,7 +2348,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 214,
-		"searchTerms": [],
+		"searchTerms": [
+			"seishun wa non-stop!"
+		],
 		"title": "青春はNon-Stop！"
 	},
 	{
@@ -2329,7 +2386,10 @@
 			"genre": "niconico"
 		},
 		"id": 217,
-		"searchTerms": [],
+		"searchTerms": [
+			"rakuen fanfare",
+			"paradise fanfare"
+		],
 		"title": "楽園ファンファーレ"
 	},
 	{
@@ -2356,7 +2416,6 @@
 		"id": 219,
 		"searchTerms": [
 			"Toy Frenzy -The end-",
-			"Toy Frenzy",
 			"Toy Madness",
 			"Toy Rhapsody",
 			"Gangukyousoukyoku -Shuen-"
@@ -2501,7 +2560,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 231,
-		"searchTerms": [],
+		"searchTerms": [
+			"colorful"
+		],
 		"title": "カラフル。"
 	},
 	{
@@ -2547,7 +2608,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 235,
-		"searchTerms": [],
+		"searchTerms": [
+			"futoshi togenkyo"
+		],
 		"title": "ファッとして桃源郷"
 	},
 	{
@@ -2558,7 +2621,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 238,
-		"searchTerms": [],
+		"searchTerms": [
+			"friends"
+		],
 		"title": "フレンズ"
 	},
 	{
@@ -2583,7 +2648,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 243,
-		"searchTerms": [],
+		"searchTerms": [
+			"sugar song and bitter step"
+		],
 		"title": "シュガーソングとビターステップ"
 	},
 	{
@@ -2636,7 +2703,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 247,
-		"searchTerms": [],
+		"searchTerms": [
+			"zessei stargate",
+			"peerless stargate"
+		],
 		"title": "絶世スターゲイト"
 	},
 	{
@@ -2735,7 +2805,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 255,
-		"searchTerms": [],
+		"searchTerms": [
+			"gekijou! milky dai sakusen"
+		],
 		"title": "激情！ミルキィ大作戦"
 	},
 	{
@@ -2902,7 +2974,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 269,
-		"searchTerms": [],
+		"searchTerms": [
+			"bokura no tsubasa",
+			"our wings"
+		],
 		"title": "僕らの翼"
 	},
 	{
@@ -3256,7 +3331,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 296,
-		"searchTerms": [],
+		"searchTerms": [
+			"kakushinteki me tamaru fuo~zetsu!"
+		],
 		"title": "かくしん的☆めたまるふぉ～ぜっ!"
 	},
 	{
@@ -3267,7 +3344,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 297,
-		"searchTerms": [],
+		"searchTerms": [
+			"fujin raijin"
+		],
 		"title": "風仁雷仁"
 	},
 	{
@@ -3289,7 +3368,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 299,
-		"searchTerms": [],
+		"searchTerms": [
+			"secret base ~kimigakuretamono~ 10 years after ver."
+		],
 		"title": "secret base ～君がくれたもの～ (10 years after Ver.)"
 	},
 	{
@@ -3447,7 +3528,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 312,
-		"searchTerms": [],
+		"searchTerms": [
+			"buiesu!! raibaru!!"
+		],
 		"title": "ぶいえす!!らいばる!!"
 	},
 	{
@@ -3458,7 +3541,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 313,
-		"searchTerms": [],
+		"searchTerms": [
+			"hidamari days"
+		],
 		"title": "ひだまりデイズ"
 	},
 	{
@@ -3480,7 +3565,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 315,
-		"searchTerms": [],
+		"searchTerms": [
+			"oracion"
+		],
 		"title": "オラシオン"
 	},
 	{
@@ -3823,7 +3910,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 344,
-		"searchTerms": [],
+		"searchTerms": [
+			"no point!"
+		],
 		"title": "ノーポイッ!"
 	},
 	{
@@ -3834,7 +3923,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 345,
-		"searchTerms": [],
+		"searchTerms": [
+			"moonlight densetsu",
+			"moonlight legend"
+		],
 		"title": "ムーンライト伝説"
 	},
 	{
@@ -3856,7 +3948,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 349,
-		"searchTerms": [],
+		"searchTerms": [
+			"gokujo smile",
+			"best smile"
+		],
 		"title": "極上スマイル"
 	},
 	{
@@ -3878,7 +3973,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 351,
-		"searchTerms": [],
+		"searchTerms": [
+			"buon! buon! raido on!"
+		],
 		"title": "ぶぉん！ぶぉん！らいど・おん！"
 	},
 	{
@@ -3924,7 +4021,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 355,
-		"searchTerms": [],
+		"searchTerms": [
+			"dango daikazoku"
+		],
 		"title": "だんご大家族"
 	},
 	{
@@ -3935,7 +4034,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 356,
-		"searchTerms": [],
+		"searchTerms": [
+			"clover kakumeshon"
+		],
 		"title": "クローバー♣かくめーしょん"
 	},
 	{
@@ -3946,7 +4047,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 357,
-		"searchTerms": [],
+		"searchTerms": [
+			"guchoki parade"
+		],
 		"title": "ぐーちょきパレード"
 	},
 	{
@@ -3979,7 +4082,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 360,
-		"searchTerms": [],
+		"searchTerms": [
+			"musouta"
+		],
 		"title": "夢想歌"
 	},
 	{
@@ -4177,7 +4282,9 @@
 			"genre": "東方Project"
 		},
 		"id": 379,
-		"searchTerms": [],
+		"searchTerms": [
+			"aiki yomichi feat. ranko, uten kekkou"
+		],
 		"title": "愛き夜道 feat. ランコ、雨天決行"
 	},
 	{
@@ -4221,7 +4328,9 @@
 			"genre": "東方Project"
 		},
 		"id": 383,
-		"searchTerms": [],
+		"searchTerms": [
+			"senshaku zesshou no fantasia"
+		],
 		"title": "仙酌絶唱のファンタジア"
 	},
 	{
@@ -4232,7 +4341,9 @@
 			"genre": "東方Project"
 		},
 		"id": 384,
-		"searchTerms": [],
+		"searchTerms": [
+			"curious mitsuyoshi ko pai -matsuri-"
+		],
 		"title": "キュアリアス光吉古牌　－祭－"
 	},
 	{
@@ -4519,7 +4630,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 413,
-		"searchTerms": [],
+		"searchTerms": [
+			"the wheel to the night ~indohito ga yume ni!?~"
+		],
 		"title": "The wheel to the Night ～インド人が夢に!?～"
 	},
 	{
@@ -4563,7 +4676,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 419,
-		"searchTerms": [],
+		"searchTerms": [
+			"sakura skip"
+		],
 		"title": "SAKURAスキップ"
 	},
 	{
@@ -4913,7 +5028,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 454,
-		"searchTerms": [],
+		"searchTerms": [
+			"gachagachaki yutofuigyu@mate"
+		],
 		"title": "ガチャガチャきゅ～と・ふぃぎゅ@メイト"
 	},
 	{
@@ -4959,7 +5076,9 @@
 			"genre": "東方Project"
 		},
 		"id": 458,
-		"searchTerms": [],
+		"searchTerms": [
+			"kaze ni noseta negai"
+		],
 		"title": "風に乗せた願い"
 	},
 	{
@@ -4984,7 +5103,10 @@
 			"genre": "東方Project"
 		},
 		"id": 460,
-		"searchTerms": [],
+		"searchTerms": [
+			"hoshiiro yozora",
+			"starry night sky"
+		],
 		"title": "星色夜空"
 	},
 	{
@@ -5360,7 +5482,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 495,
-		"searchTerms": [],
+		"searchTerms": [
+			"fuanteina kamisama",
+			"an unstable god"
+		],
 		"title": "不安定な神様"
 	},
 	{
@@ -5436,7 +5561,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 501,
-		"searchTerms": [],
+		"searchTerms": [
+			"hoshiakari",
+			"starlight"
+		],
 		"title": "星灯"
 	},
 	{
@@ -5616,7 +5744,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 523,
-		"searchTerms": [],
+		"searchTerms": [
+			"nijiiro no flugel",
+			"rainbow colored flugel"
+		],
 		"title": "虹色のフリューゲル"
 	},
 	{
@@ -5681,7 +5812,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 529,
-		"searchTerms": [],
+		"searchTerms": [
+			"pre-parade"
+		],
 		"title": "プレパレード"
 	},
 	{
@@ -5692,7 +5825,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 530,
-		"searchTerms": [],
+		"searchTerms": [
+			"orange"
+		],
 		"title": "オレンジ"
 	},
 	{
@@ -5703,7 +5838,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 531,
-		"searchTerms": [],
+		"searchTerms": [
+			"holy night"
+		],
 		"title": "ホーリーナイト"
 	},
 	{
@@ -5760,7 +5897,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 537,
-		"searchTerms": [],
+		"searchTerms": [
+			"harebareyukai"
+		],
 		"title": "ハレ晴レユカイ"
 	},
 	{
@@ -5801,7 +5940,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 541,
-		"searchTerms": [],
+		"searchTerms": [
+			"hitorigoto"
+		],
 		"title": "ヒトリゴト"
 	},
 	{
@@ -5823,7 +5964,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 544,
-		"searchTerms": [],
+		"searchTerms": [
+			"yumeji labyrinth"
+		],
 		"title": "夢路らびりんす"
 	},
 	{
@@ -5834,7 +5977,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 545,
-		"searchTerms": [],
+		"searchTerms": [
+			"zenryoku batankyu"
+		],
 		"title": "全力バタンキュー"
 	},
 	{
@@ -6220,7 +6365,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 579,
-		"searchTerms": [],
+		"searchTerms": [
+			"habataki no birthday"
+		],
 		"title": "羽ばたきのバースデイ"
 	},
 	{
@@ -6231,7 +6378,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 580,
-		"searchTerms": [],
+		"searchTerms": [
+			"kusabi"
+		],
 		"title": "楔"
 	},
 	{
@@ -6264,7 +6413,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 583,
-		"searchTerms": [],
+		"searchTerms": [
+			"aoki kotou no anguis"
+		],
 		"title": "碧き孤島のアングゥィス"
 	},
 	{
@@ -6300,7 +6451,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 586,
-		"searchTerms": [],
+		"searchTerms": [
+			"bure ikuru miru karabu!"
+		],
 		"title": "ぶれいくるみるくらぶ！"
 	},
 	{
@@ -6361,7 +6514,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 591,
-		"searchTerms": [],
+		"searchTerms": [
+			"gabriel dropkick"
+		],
 		"title": "ガヴリールドロップキック"
 	},
 	{
@@ -6535,7 +6690,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 609,
-		"searchTerms": [],
+		"searchTerms": [
+			"a e i u e o ao!!"
+		],
 		"title": "あ・え・い・う・え・お・あお!!"
 	},
 	{
@@ -6546,7 +6703,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 610,
-		"searchTerms": [],
+		"searchTerms": [
+			"kaaten koru!!!!!"
+		],
 		"title": "かーてんこーる!!!!!"
 	},
 	{
@@ -6661,7 +6820,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 620,
-		"searchTerms": [],
+		"searchTerms": [
+			"menimenimanimani"
+		],
 		"title": "メニメニマニマニ"
 	},
 	{
@@ -6672,7 +6833,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 621,
-		"searchTerms": [],
+		"searchTerms": [
+			"nihongo wakarimasen"
+		],
 		"title": "ニホンゴワカリマセン"
 	},
 	{
@@ -6705,7 +6868,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 624,
-		"searchTerms": [],
+		"searchTerms": [
+			"shakunetsu switch"
+		],
 		"title": "灼熱スイッチ"
 	},
 	{
@@ -6740,7 +6905,9 @@
 			"genre": "東方Project"
 		},
 		"id": 627,
-		"searchTerms": [],
+		"searchTerms": [
+			"yukemuri tamashiionsen II"
+		],
 		"title": "ゆけむり魂温泉 II"
 	},
 	{
@@ -6817,7 +6984,9 @@
 			"genre": "東方Project"
 		},
 		"id": 635,
-		"searchTerms": [],
+		"searchTerms": [
+			"cirno okan no saikyou vibes gohan"
+		],
 		"title": "チルノおかんのさいきょう☆バイブスごはん"
 	},
 	{
@@ -6841,7 +7010,9 @@
 			"genre": "東方Project"
 		},
 		"id": 637,
-		"searchTerms": [],
+		"searchTerms": [
+			"kyuuri ba ni dive"
+		],
 		"title": "きゅうりバーにダイブ"
 	},
 	{
@@ -6887,7 +7058,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 642,
-		"searchTerms": [],
+		"searchTerms": [
+			"aozora no rhapsody",
+			"rhapsody of the blue sky"
+		],
 		"title": "青空のラプソディ"
 	},
 	{
@@ -6909,7 +7083,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 645,
-		"searchTerms": [],
+		"searchTerms": [
+			"korekara"
+		],
 		"title": "コレカラ"
 	},
 	{
@@ -6920,7 +7096,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 646,
-		"searchTerms": [],
+		"searchTerms": [
+			"rimen -kotowari-"
+		],
 		"title": "理燃-コトワリ-"
 	},
 	{
@@ -6931,7 +7109,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 647,
-		"searchTerms": [],
+		"searchTerms": [
+			"alka tail"
+		],
 		"title": "アルカテイル"
 	},
 	{
@@ -7075,7 +7255,9 @@
 			"genre": "niconico"
 		},
 		"id": 659,
-		"searchTerms": [],
+		"searchTerms": [
+			"rinnetenshou"
+		],
 		"title": "輪廻転生"
 	},
 	{
@@ -7099,7 +7281,10 @@
 			"genre": "東方Project"
 		},
 		"id": 662,
-		"searchTerms": [],
+		"searchTerms": [
+			"Jigoku no hashi ni te kimi womatsu",
+			"i'm waiting for you at hell's end"
+		],
 		"title": "地獄の端にて君を待つ"
 	},
 	{
@@ -7110,7 +7295,10 @@
 			"genre": "東方Project"
 		},
 		"id": 663,
-		"searchTerms": [],
+		"searchTerms": [
+			"seishoujo sacrifice",
+			"sacred girl sacrifice"
+		],
 		"title": "聖少女サクリファイス"
 	},
 	{
@@ -7256,7 +7444,10 @@
 			"genre": "VARIETY"
 		},
 		"id": 675,
-		"searchTerms": [],
+		"searchTerms": [
+			"subete no hito no tamashii no tatakai (daisuke asakura remix)",
+			"battle hymn of the soul (daisuke asakura remix)"
+		],
 		"title": "全ての人の魂の戦い (Daisuke Asakura Remix)"
 	},
 	{
@@ -7771,7 +7962,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 724,
-		"searchTerms": [],
+		"searchTerms": [
+			"kimi to boku no mirai",
+			"the future of you and me"
+		],
 		"title": "キミとボクのミライ"
 	},
 	{
@@ -7981,7 +8175,10 @@
 			"genre": "東方Project"
 		},
 		"id": 741,
-		"searchTerms": [],
+		"searchTerms": [
+			"aundo bai mii",
+			"aund by me"
+		],
 		"title": "あうんどばいみー"
 	},
 	{
@@ -8054,7 +8251,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 747,
-		"searchTerms": [],
+		"searchTerms": [
+			"sakaseyo wakaseyo banban burn",
+			"let it bloom, let it boil, bang bang burn"
+		],
 		"title": "咲かせよ 沸かせよ バンバンBURN！"
 	},
 	{
@@ -8638,7 +8838,10 @@
 			"genre": "東方Project"
 		},
 		"id": 799,
-		"searchTerms": [],
+		"searchTerms": [
+			"hoshi no utsuwa ~ star of andromeda",
+			"star vessel ~ star of andromeda"
+		],
 		"title": "星の器～STAR OF ANDROMEDA"
 	},
 	{
@@ -8684,7 +8887,10 @@
 			"genre": "VARIETY"
 		},
 		"id": 806,
-		"searchTerms": [],
+		"searchTerms": [
+			"suisho sekai ~fracture~",
+			"crystal world ~fracture~"
+		],
 		"title": "水晶世界 ～Fracture～"
 	},
 	{
@@ -8761,7 +8967,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 813,
-		"searchTerms": [],
+		"searchTerms": [
+			"Hypnosismic"
+		],
 		"title": "ヒプノシスマイク -Division Battle Anthem-"
 	},
 	{
@@ -8772,7 +8980,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 814,
-		"searchTerms": [],
+		"searchTerms": [
+			"Happy Material"
+		],
 		"title": "ハッピー☆マテリアル"
 	},
 	{
@@ -9165,7 +9375,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 846,
-		"searchTerms": [],
+		"searchTerms": [
+			"noraneko heart"
+		],
 		"title": "野良猫ハート"
 	},
 	{
@@ -9291,7 +9503,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 857,
-		"searchTerms": [],
+		"searchTerms": [
+			"Rondo",
+			"Rondo Revolution"
+		],
 		"title": "輪舞-revolution"
 	},
 	{
@@ -9328,7 +9543,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 860,
-		"searchTerms": [],
+		"searchTerms": [
+			"Tokyozeniki akihabara? (ver. nikoru)"
+		],
 		"title": "とーきょー全域★アキハバラ？ (ver.にこる)"
 	},
 	{
@@ -9339,7 +9556,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 861,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kimama na Tenshi-tachi"
+		],
 		"title": "気ままな天使たち"
 	},
 	{
@@ -9350,7 +9569,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 862,
-		"searchTerms": [],
+		"searchTerms": [
+			"Happy Happy Friends"
+		],
 		"title": "ハッピー・ハッピー・フレンズ"
 	},
 	{
@@ -9383,7 +9604,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 866,
-		"searchTerms": [],
+		"searchTerms": [
+			"Strike the Blood"
+		],
 		"title": "ストライク・ザ・ブラッド"
 	},
 	{
@@ -9494,7 +9717,9 @@
 			"genre": "東方Project"
 		},
 		"id": 875,
-		"searchTerms": [],
+		"searchTerms": [
+			"kagura"
+		],
 		"title": "神楽"
 	},
 	{
@@ -9593,7 +9818,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 883,
-		"searchTerms": [],
+		"searchTerms": [
+			"Adabana Necromancy"
+		],
 		"title": "徒花ネクロマンシー"
 	},
 	{
@@ -9604,7 +9831,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 884,
-		"searchTerms": [],
+		"searchTerms": [
+			"Mezame Returner"
+		],
 		"title": "目覚めRETURNER"
 	},
 	{
@@ -9659,7 +9888,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 889,
-		"searchTerms": [],
+		"searchTerms": [
+			"miko miko nurse ai no theme"
+		],
 		"title": "巫女みこナース・愛のテーマ"
 	},
 	{
@@ -9681,7 +9912,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 891,
-		"searchTerms": [],
+		"searchTerms": [
+			"oto-dan chojin gorillaizer"
+		],
 		"title": "音弾超人ゴリライザー"
 	},
 	{
@@ -9774,7 +10007,10 @@
 			"genre": "VARIETY"
 		},
 		"id": 900,
-		"searchTerms": [],
+		"searchTerms": [
+			"cho no hyouhon",
+			"butterfly specimen"
+		],
 		"title": "チョウの標本"
 	},
 	{
@@ -9906,7 +10142,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 912,
-		"searchTerms": [],
+		"searchTerms": [
+			"yaranakya ikenai koto bakari"
+		],
 		"title": "やらなきゃいけないことばかり"
 	},
 	{
@@ -10004,7 +10242,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 920,
-		"searchTerms": [],
+		"searchTerms": [
+			"shuryo senki ~ requiem"
+		],
 		"title": "狩猟戦旗～REQUIEM"
 	},
 	{
@@ -10118,7 +10358,10 @@
 			"genre": "東方Project"
 		},
 		"id": 929,
-		"searchTerms": [],
+		"searchTerms": [
+			"energy booster ~ shanhai kochakan",
+			"energy booster ~ shanghai tea house"
+		],
 		"title": "Energy Booster ～ 上海紅茶館"
 	},
 	{
@@ -10140,7 +10383,10 @@
 			"genre": "東方Project"
 		},
 		"id": 931,
-		"searchTerms": [],
+		"searchTerms": [
+			"Meido to Chi no Kaichu Dokei",
+			"The Maid and the Pocket Watch of Blood"
+		],
 		"title": "メイドと血の懐中時計"
 	},
 	{
@@ -10177,7 +10423,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 934,
-		"searchTerms": [],
+		"searchTerms": [
+			"akari majiru, yami yori orite tenkei no hibiki o michibiku"
+		],
 		"title": "紅き魔汁、闇より降りて天啓の響きを導く"
 	},
 	{
@@ -10528,7 +10776,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 962,
-		"searchTerms": [],
+		"searchTerms": [
+			"GEKI! TEIKOKUKAGEKIDAN <SHINFUMI>"
+		],
 		"title": "檄！帝国華撃団＜新章＞"
 	},
 	{
@@ -10552,7 +10802,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 964,
-		"searchTerms": [],
+		"searchTerms": [
+			"satsujin record kyoufu no melody"
+		],
 		"title": "殺人レコード恐怖のメロディ"
 	},
 	{
@@ -10587,7 +10839,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 967,
-		"searchTerms": [],
+		"searchTerms": [
+			"kimi to, kono shunkan"
+		],
 		"title": "君と、この瞬間"
 	},
 	{
@@ -10707,7 +10961,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 977,
-		"searchTerms": [],
+		"searchTerms": [
+			"koyoi mofumofu!!"
+		],
 		"title": "今宵mofumofu!!"
 	},
 	{
@@ -10740,7 +10996,9 @@
 			"genre": "東方Project"
 		},
 		"id": 980,
-		"searchTerms": [],
+		"searchTerms": [
+			"RetaiSparkEx"
+		],
 		"title": "レータイスパークEx"
 	},
 	{
@@ -10751,7 +11009,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 981,
-		"searchTerms": [],
+		"searchTerms": [
+			"shoakuma no yuenchi"
+		],
 		"title": "小悪魔の遊園地"
 	},
 	{
@@ -11369,7 +11629,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 1035,
-		"searchTerms": [],
+		"searchTerms": [
+			"sekiheki, dai enjo!!"
+		],
 		"title": "赤壁、大炎上！！"
 	},
 	{
@@ -11417,7 +11679,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 1039,
-		"searchTerms": [],
+		"searchTerms": [
+			"koi wa rinrin arin bell"
+		],
 		"title": "恋はりんりん☆あーりんベル"
 	},
 	{
@@ -11606,7 +11870,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 1056,
-		"searchTerms": [],
+		"searchTerms": [
+			"nanka noise ni kikoeru"
+		],
 		"title": "なんかノイズにきこえる"
 	},
 	{
@@ -11806,7 +12072,10 @@
 			"genre": "東方Project"
 		},
 		"id": 1072,
-		"searchTerms": [],
+		"searchTerms": [
+			"Hatate no Bakkoi Satsujin Jiken",
+			"hatate's bakkoi murder case"
+		],
 		"title": "はたてのバッコイ殺人事件"
 	},
 	{
@@ -11916,7 +12185,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 1081,
-		"searchTerms": [],
+		"searchTerms": [
+			"shotai hanmei nameless girl"
+		],
 		"title": "正体判明ネームレスガール"
 	},
 	{
@@ -12056,7 +12327,10 @@
 			"genre": "VARIETY"
 		},
 		"id": 1092,
-		"searchTerms": [],
+		"searchTerms": [
+			"millenium queen",
+			"machitose jo"
+		],
 		"title": "真千年女王"
 	},
 	{
@@ -12118,7 +12392,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 1098,
-		"searchTerms": [],
+		"searchTerms": [
+			"totaku utsubeshi"
+		],
 		"title": "董卓討つべし"
 	},
 	{
@@ -12188,7 +12464,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 1104,
-		"searchTerms": [],
+		"searchTerms": [
+			"norouta -jyuka-"
+		],
 		"title": "呪歌-JyuKa-"
 	},
 	{
@@ -12437,7 +12715,11 @@
 			"genre": "niconico"
 		},
 		"id": 2019,
-		"searchTerms": [],
+		"searchTerms": [
+			"Dennou Shoujo wa Utahime no Yume o Miru ka?",
+			"Do Cyber Girls Dream Of Divas?",
+			"Do Cyber Girl Dream of Becoming a Diva?"
+		],
 		"title": "電脳少女は歌姫の夢を見るか？"
 	},
 	{
@@ -12449,7 +12731,7 @@
 		},
 		"id": 2020,
 		"searchTerms": [
-			"Kokoroyohou "
+			"Kokoroyohou"
 		],
 		"title": "心予報"
 	},
@@ -12623,7 +12905,10 @@
 			"genre": "東方Project"
 		},
 		"id": 2033,
-		"searchTerms": [],
+		"searchTerms": [
+			"hoihoi gensou horoizumu",
+			"hoy hoy illusion holoism"
+		],
 		"title": "ホイホイ☆幻想ホロイズム"
 	},
 	{
@@ -12802,7 +13087,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2048,
-		"searchTerms": [],
+		"searchTerms": [
+			"meshimase! rock'n roll party"
+		],
 		"title": "召しませ！Rock'n Roll Party"
 	},
 	{
@@ -12964,7 +13251,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2062,
-		"searchTerms": [],
+		"searchTerms": [
+			"yumeji hyoushi"
+		],
 		"title": "夢路拍子"
 	},
 	{
@@ -12975,7 +13264,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2063,
-		"searchTerms": [],
+		"searchTerms": [
+			"jinsei koryaku tips"
+		],
 		"title": "人生攻略☆Tips"
 	},
 	{
@@ -12986,7 +13277,10 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2064,
-		"searchTerms": [],
+		"searchTerms": [
+			"Pygmalion's Spell",
+			"Hex of Pygmalion"
+		],
 		"title": "ピュグマリオンの咒文"
 	},
 	{
@@ -12997,7 +13291,10 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2065,
-		"searchTerms": [],
+		"searchTerms": [
+			"sosei no kontsuerutiina",
+			"concertina of genesis"
+		],
 		"title": "創世のコンツェルティーナ"
 	},
 	{
@@ -13601,7 +13898,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2116,
-		"searchTerms": [],
+		"searchTerms": [
+			"newstart de readygo!"
+		],
 		"title": "NewStartでReadyGo!"
 	},
 	{
@@ -13742,7 +14041,10 @@
 			"genre": "niconico"
 		},
 		"id": 2128,
-		"searchTerms": [],
+		"searchTerms": [
+			"Tajuu Mirai no Quartet -Quartet Theme-",
+			"Multiple Future Quartet -Quartet Theme-"
+		],
 		"title": "多重未来のカルテット -Quartet Theme-"
 	},
 	{
@@ -13764,7 +14066,10 @@
 			"genre": "niconico"
 		},
 		"id": 2130,
-		"searchTerms": [],
+		"searchTerms": [
+			"Houkai Utahime -disruptive diva-",
+			"Diva Of Destruction -disruptive diva-"
+		],
 		"title": "崩壊歌姫 -disruptive diva-"
 	},
 	{
@@ -13775,7 +14080,9 @@
 			"genre": "niconico"
 		},
 		"id": 2131,
-		"searchTerms": [],
+		"searchTerms": [
+			"marginal"
+		],
 		"title": "マージナル"
 	},
 	{
@@ -13786,7 +14093,10 @@
 			"genre": "niconico"
 		},
 		"id": 2132,
-		"searchTerms": [],
+		"searchTerms": [
+			"poppipo",
+			"vegetable juice"
+		],
 		"title": "ぽっぴっぽー"
 	},
 	{
@@ -14057,7 +14367,10 @@
 			"genre": "niconico"
 		},
 		"id": 2153,
-		"searchTerms": [],
+		"searchTerms": [
+			"kuuneru and gazer",
+			"eating, sleeping and gazing"
+		],
 		"title": "クーネル・エンゲイザー"
 	},
 	{
@@ -14068,7 +14381,9 @@
 			"genre": "東方Project"
 		},
 		"id": 2154,
-		"searchTerms": [],
+		"searchTerms": [
+			"rotation feat. ayaponzu*"
+		],
 		"title": "回転 feat.あやぽんず＊"
 	},
 	{
@@ -14101,7 +14416,9 @@
 			"genre": "東方Project"
 		},
 		"id": 2157,
-		"searchTerms": [],
+		"searchTerms": [
+			"youyou bakko ~ who done it!!!"
+		],
 		"title": "妖々跋扈　～ Who done it！！！"
 	},
 	{
@@ -14112,7 +14429,9 @@
 			"genre": "東方Project"
 		},
 		"id": 2158,
-		"searchTerms": [],
+		"searchTerms": [
+			"Yoiyami no Tsuki ni Idakarete"
+		],
 		"title": "宵闇の月に抱かれて"
 	},
 	{
@@ -14145,7 +14464,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2162,
-		"searchTerms": [],
+		"searchTerms": [
+			"massugu stream!"
+		],
 		"title": "まっすぐ→→→ストリーム！"
 	},
 	{
@@ -14156,7 +14477,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2163,
-		"searchTerms": [],
+		"searchTerms": [
+			"toridori morimori lovely fruits"
+		],
 		"title": "トリドリ⇒モリモリ! Lovely fruits☆"
 	},
 	{
@@ -14167,7 +14490,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2164,
-		"searchTerms": [],
+		"searchTerms": [
+			"yoake no string"
+		],
 		"title": "夜明けのストリング"
 	},
 	{
@@ -14354,7 +14679,7 @@
 		},
 		"id": 2179,
 		"searchTerms": [
-			"Keitairenwa "
+			"Keitairenwa"
 		],
 		"title": "携帯恋話"
 	},
@@ -14406,7 +14731,10 @@
 			"genre": "東方Project"
 		},
 		"id": 2183,
-		"searchTerms": [],
+		"searchTerms": [
+			"Netaminity Gekijou \"666\"",
+			"Netaminity Theatre \"666\""
+		],
 		"title": "無間嫉妬劇場『666』"
 	},
 	{
@@ -14682,7 +15010,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2205,
-		"searchTerms": [],
+		"searchTerms": [
+			"maitaka saikyo dream session!!!!! ~ 180-byou ichikyoku shobu ~"
+		],
 		"title": "舞高最強ドリームセッション!!!!! ～180秒一曲勝負～"
 	},
 	{
@@ -14764,7 +15094,7 @@
 		"id": 2212,
 		"searchTerms": [
 			"I'm getting on the bus to the other world, see ya!",
-			"bus"
+			"anoyo-iki no bus ni notte saraba"
 		],
 		"title": "あの世行きのバスに乗ってさらば。"
 	},
@@ -14777,7 +15107,7 @@
 		},
 		"id": 2213,
 		"searchTerms": [
-			"dorono",
+			"doro no bunzai de watashidake no taisetsu o ubaounda nante",
 			"Being low as dirt, taking what's important from me",
 			"being low as dirt",
 			"low as dirt"
@@ -14861,8 +15191,7 @@
 		},
 		"id": 2219,
 		"searchTerms": [
-			"Fd Irodori",
-			"Freedom Dive Irodori"
+			"bokura no freedom dive"
 		],
 		"title": "僕らのFreedom DiVE↓"
 	},
@@ -14874,7 +15203,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2220,
-		"searchTerms": [],
+		"searchTerms": [
+			"shinkisai kajou no diary music"
+		],
 		"title": "色彩過剰のダイアリーミュージック"
 	},
 	{
@@ -14896,7 +15227,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2222,
-		"searchTerms": [],
+		"searchTerms": [
+			"3-bai! sun shine! carnival!"
+		],
 		"title": "3倍！Sun Shine！カーニバル！"
 	},
 	{
@@ -14907,7 +15240,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2223,
-		"searchTerms": [],
+		"searchTerms": [
+			"jigokuya hatchou arashi"
+		],
 		"title": "地獄屋八丁荒らし"
 	},
 	{
@@ -14918,7 +15253,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2224,
-		"searchTerms": [],
+		"searchTerms": [
+			"happy end o hajime kara"
+		],
 		"title": "ハッピーエンドをはじめから"
 	},
 	{
@@ -14929,7 +15266,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2225,
-		"searchTerms": [],
+		"searchTerms": [
+			"kako o kurau"
+		],
 		"title": "過去を喰らう"
 	},
 	{
@@ -14940,7 +15279,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2226,
-		"searchTerms": [],
+		"searchTerms": [
+			"shitsureishimasu ga, rip",
+			"excuse my rudeness, but could you please rip"
+		],
 		"title": "失礼しますが、RIP♡"
 	},
 	{
@@ -14962,7 +15304,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2228,
-		"searchTerms": [],
+		"searchTerms": [
+			"kaerimichi"
+		],
 		"title": "帰り道"
 	},
 	{
@@ -14973,11 +15317,7 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2229,
-		"searchTerms": [
-			"qzkago",
-			"qz",
-			"qzingo"
-		],
+		"searchTerms": [],
 		"title": "QZKago Requiem"
 	},
 	{
@@ -15036,7 +15376,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2234,
-		"searchTerms": [],
+		"searchTerms": [
+			"boku no sensou",
+			"my war"
+		],
 		"title": "僕の戦争"
 	},
 	{
@@ -15047,7 +15390,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2235,
-		"searchTerms": [],
+		"searchTerms": [
+			"pocket kara nuritsubuse!"
+		],
 		"title": "ポケットからぬりつぶせ！"
 	},
 	{
@@ -15058,7 +15403,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2236,
-		"searchTerms": [],
+		"searchTerms": [
+			"y.y.y. keikaku!!!"
+		],
 		"title": "Y.Y.Y.計画!!!!"
 	},
 	{
@@ -15069,7 +15416,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2237,
-		"searchTerms": [],
+		"searchTerms": [
+			"saittaka no entertainment!!"
+		],
 		"title": "最っ高のエンタメだ!!"
 	},
 	{
@@ -15130,7 +15479,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2242,
-		"searchTerms": [],
+		"searchTerms": [
+			"kill me baby"
+		],
 		"title": "キルミーのベイベー！"
 	},
 	{
@@ -15152,7 +15503,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2244,
-		"searchTerms": [],
+		"searchTerms": [
+			"hijitsuzaikei joshitachi wa dou surya iidesu ka"
+		],
 		"title": "非実在系女子達はどうすりゃいいですか？"
 	},
 	{
@@ -15163,7 +15516,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2245,
-		"searchTerms": [],
+		"searchTerms": [
+			"koi hi koi fu en"
+		],
 		"title": "恋ひ恋ふ縁"
 	},
 	{
@@ -15222,7 +15577,9 @@
 			"genre": "東方Project"
 		},
 		"id": 2250,
-		"searchTerms": [],
+		"searchTerms": [
+			"kamokunaru fall"
+		],
 		"title": "寡黙なるフォール"
 	},
 	{
@@ -15233,7 +15590,9 @@
 			"genre": "東方Project"
 		},
 		"id": 2251,
-		"searchTerms": [],
+		"searchTerms": [
+			"mizuiro raindrop"
+		],
 		"title": "みずいろレインドロップ"
 	},
 	{
@@ -15382,8 +15741,7 @@
 		},
 		"id": 2264,
 		"searchTerms": [
-			"TONDEMO-WONDERZ",
-			"TONDEMO-WONDERS"
+			"TONDEMO-WONDERZ"
 		],
 		"title": "トンデモワンダーズ"
 	},
@@ -15509,7 +15867,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2274,
-		"searchTerms": [],
+		"searchTerms": [
+			"creeper"
+		],
 		"title": "クリーパー"
 	},
 	{
@@ -15531,7 +15891,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2276,
-		"searchTerms": [],
+		"searchTerms": [
+			"oshite mo damenara hiite mina"
+		],
 		"title": "推してもダメならひいてみな！"
 	},
 	{
@@ -15706,7 +16068,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2292,
-		"searchTerms": [],
+		"searchTerms": [
+			"ganbare! kumokosan no theme"
+		],
 		"title": "がんばれ！蜘蛛子さんのテーマ"
 	},
 	{
@@ -15774,7 +16138,10 @@
 			"genre": "VARIETY"
 		},
 		"id": 2298,
-		"searchTerms": [],
+		"searchTerms": [
+			"Metcha aotte kuru taipu no oto geebosu-kyoku-chan nanka ni makenaiga?????",
+			"Is there no way I'm defeated by OTOGE-BOSS-KYOKU-CHAN is strongly provoking?"
+		],
 		"title": "めっちゃ煽ってくるタイプの音ゲーボス曲ちゃんなんかに負けないが？？？？？"
 	},
 	{
@@ -15855,7 +16222,9 @@
 			"genre": "niconico"
 		},
 		"id": 2305,
-		"searchTerms": [],
+		"searchTerms": [
+			"cat loving"
+		],
 		"title": "キャットラビング"
 	},
 	{
@@ -15905,7 +16274,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2310,
-		"searchTerms": [],
+		"searchTerms": [
+			"makasete JC inyoushi yakumo-chan"
+		],
 		"title": "任せてJC陰陽師☆八雲ちゃん"
 	},
 	{
@@ -15916,7 +16287,11 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2311,
-		"searchTerms": [],
+		"searchTerms": [
+			"great fighter = klein vogel spiel = erika",
+			"erika",
+			"daitoshi"
+		],
 		"title": "†大闘士＝クライン・フォーゲル・シュピール＝えりか†"
 	},
 	{
@@ -15938,7 +16313,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2313,
-		"searchTerms": [],
+		"searchTerms": [
+			"koisuru mitai ni kamase red hells"
+		],
 		"title": "恋するみたいに☆かませレッドヘルズ"
 	},
 	{
@@ -16014,7 +16391,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2319,
-		"searchTerms": [],
+		"searchTerms": [
+			"MAIGAHARA Punchline Kickers"
+		],
 		"title": "MAIGAHARA パンチラインキッカーズ"
 	},
 	{
@@ -16052,7 +16431,9 @@
 			"genre": "東方Project"
 		},
 		"id": 2322,
-		"searchTerms": [],
+		"searchTerms": [
+			"o sora no nuclear fusion dojo"
+		],
 		"title": "お空のニュークリアフュージョン道場"
 	},
 	{
@@ -16090,9 +16471,9 @@
 		},
 		"id": 2326,
 		"searchTerms": [
-			"u&i",
 			"universe",
-			"u&iverse"
+			"u&iverse",
+			"u&iverse -dawn of the galaxy-"
 		],
 		"title": "U&iVERSE -銀河鸞翔-"
 	},
@@ -16115,7 +16496,11 @@
 			"genre": "niconico"
 		},
 		"id": 2328,
-		"searchTerms": [],
+		"searchTerms": [
+			"aijou rettousei",
+			"underachieving lover",
+			"affection/sadness underachiever"
+		],
 		"title": "アイ情劣等生"
 	},
 	{
@@ -16139,7 +16524,9 @@
 			"genre": "niconico"
 		},
 		"id": 2330,
-		"searchTerms": [],
+		"searchTerms": [
+			"lonely poison"
+		],
 		"title": "孤独毒毒"
 	},
 	{
@@ -16150,7 +16537,9 @@
 			"genre": "niconico"
 		},
 		"id": 2331,
-		"searchTerms": [],
+		"searchTerms": [
+			"steal you"
+		],
 		"title": "スティールユー"
 	},
 	{
@@ -16161,7 +16550,9 @@
 			"genre": "niconico"
 		},
 		"id": 2332,
-		"searchTerms": [],
+		"searchTerms": [
+			"machigaisagashi"
+		],
 		"title": "マチガイサガシ"
 	},
 	{
@@ -16172,7 +16563,10 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2333,
-		"searchTerms": [],
+		"searchTerms": [
+			"tsukai rhythm action b.b.k.k.b.k.k.",
+			"exciting rhythm action b.b.k.k.b.k.k."
+		],
 		"title": "痛快リズムアクション「B.B.K.K.B.K.K.」"
 	},
 	{
@@ -16194,7 +16588,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2336,
-		"searchTerms": [],
+		"searchTerms": [
+			"mei tsuki"
+		],
 		"title": "盟月"
 	},
 	{
@@ -16251,7 +16647,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2341,
-		"searchTerms": [],
+		"searchTerms": [
+			"Amakamisama"
+		],
 		"title": "アマカミサマ"
 	},
 	{
@@ -16262,7 +16660,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2342,
-		"searchTerms": [],
+		"searchTerms": [
+			"daji yarekuire ishon"
+		],
 		"title": "だじゃれくりえぃしょん"
 	},
 	{
@@ -16273,7 +16673,9 @@
 			"genre": "niconico"
 		},
 		"id": 2343,
-		"searchTerms": [],
+		"searchTerms": [
+			"World is Mine"
+		],
 		"title": "ワールドイズマイン"
 	},
 	{
@@ -16284,7 +16686,9 @@
 			"genre": "niconico"
 		},
 		"id": 2344,
-		"searchTerms": [],
+		"searchTerms": [
+			"Future Eve"
+		],
 		"title": "フューチャー・イヴ"
 	},
 	{
@@ -16350,7 +16754,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 2350,
-		"searchTerms": [],
+		"searchTerms": [
+			"A Wandering Melody of Love"
+		],
 		"title": "迷える音色は恋の唄"
 	},
 	{
@@ -16383,7 +16789,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 2353,
-		"searchTerms": [],
+		"searchTerms": [
+			"fantasie impromptu"
+		],
 		"title": "幻想即興曲"
 	},
 	{
@@ -16394,7 +16802,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 2354,
-		"searchTerms": [],
+		"searchTerms": [
+			"clair de lune"
+		],
 		"title": "月の光"
 	},
 	{
@@ -16405,7 +16815,10 @@
 			"genre": "VARIETY"
 		},
 		"id": 2355,
-		"searchTerms": [],
+		"searchTerms": [
+			"winter from four seasons",
+			"shiki yori fuyu"
+		],
 		"title": "「四季」より「冬」"
 	},
 	{
@@ -16427,7 +16840,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2358,
-		"searchTerms": [],
+		"searchTerms": [
+			"4-tsuki 1-nichi degozaimashita"
+		],
 		"title": "4月1日でございました"
 	},
 	{
@@ -16438,7 +16853,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2359,
-		"searchTerms": [],
+		"searchTerms": [
+			"gotoubun no katachi"
+		],
 		"title": "五等分のカタチ"
 	},
 	{
@@ -16449,7 +16866,10 @@
 			"genre": "niconico"
 		},
 		"id": 2360,
-		"searchTerms": [],
+		"searchTerms": [
+			"Magical Girl and Chocolate",
+			"mahou shoujo to chocolate"
+		],
 		"title": "魔法少女とチョコレゐト"
 	},
 	{
@@ -16460,7 +16880,10 @@
 			"genre": "niconico"
 		},
 		"id": 2361,
-		"searchTerms": [],
+		"searchTerms": [
+			"shoujo rei",
+			"ghost girl"
+		],
 		"title": "少女レイ"
 	},
 	{
@@ -16471,7 +16894,10 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2362,
-		"searchTerms": [],
+		"searchTerms": [
+			"Paranormal my mind",
+			"Chojo maimain"
+		],
 		"title": "超常マイマイン"
 	},
 	{
@@ -16482,7 +16908,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2363,
-		"searchTerms": [],
+		"searchTerms": [
+			"8bit"
+		],
 		"title": "VIIIbit Explorer"
 	},
 	{
@@ -16504,7 +16932,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2365,
-		"searchTerms": [],
+		"searchTerms": [
+			"Pakupaku Girl"
+		],
 		"title": "ぱくぱく☆がーる"
 	},
 	{
@@ -16550,7 +16980,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2369,
-		"searchTerms": [],
+		"searchTerms": [
+			"kizuna wa zutto growing up!!!"
+		],
 		"title": "絆はずっとGrowing Up!!!"
 	},
 	{
@@ -16561,7 +16993,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2370,
-		"searchTerms": [],
+		"searchTerms": [
+			"amatsukami"
+		],
 		"title": "アマツカミ"
 	},
 	{
@@ -16583,7 +17017,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2372,
-		"searchTerms": [],
+		"searchTerms": [
+			"susume my way"
+		],
 		"title": "進め！マイウェイ！"
 	},
 	{
@@ -16660,7 +17096,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2386,
-		"searchTerms": [],
+		"searchTerms": [
+			"seishun complex"
+		],
 		"title": "青春コンプレックス"
 	},
 	{
@@ -16671,7 +17109,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2387,
-		"searchTerms": [],
+		"searchTerms": [
+			"Guitar, Loneliness and Blue Planet"
+		],
 		"title": "ギターと孤独と蒼い惑星"
 	},
 	{
@@ -16693,7 +17133,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2389,
-		"searchTerms": [],
+		"searchTerms": [
+			"New Genesis"
+		],
 		"title": "新時代（ウタfrom ONE PIECE FILM RED）"
 	},
 	{
@@ -16704,7 +17146,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2390,
-		"searchTerms": [],
+		"searchTerms": [
+			"The Blessing",
+			"Shuufuku"
+		],
 		"title": "祝福"
 	},
 	{
@@ -16715,7 +17160,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2391,
-		"searchTerms": [],
+		"searchTerms": [
+			"HAWATARI NIOKU CENTI",
+			"200 million centimeters on the edge"
+		],
 		"title": "刃渡り2億センチ(TV edit)"
 	},
 	{
@@ -16726,7 +17174,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2392,
-		"searchTerms": [],
+		"searchTerms": [
+			"Thunder Shoot",
+			"Otose Thunder"
+		],
 		"title": "おとせサンダー"
 	},
 	{
@@ -16737,7 +17188,10 @@
 			"genre": "niconico"
 		},
 		"id": 2393,
-		"searchTerms": [],
+		"searchTerms": [
+			"kareshi no jude",
+			"her boyfriend jude"
+		],
 		"title": "カレシのジュード"
 	},
 	{
@@ -16748,7 +17202,9 @@
 			"genre": "niconico"
 		},
 		"id": 2394,
-		"searchTerms": [],
+		"searchTerms": [
+			"Salamander"
+		],
 		"title": "サラマンダー"
 	},
 	{
@@ -16759,7 +17215,10 @@
 			"genre": "niconico"
 		},
 		"id": 2395,
-		"searchTerms": [],
+		"searchTerms": [
+			"yoidore shirazu",
+			"unaware drunkard"
+		],
 		"title": "酔いどれ知らず"
 	},
 	{
@@ -16770,7 +17229,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 2397,
-		"searchTerms": [],
+		"searchTerms": [
+			"mopemope"
+		],
 		"title": "もぺもぺ"
 	},
 	{
@@ -16814,7 +17275,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2401,
-		"searchTerms": [],
+		"searchTerms": [
+			"onsoku days"
+		],
 		"title": "オンソクデイズ!!"
 	},
 	{
@@ -16825,7 +17288,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2403,
-		"searchTerms": [],
+		"searchTerms": [
+			"urgaleon"
+		],
 		"title": "ウルガレオン"
 	},
 	{
@@ -16836,7 +17301,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2404,
-		"searchTerms": [],
+		"searchTerms": [
+			"yamerannaina"
+		],
 		"title": "やめらんないな!"
 	},
 	{
@@ -16880,7 +17347,10 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2408,
-		"searchTerms": [],
+		"searchTerms": [
+			"primary shinkaron",
+			"primary evolutionary theory"
+		],
 		"title": "プライマリー進化論"
 	},
 	{
@@ -16893,8 +17363,7 @@
 		"id": 2409,
 		"searchTerms": [
 			"furiforu",
-			"Freefall",
-			"Free Fall"
+			"Freefall"
 		],
 		"title": "フリーフォール"
 	},
@@ -16928,7 +17397,9 @@
 			"genre": "東方Project"
 		},
 		"id": 2412,
-		"searchTerms": [],
+		"searchTerms": [
+			"fantasy syndrome"
+		],
 		"title": "幻想症候群"
 	},
 	{
@@ -16939,7 +17410,10 @@
 			"genre": "東方Project"
 		},
 		"id": 2413,
-		"searchTerms": [],
+		"searchTerms": [
+			"yoru no circus",
+			"night circus"
+		],
 		"title": "夜のサーカス"
 	},
 	{
@@ -16961,7 +17435,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2415,
-		"searchTerms": [],
+		"searchTerms": [
+			"hokago mermaid"
+		],
 		"title": "放課後マーメイド"
 	},
 	{
@@ -16994,7 +17470,9 @@
 			"genre": "niconico"
 		},
 		"id": 2418,
-		"searchTerms": [],
+		"searchTerms": [
+			"hitorinbo envy"
+		],
 		"title": "独りんぼエンヴィー"
 	},
 	{
@@ -17005,7 +17483,10 @@
 			"genre": "niconico"
 		},
 		"id": 2419,
-		"searchTerms": [],
+		"searchTerms": [
+			"go to daitokai",
+			"go to the big city"
+		],
 		"title": "ゴー・トゥ・大都会"
 	},
 	{
@@ -17027,7 +17508,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2421,
-		"searchTerms": [],
+		"searchTerms": [
+			"yorimichi ritoru suta"
+		],
 		"title": "よりみちリトルスター"
 	},
 	{
@@ -17060,7 +17543,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2426,
-		"searchTerms": [],
+		"searchTerms": [
+			"cinderella disco"
+		],
 		"title": "シンデレラディスコ"
 	},
 	{
@@ -17071,7 +17556,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2427,
-		"searchTerms": [],
+		"searchTerms": [
+			"utakata no sekai de"
+		],
 		"title": "うたかたのせかいで"
 	},
 	{
@@ -17082,7 +17569,10 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2428,
-		"searchTerms": [],
+		"searchTerms": [
+			"toa-chan no omochahako",
+			"toa-chan's toybox"
+		],
 		"title": "とあちゃんのおもちゃ箱"
 	},
 	{
@@ -17093,7 +17583,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2429,
-		"searchTerms": [],
+		"searchTerms": [
+			"shironiwa"
+		],
 		"title": "白庭"
 	},
 	{
@@ -17137,7 +17629,9 @@
 			"genre": "niconico"
 		},
 		"id": 2433,
-		"searchTerms": [],
+		"searchTerms": [
+			"hana to nare"
+		],
 		"title": "花となれ"
 	},
 	{
@@ -17148,7 +17642,10 @@
 			"genre": "niconico"
 		},
 		"id": 2434,
-		"searchTerms": [],
+		"searchTerms": [
+			"kanon",
+			"canon"
+		],
 		"title": "カノン"
 	},
 	{
@@ -17159,7 +17656,11 @@
 			"genre": "niconico"
 		},
 		"id": 2435,
-		"searchTerms": [],
+		"searchTerms": [
+			"isei ni ikou ne",
+			"take you to an alien",
+			"let's go to another planet"
+		],
 		"title": "異星にいこうね"
 	},
 	{
@@ -17170,7 +17671,11 @@
 			"genre": "niconico"
 		},
 		"id": 2436,
-		"searchTerms": [],
+		"searchTerms": [
+			"akuma no odori kata",
+			"devil's manner",
+			"how the devil dances"
+		],
 		"title": "悪魔の踊り方"
 	},
 	{
@@ -17181,7 +17686,10 @@
 			"genre": "niconico"
 		},
 		"id": 2437,
-		"searchTerms": [],
+		"searchTerms": [
+			"do kuzu",
+			"scum of the earth"
+		],
 		"title": "ド屑"
 	},
 	{
@@ -17192,7 +17700,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2438,
-		"searchTerms": [],
+		"searchTerms": [
+			"natsuiro hanabi"
+		],
 		"title": "夏色花火"
 	},
 	{
@@ -17203,7 +17713,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2439,
-		"searchTerms": [],
+		"searchTerms": [
+			"yume to gensou no shuuten nite"
+		],
 		"title": "夢と幻想の終点にて"
 	},
 	{
@@ -17225,7 +17737,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2441,
-		"searchTerms": [],
+		"searchTerms": [
+			"kukan souzou riron"
+		],
 		"title": "空間創造理論"
 	},
 	{
@@ -17247,7 +17761,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2443,
-		"searchTerms": [],
+		"searchTerms": [
+			"rehearsal time"
+		],
 		"title": "リハーサルタイム"
 	},
 	{
@@ -17280,7 +17796,10 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2446,
-		"searchTerms": [],
+		"searchTerms": [
+			"aku airo paretto",
+			"aqua color palette"
+		],
 		"title": "#あくあ色ぱれっと"
 	},
 	{
@@ -17291,7 +17810,10 @@
 			"genre": "niconico"
 		},
 		"id": 2447,
-		"searchTerms": [],
+		"searchTerms": [
+			"itsuka otona ni nareruto ii ne.",
+			"would be nice if you grow up one day."
+		],
 		"title": "いつかオトナになれるといいね。"
 	},
 	{
@@ -17313,7 +17835,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 2449,
-		"searchTerms": [],
+		"searchTerms": [
+			"baka mitai"
+		],
 		"title": "ばかみたい【Taxi Driver Edition】"
 	},
 	{
@@ -17324,7 +17848,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 2450,
-		"searchTerms": [],
+		"searchTerms": [
+			"sega saturn startup sound"
+		],
 		"title": "セガサターン起動音[H.][Remix]"
 	},
 	{
@@ -17346,7 +17872,9 @@
 			"genre": "niconico"
 		},
 		"id": 2452,
-		"searchTerms": [],
+		"searchTerms": [
+			"anata wa sekainoowari ni zunda o taberu noda"
+		],
 		"title": "あなたは世界の終わりにずんだを食べるのだ"
 	},
 	{
@@ -17357,7 +17885,10 @@
 			"genre": "niconico"
 		},
 		"id": 2453,
-		"searchTerms": [],
+		"searchTerms": [
+			"chotto azatoi",
+			"a little sly"
+		],
 		"title": "ちょっとあざとい"
 	},
 	{
@@ -17456,7 +17987,10 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2463,
-		"searchTerms": [],
+		"searchTerms": [
+			"hangeki! totsugeki! back to back!",
+			"counterattack! charge! back to back!"
+		],
 		"title": "反撃! 突撃! Back To Back!"
 	},
 	{
@@ -17511,7 +18045,10 @@
 			"genre": "東方Project"
 		},
 		"id": 2468,
-		"searchTerms": [],
+		"searchTerms": [
+			"karisuma rengoku tenjin",
+			"charismatic purgatory goddess"
+		],
 		"title": "カリスマ煉獄天神"
 	},
 	{
@@ -17522,8 +18059,34 @@
 			"genre": "東方Project"
 		},
 		"id": 2469,
-		"searchTerms": [],
+		"searchTerms": [
+			"shiawase usagi"
+		],
 		"title": "シアワセうさぎ"
+	},
+	{
+		"altTitles": [],
+		"artist": "TAG VS Kai",
+		"data": {
+			"displayVersion": "sunplus",
+			"genre": "ORIGINAL"
+		},
+		"id": 2475,
+		"searchTerms": [],
+		"title": "Chaotic Ørder"
+	},
+	{
+		"altTitles": [],
+		"artist": "曲：橘亮祐、篠崎あやと／歌：三角 葵(CV：春野 杏)、逢坂 茜(CV：大空 直美)、日向 千夏(CV：岡咲 美保)",
+		"data": {
+			"displayVersion": "sunplus",
+			"genre": "ゲキマイ"
+		},
+		"id": 2476,
+		"searchTerms": [
+			"pokapokaonsen ondo"
+		],
+		"title": "ぽかぽか温泉音頭"
 	},
 	{
 		"altTitles": [],
@@ -17533,7 +18096,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2489,
-		"searchTerms": [],
+		"searchTerms": [
+			"hifi days"
+		],
 		"title": "ハイファイ☆デイズ"
 	},
 	{


### PR DESCRIPTION
## Songs
### Newly added
- TAG vs. Kai - Chaotic Ørder
- 曲：橘亮祐、篠崎あやと／歌：三角 葵(CV：春野 杏)、逢坂 茜(CV：大空 直美)、日向 千夏(CV：岡咲 美保) - ぽかぽか温泉音頭

### ULTIMA chart added
- 月鈴 那知(CV:今村 彩夏) - 猛進ソリストライフ！

### Now available in Japan version
These songs were first released in International version.
- REDALiCE - HiGHER
- t+pazolite feat. ななひら - めっちゃ煽ってくるタイプの音ゲーボス曲ちゃんなんかに負けないが？？？？？
- Getty & Kobaryo - Breaking Dawn (feat. 棗いつき)
- Gram - Odin
- USAO - Wildfire

### Now available in International version
These songs were first released in Japan version.
- koyori（電ポルP）- 独りんぼエンヴィー
- James Landino X Akira Complex「Cytus Ⅱ」- Hydra
- Kevin Penkin feat. Nikki Simmons「Cytus Ⅱ」- Survive
- MAYA AKAI - LiftOff
- 曲：橘亮祐、篠崎あやと／歌：藍原 椿(CV：橋本 ちなみ)、早乙女 彩華(CV：中島 唯) - シンデレラディスコ

## Others
Most song with kanji titles now have romaji spellings as a `searchTerm`.