### PR TITLE
[chunithm] international: update seeds to 2024-01-11

### DIFF
--- a/database-seeds/collections/charts-chunithm.json
+++ b/database-seeds/collections/charts-chunithm.json
@@ -108877,7 +108877,8 @@
 		"playtype": "Single",
 		"songID": 2439,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -108892,7 +108893,8 @@
 		"playtype": "Single",
 		"songID": 2439,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -108907,7 +108909,8 @@
 		"playtype": "Single",
 		"songID": 2439,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -108922,7 +108925,8 @@
 		"playtype": "Single",
 		"songID": 2439,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -108937,7 +108941,8 @@
 		"playtype": "Single",
 		"songID": 2440,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -108952,7 +108957,8 @@
 		"playtype": "Single",
 		"songID": 2440,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -108967,7 +108973,8 @@
 		"playtype": "Single",
 		"songID": 2440,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -108982,7 +108989,8 @@
 		"playtype": "Single",
 		"songID": 2440,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -108997,7 +109005,8 @@
 		"playtype": "Single",
 		"songID": 2441,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109012,7 +109021,8 @@
 		"playtype": "Single",
 		"songID": 2441,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109027,7 +109037,8 @@
 		"playtype": "Single",
 		"songID": 2441,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109042,7 +109053,8 @@
 		"playtype": "Single",
 		"songID": 2441,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109057,7 +109069,8 @@
 		"playtype": "Single",
 		"songID": 2442,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109072,7 +109085,8 @@
 		"playtype": "Single",
 		"songID": 2442,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109087,7 +109101,8 @@
 		"playtype": "Single",
 		"songID": 2442,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109102,7 +109117,8 @@
 		"playtype": "Single",
 		"songID": 2442,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109185,7 +109201,8 @@
 		"playtype": "Single",
 		"songID": 2444,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109200,7 +109217,8 @@
 		"playtype": "Single",
 		"songID": 2444,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109215,7 +109233,8 @@
 		"playtype": "Single",
 		"songID": 2444,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109230,7 +109249,8 @@
 		"playtype": "Single",
 		"songID": 2444,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109245,7 +109265,8 @@
 		"playtype": "Single",
 		"songID": 2445,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109260,7 +109281,8 @@
 		"playtype": "Single",
 		"songID": 2445,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109275,7 +109297,8 @@
 		"playtype": "Single",
 		"songID": 2445,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109290,7 +109313,8 @@
 		"playtype": "Single",
 		"songID": 2445,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109305,7 +109329,8 @@
 		"playtype": "Single",
 		"songID": 2446,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109320,7 +109345,8 @@
 		"playtype": "Single",
 		"songID": 2446,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109335,7 +109361,8 @@
 		"playtype": "Single",
 		"songID": 2446,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109350,7 +109377,8 @@
 		"playtype": "Single",
 		"songID": 2446,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109365,7 +109393,8 @@
 		"playtype": "Single",
 		"songID": 2447,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109380,7 +109409,8 @@
 		"playtype": "Single",
 		"songID": 2447,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109395,7 +109425,8 @@
 		"playtype": "Single",
 		"songID": 2447,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109410,7 +109441,8 @@
 		"playtype": "Single",
 		"songID": 2447,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109485,7 +109517,8 @@
 		"playtype": "Single",
 		"songID": 2449,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109500,7 +109533,8 @@
 		"playtype": "Single",
 		"songID": 2449,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109515,7 +109549,8 @@
 		"playtype": "Single",
 		"songID": 2449,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109530,7 +109565,8 @@
 		"playtype": "Single",
 		"songID": 2449,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109545,7 +109581,8 @@
 		"playtype": "Single",
 		"songID": 2450,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109560,7 +109597,8 @@
 		"playtype": "Single",
 		"songID": 2450,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109575,7 +109613,8 @@
 		"playtype": "Single",
 		"songID": 2450,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109590,7 +109629,8 @@
 		"playtype": "Single",
 		"songID": 2450,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109605,7 +109645,8 @@
 		"playtype": "Single",
 		"songID": 2451,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109620,7 +109661,8 @@
 		"playtype": "Single",
 		"songID": 2451,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109635,7 +109677,8 @@
 		"playtype": "Single",
 		"songID": 2451,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -109650,7 +109693,8 @@
 		"playtype": "Single",
 		"songID": 2451,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{

--- a/database-seeds/collections/songs-chunithm.json
+++ b/database-seeds/collections/songs-chunithm.json
@@ -17726,7 +17726,8 @@
 		},
 		"id": 2439,
 		"searchTerms": [
-			"yume to gensou no shuuten nite"
+			"yume to gensou no shuuten nite",
+			"the end of dream and fantasy"
 		],
 		"title": "夢と幻想の終点にて"
 	},
@@ -17750,7 +17751,8 @@
 		},
 		"id": 2441,
 		"searchTerms": [
-			"kukan souzou riron"
+			"kukan souzou riron",
+			"space creation theory"
 		],
 		"title": "空間創造理論"
 	},


### PR DESCRIPTION
Marks some songs as available in SUN PLUS (International):
- しーけー - 夢と幻想の終点にて
- Team Grimoire - Superbia
- Sound piercer - 空間創造理論
- Aoi - βlαnoir
- ▽▲TRiNITY▲▽ - Night Spider
- 湊あくあ（ホロライブ）- #あくあ色ぱれっと
- 桐生一馬(黒田崇矢) - ばかみたい【Taxi Driver Edition】
- Hiro - セガサターン起動音[H.][Remix]
- LV.4 - Cult future
- 曲：Funta7／歌：星咲 あかり(CV：赤尾 ひかる)、日向 千夏(CV：岡咲 美保) - スン(マイル)フラワー～Sun(Mile)Flower

Adds some English search terms:
Both of these titles are in the original jackets for the songs: https://info-chunithm.sega.jp/5518/

- "夢と幻想の終点にて" -> "The end of dream and fantasy"
- "空間創造理論" -> "Space Creation Theory"