### PR TITLE
feat: support iidx omnimix 1.30.1

### DIFF
--- a/common/src/config/game-support/iidx.ts
+++ b/common/src/config/game-support/iidx.ts
@@ -259,6 +259,7 @@ export const IIDX_SP_CONF = {
 		"27-omni": "HEROIC VERSE Omnimix",
 		"28-omni": "BISTROVER Omnimix",
 		"29-omni": "CastHour Omnimix",
+		"30-omni": "Resident Omnimix",
 		"27-2dxtra": "HEROIC VERSE 2dxtra",
 		"28-2dxtra": "BISTROVER 2dxtra",
 		bmus: "BEATMANIA US",

--- a/docs/docs/game-support/games/iidx-DP.md
+++ b/docs/docs/game-support/games/iidx-DP.md
@@ -136,6 +136,7 @@ The default rating algorithm is `ktLampRating`.
 | `27-omni` | HEROIC VERSE Omnimix |
 | `28-omni` | BISTROVER Omnimix |
 | `29-omni` | CastHour Omnimix |
+| `30-omni` | Resident Omnimix |
 | `27-2dxtra` | HEROIC VERSE 2dxtra |
 | `28-2dxtra` | BISTROVER 2dxtra |
 | `bmus` | BEATMANIA US |

--- a/docs/docs/game-support/games/iidx-SP.md
+++ b/docs/docs/game-support/games/iidx-SP.md
@@ -136,6 +136,7 @@ The default rating algorithm is `ktLampRating`.
 | `27-omni` | HEROIC VERSE Omnimix |
 | `28-omni` | BISTROVER Omnimix |
 | `29-omni` | CastHour Omnimix |
+| `30-omni` | Resident Omnimix |
 | `27-2dxtra` | HEROIC VERSE 2dxtra |
 | `28-2dxtra` | BISTROVER 2dxtra |
 | `bmus` | BEATMANIA US |

--- a/server/src/lib/score-import/import-types/ir/fervidex-static/converter.ts
+++ b/server/src/lib/score-import/import-types/ir/fervidex-static/converter.ts
@@ -15,6 +15,7 @@ export const ConverterIRFervidexStatic: ConverterFunction<
 > = async (data, context, importType, logger) => {
 	let { difficulty, playtype } = SplitFervidexChartRef(data.chart);
 
+	//hack for scripted connection long support in older omnimixes
 	if(data.entry_id === 21201 && difficulty === "ANOTHER") {
 		data.entry_id = 12250;
 		difficulty = "LEGGENDARIA";

--- a/server/src/lib/score-import/import-types/ir/fervidex-static/converter.ts
+++ b/server/src/lib/score-import/import-types/ir/fervidex-static/converter.ts
@@ -13,7 +13,12 @@ export const ConverterIRFervidexStatic: ConverterFunction<
 	FervidexStaticScore,
 	FervidexStaticContext
 > = async (data, context, importType, logger) => {
-	const { difficulty, playtype } = SplitFervidexChartRef(data.chart);
+	let { difficulty, playtype } = SplitFervidexChartRef(data.chart);
+
+	if(data.entry_id === 21201 && difficulty === "ANOTHER") {
+		data.entry_id = 12250;
+		difficulty = "LEGGENDARIA";
+	}
 
 	const chart = await FindChartOnInGameIDVersion(
 		"iidx",

--- a/server/src/lib/score-import/import-types/ir/fervidex-static/converter.ts
+++ b/server/src/lib/score-import/import-types/ir/fervidex-static/converter.ts
@@ -16,8 +16,8 @@ export const ConverterIRFervidexStatic: ConverterFunction<
 	let { difficulty, playtype } = SplitFervidexChartRef(data.chart);
 
 	//hack for scripted connection long support in older omnimixes
-	if(data.entry_id === 21201 && difficulty === "ANOTHER") {
-		data.entry_id = 12250;
+	if(data.song_id === 21201 && difficulty === "ANOTHER") {
+		data.song_id = 12250;
 		difficulty = "LEGGENDARIA";
 	}
 

--- a/server/src/lib/score-import/import-types/ir/fervidex-static/converter.ts
+++ b/server/src/lib/score-import/import-types/ir/fervidex-static/converter.ts
@@ -13,10 +13,14 @@ export const ConverterIRFervidexStatic: ConverterFunction<
 	FervidexStaticScore,
 	FervidexStaticContext
 > = async (data, context, importType, logger) => {
+	// eslint-disable-next-line prefer-const
 	let { difficulty, playtype } = SplitFervidexChartRef(data.chart);
 
-	//hack for scripted connection long support in older omnimixes
-	if(data.song_id === 21201 && difficulty === "ANOTHER") {
+	// Scripted Long used to be an ANOTHER with id 21201
+	//
+	// now it has an id of 12250 and is a legg.
+	// Versions of omnimix prior to oct 2023 depend on this behaviour.
+	if (data.song_id === 21201 && difficulty === "ANOTHER") {
 		data.song_id = 12250;
 		difficulty = "LEGGENDARIA";
 	}

--- a/server/src/lib/score-import/import-types/ir/fervidex/converter.ts
+++ b/server/src/lib/score-import/import-types/ir/fervidex/converter.ts
@@ -147,6 +147,7 @@ export const ConverterIRFervidex: ConverterFunction<FervidexScore, FervidexConte
 ) => {
 	let { difficulty, playtype } = SplitFervidexChartRef(data.chart);
 
+	//hack for scripted connection long support in older omnimixes
 	if(data.entry_id === 21201 && difficulty === "ANOTHER") {
 		data.entry_id = 12250;
 		difficulty = "LEGGENDARIA";

--- a/server/src/lib/score-import/import-types/ir/fervidex/converter.ts
+++ b/server/src/lib/score-import/import-types/ir/fervidex/converter.ts
@@ -145,7 +145,12 @@ export const ConverterIRFervidex: ConverterFunction<FervidexScore, FervidexConte
 	importType,
 	logger
 ) => {
-	const { difficulty, playtype } = SplitFervidexChartRef(data.chart);
+	let { difficulty, playtype } = SplitFervidexChartRef(data.chart);
+
+	if(data.entry_id === 21201 && difficulty === "ANOTHER") {
+		data.entry_id = 12250;
+		difficulty = "LEGGENDARIA";
+	}
 
 	let chart;
 

--- a/server/src/lib/score-import/import-types/ir/fervidex/converter.ts
+++ b/server/src/lib/score-import/import-types/ir/fervidex/converter.ts
@@ -147,8 +147,11 @@ export const ConverterIRFervidex: ConverterFunction<FervidexScore, FervidexConte
 ) => {
 	let { difficulty, playtype } = SplitFervidexChartRef(data.chart);
 
-	//hack for scripted connection long support in older omnimixes
-	if(data.entry_id === 21201 && difficulty === "ANOTHER") {
+	// Scripted Long used to be an ANOTHER with id 21201
+	//
+	// now it has an id of 12250 and is a legg.
+	// Versions of omnimix prior to oct 2023 depend on this behaviour.
+	if (data.entry_id === 21201 && difficulty === "ANOTHER") {
 		data.entry_id = 12250;
 		difficulty = "LEGGENDARIA";
 	}

--- a/server/src/lib/score-import/import-types/ir/fervidex/parser.ts
+++ b/server/src/lib/score-import/import-types/ir/fervidex/parser.ts
@@ -114,6 +114,8 @@ export function SoftwareIDToVersion(
 			} else if (EXT_RESIDENT.includes(data.ext)) {
 				if (data.rev === REV_NORMAL) {
 					return "30";
+				} else if (data.rev === REV_OMNIMIX) {
+					return "30-omni";
 				}
 			}
 		}


### PR DESCRIPTION
This adds support for resident omnimix, with a few catches:

 - What was originally Scripted Connection Long Mix SPA is now SPL.  This is treated as a new chart in 30-omni.

 - What was originally Junglist King Long SPA and DPA is now SPH and DPH.  This is correct, it was erroneous before, but to maintain compatibility these are also treated as new charts in 30-omni.

 - "Theme from Flo-jack" has bad data and is not supported in 30-omni atm (hoping ryuuou patches this).

 - Deep Clear Eyes has a bug (Anothers and Hypers swapped) and not supported in 30-omni atm (hoping ryuuou patches this).

 - Morning Prayer is I think also bugged (?) and not supported in 30-omni atm.
 
 
 Everything else should (hopefully) be good :)