### PR TITLE
fix: header overflow

### DIFF
--- a/client/src/components/layout/header/Header.tsx
+++ b/client/src/components/layout/header/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import Container from "react-bootstrap/Container";
-import { Navbar, Offcanvas, OffcanvasHeader } from "react-bootstrap";
+import { Navbar, Offcanvas } from "react-bootstrap";
 import SiteWordmark from "components/util/SiteWordmark";
 import SignOut from "components/util/SignOut";
 import { UserContext } from "context/UserContext";
@@ -44,7 +44,7 @@ export default function Header({ styles }: { styles: LayoutStyles }) {
 						show={showMobileMenu}
 						onHide={() => setShowMobileMenu(false)}
 					>
-						<OffcanvasHeader className="p-4 border-bottom border-body-tertiary">
+						<Offcanvas.Header className="p-4 border-bottom border-body-tertiary">
 							<Link
 								id="home"
 								to="/"
@@ -52,17 +52,17 @@ export default function Header({ styles }: { styles: LayoutStyles }) {
 							>
 								<SiteWordmark id="navbar-label" width="192px" />
 							</Link>
-						</OffcanvasHeader>
+						</Offcanvas.Header>
 						<Offcanvas.Body className="d-flex flex-column">
 							<HeaderMenu
 								user={user}
 								dropdownMenuStyle={dropdownMenuStyle}
 								setState={setState}
 							/>
-							<div className="pb-4 px-4 d-md-none">
-								<SignOut className="w-100" />
-							</div>
 						</Offcanvas.Body>
+						<div className="d-flex bottom-0 pb-2 px-4 d-lg-none">
+							<SignOut className="w-100" />
+						</div>
 					</Navbar.Offcanvas>
 					<UserArea user={user} dropdownMenuStyle={dropdownMenuStyle} />
 				</Container>

--- a/client/src/components/layout/header/HeaderMenu.tsx
+++ b/client/src/components/layout/header/HeaderMenu.tsx
@@ -41,10 +41,7 @@ export function HeaderMenu({
 	}, [error, data]);
 
 	return (
-		<Nav
-			as="nav"
-			className="p-4 d-flex align-content-between gap-4 h-100 overflow-y-auto overflow-x-hidden"
-		>
+		<Nav as="nav" className="p-4 d-flex align-content-between gap-4 h-100">
 			{user && ugs && ugs.length !== 0 && (
 				<UGPTDropdown
 					user={user}


### PR DESCRIPTION
In a previous attempt to fix a bug where the sign out button was fixed in place overlaying menu elements, I created an overflow container within the menu container which already has overflow properties applied. This results in an issue where the header always overflows across all breakpoints breaking the menus on desktop displays. The actual fix is to move the sign-out button outside of said container so it's statically positioned at the end of the offcanvas.