### PR TITLE
[maimaidx/chunithm] Update seeds for KoP5th update, add some songs to SUN Omnimix

### DIFF
--- a/database-seeds/collections/charts-chunithm.json
+++ b/database-seeds/collections/charts-chunithm.json
@@ -107378,7 +107378,9 @@
 		"playtype": "Single",
 		"songID": 2416,
 		"versions": [
-			"sunplus"
+			"sun-omni",
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107393,7 +107395,9 @@
 		"playtype": "Single",
 		"songID": 2416,
 		"versions": [
-			"sunplus"
+			"sun-omni",
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107408,7 +107412,9 @@
 		"playtype": "Single",
 		"songID": 2416,
 		"versions": [
-			"sunplus"
+			"sun-omni",
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107423,7 +107429,9 @@
 		"playtype": "Single",
 		"songID": 2416,
 		"versions": [
-			"sunplus"
+			"sun-omni",
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -107438,7 +107446,9 @@
 		"playtype": "Single",
 		"songID": 2416,
 		"versions": [
-			"sunplus"
+			"sun-omni",
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110595,6 +110605,74 @@
 		"songID": 2476,
 		"versions": [
 			"sunplus"
+		]
+	},
+	{
+		"chartID": "7e11d364e6211e0fd0e1b68fa780deb86bb5fe78",
+		"data": {
+			"inGameID": 2477
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "9+",
+		"levelNum": 9.5,
+		"playtype": "Single",
+		"songID": 2477,
+		"versions": [
+			"sun-omni",
+			"sunplus",
+			"sunplus-intl"
+		]
+	},
+	{
+		"chartID": "ec6a59a5ee8a29afba9e5206c94687b0ab3972fb",
+		"data": {
+			"inGameID": 2477
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"songID": 2477,
+		"versions": [
+			"sun-omni",
+			"sunplus",
+			"sunplus-intl"
+		]
+	},
+	{
+		"chartID": "1ce0478e6371a68c9bea8a3bd3c20f3f1750b9b4",
+		"data": {
+			"inGameID": 2477
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13+",
+		"levelNum": 13.5,
+		"playtype": "Single",
+		"songID": 2477,
+		"versions": [
+			"sun-omni",
+			"sunplus",
+			"sunplus-intl"
+		]
+	},
+	{
+		"chartID": "8a6c3a76d8c4600e2d3764da456c992345a8787c",
+		"data": {
+			"inGameID": 2477
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15.1,
+		"playtype": "Single",
+		"songID": 2477,
+		"versions": [
+			"sun-omni",
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{

--- a/database-seeds/collections/charts-chunithm.json
+++ b/database-seeds/collections/charts-chunithm.json
@@ -107463,6 +107463,7 @@
 		"playtype": "Single",
 		"songID": 2417,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107479,6 +107480,7 @@
 		"playtype": "Single",
 		"songID": 2417,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107495,6 +107497,7 @@
 		"playtype": "Single",
 		"songID": 2417,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107511,6 +107514,7 @@
 		"playtype": "Single",
 		"songID": 2417,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107527,6 +107531,7 @@
 		"playtype": "Single",
 		"songID": 2418,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107543,6 +107548,7 @@
 		"playtype": "Single",
 		"songID": 2418,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107559,6 +107565,7 @@
 		"playtype": "Single",
 		"songID": 2418,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107575,6 +107582,7 @@
 		"playtype": "Single",
 		"songID": 2418,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107771,6 +107779,7 @@
 		"playtype": "Single",
 		"songID": 2422,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107787,6 +107796,7 @@
 		"playtype": "Single",
 		"songID": 2422,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107803,6 +107813,7 @@
 		"playtype": "Single",
 		"songID": 2422,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107819,6 +107830,7 @@
 		"playtype": "Single",
 		"songID": 2422,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107835,6 +107847,7 @@
 		"playtype": "Single",
 		"songID": 2425,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107851,6 +107864,7 @@
 		"playtype": "Single",
 		"songID": 2425,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107867,6 +107881,7 @@
 		"playtype": "Single",
 		"songID": 2425,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107883,6 +107898,7 @@
 		"playtype": "Single",
 		"songID": 2425,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107899,6 +107915,7 @@
 		"playtype": "Single",
 		"songID": 2426,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107915,6 +107932,7 @@
 		"playtype": "Single",
 		"songID": 2426,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107931,6 +107949,7 @@
 		"playtype": "Single",
 		"songID": 2426,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]
@@ -107947,6 +107966,7 @@
 		"playtype": "Single",
 		"songID": 2426,
 		"versions": [
+			"sun-omni",
 			"sunplus",
 			"sunplus-intl"
 		]

--- a/database-seeds/collections/charts-maimaidx.json
+++ b/database-seeds/collections/charts-maimaidx.json
@@ -80730,5 +80730,65 @@
 		"versions": [
 			"festivalplus"
 		]
+	},
+	{
+		"chartID": "2d2196d0d33f27f5b6ac4b9a1e2e937ad43c9ce1",
+		"data": {
+			"isLatest": true
+		},
+		"difficulty": "DX Advanced",
+		"isPrimary": true,
+		"level": "8+",
+		"levelNum": 8.7,
+		"playtype": "Single",
+		"songID": 1129,
+		"versions": [
+			"festivalplus"
+		]
+	},
+	{
+		"chartID": "015eab66f424d7bd913beb3a1bef51e801fe6995",
+		"data": {
+			"isLatest": true
+		},
+		"difficulty": "DX Basic",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 1129,
+		"versions": [
+			"festivalplus"
+		]
+	},
+	{
+		"chartID": "88b5def1d194009d8fccfd4a019879f4a45802eb",
+		"data": {
+			"isLatest": true
+		},
+		"difficulty": "DX Expert",
+		"isPrimary": true,
+		"level": "12+",
+		"levelNum": 12.7,
+		"playtype": "Single",
+		"songID": 1129,
+		"versions": [
+			"festivalplus"
+		]
+	},
+	{
+		"chartID": "d592519617c007e81bae6233ee37e13ba016262d",
+		"data": {
+			"isLatest": true
+		},
+		"difficulty": "DX Master",
+		"isPrimary": true,
+		"level": "14+",
+		"levelNum": 14.7,
+		"playtype": "Single",
+		"songID": 1129,
+		"versions": [
+			"festivalplus"
+		]
 	}
 ]

--- a/database-seeds/collections/charts-maimaidx.json
+++ b/database-seeds/collections/charts-maimaidx.json
@@ -80769,7 +80769,7 @@
 		"difficulty": "DX Expert",
 		"isPrimary": true,
 		"level": "12+",
-		"levelNum": 12.7,
+		"levelNum": 12.9,
 		"playtype": "Single",
 		"songID": 1129,
 		"versions": [

--- a/database-seeds/collections/songs-chunithm.json
+++ b/database-seeds/collections/songs-chunithm.json
@@ -18091,6 +18091,17 @@
 	},
 	{
 		"altTitles": [],
+		"artist": "rintaro soma",
+		"data": {
+			"displayVersion": "sunplus",
+			"genre": "ゲキマイ"
+		},
+		"id": 2477,
+		"searchTerms": [],
+		"title": "sølips"
+	},
+	{
+		"altTitles": [],
 		"artist": "佐々木千枝、櫻井桃華、市原仁奈、龍崎薫、赤城みりあ「アイドルマスター シンデレラガールズ」",
 		"data": {
 			"displayVersion": "sunplus",

--- a/database-seeds/collections/songs-chunithm.json
+++ b/database-seeds/collections/songs-chunithm.json
@@ -14349,7 +14349,7 @@
 	},
 	{
 		"altTitles": [],
-		"artist": "R Sound Design ",
+		"artist": "R Sound Design",
 		"data": {
 			"displayVersion": "new",
 			"genre": "niconico"
@@ -16916,7 +16916,7 @@
 	},
 	{
 		"altTitles": [],
-		"artist": "EBIMAYO ",
+		"artist": "EBIMAYO",
 		"data": {
 			"displayVersion": "sun",
 			"genre": "ゲキマイ"

--- a/database-seeds/collections/songs-maimaidx.json
+++ b/database-seeds/collections/songs-maimaidx.json
@@ -14433,7 +14433,10 @@
 			"genre": "maimai"
 		},
 		"id": 1129,
-		"searchTerms": [],
+		"searchTerms": [
+			"khymexa",
+			"chimera"
+		],
 		"title": "KHYMΞXΛ"
 	}
 ]

--- a/database-seeds/collections/songs-maimaidx.json
+++ b/database-seeds/collections/songs-maimaidx.json
@@ -14424,5 +14424,16 @@
 		"id": 1128,
 		"searchTerms": [],
 		"title": "LAMIA"
+	},
+	{
+		"altTitles": [],
+		"artist": "のらねこさい feat.ricono",
+		"data": {
+			"displayVersion": "FESTiVAL PLUS",
+			"genre": "maimai"
+		},
+		"id": 1129,
+		"searchTerms": [],
+		"title": "KHYMΞXΛ"
 	}
 ]

--- a/database-seeds/scripts/rerunners/chunithm/merge-options.ts
+++ b/database-seeds/scripts/rerunners/chunithm/merge-options.ts
@@ -69,7 +69,7 @@ function calculateLevelNum(data: Pick<MusicFumenData, "level" | "levelDecimal">)
 
 const program = new Command();
 program.requiredOption("-i, --input <OPTION FOLDERS...>");
-program.requiredOption("-v, --version <sun, sunplus>");
+program.requiredOption("-v, --version <VERSION>");
 
 program.parse(process.argv);
 const options = program.opts();


### PR DESCRIPTION
King of Performai (KoP) is an annual competition held by Sega for its Performai rhythm game series (maimai DX, CHUNITHM, O.N.G.E.K.I.). This update adds new songs used for the qualifying rounds.

## maimai DX
### New songs
- のらねこさい feat.ricono - KHYMΞXΛ (read "[chimera](https://twitter.com/com_giko_31/status/1712314803711344947)")

## CHUNITHM
### New songs
Immediately available in all regions.
- rintaro soma - sølips

### Now available in SUN Omnimix
- koyori（電ポルP）- 独りんぼエンヴィー
- James Landino X Akira Complex「Cytus Ⅱ」- Hydra
- Kevin Penkin feat. Nikki Simmons「Cytus Ⅱ」- Survive
- MAYA AKAI - LiftOff
- 曲：橘亮祐、篠崎あやと／歌：藍原 椿(CV：橋本 ちなみ)、早乙女 彩華(CV：中島 唯) - シンデレラディスコ
