### PR TITLE
feat: IIDX update

### DIFF
--- a/common/src/config/game-support/iidx.ts
+++ b/common/src/config/game-support/iidx.ts
@@ -255,6 +255,7 @@ export const IIDX_SP_CONF = {
 		"28": "BISTROVER",
 		"29": "CastHour",
 		"30": "Resident",
+		"31": "Epolis",
 		"26-omni": "ROOTAGE Omnimix",
 		"27-omni": "HEROIC VERSE Omnimix",
 		"28-omni": "BISTROVER Omnimix",

--- a/database-seeds/collections/folders.json
+++ b/database-seeds/collections/folders.json
@@ -11007,6 +11007,19 @@
 	{
 		"data": {
 			"level": "1",
+			"versions": "31"
+		},
+		"folderID": "F433523a3d513a07b3e1e4e4b9441eec2337f748bd6e8a249ea49dd4bcae92d7b",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 1 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "1",
 			"versions": "14-cs"
 		},
 		"folderID": "F14159009731b0ab1fca61d9f61a51aafb9c014ef6a5aa814db697ffefc79cfc1",
@@ -11431,6 +11444,19 @@
 		"playtype": "DP",
 		"searchTerms": [],
 		"title": "Level 10 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "10",
+			"versions": "31"
+		},
+		"folderID": "Fbe4f47c37dd0902394f94049e63c95e1da77686f6b71e38782adb3985d0264b1",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 10 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -11865,6 +11891,19 @@
 	{
 		"data": {
 			"level": "11",
+			"versions": "31"
+		},
+		"folderID": "F9c0a1ec60283b225f62eb8cd5ad240651fad00c1cbdfc2b1ca3fe3cb0e0689a4",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 11 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "11",
 			"versions": "14-cs"
 		},
 		"folderID": "F75593cd8aa5156a7f2fda4383609a3acf39048f5575c154038f01861c199fb60",
@@ -12289,6 +12328,19 @@
 		"playtype": "DP",
 		"searchTerms": [],
 		"title": "Level 12 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "12",
+			"versions": "31"
+		},
+		"folderID": "F534cb868ae0066629b76a5e92d4c21fbb86d6ff1b8ede167a1a46c4dd8a0fb6f",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 12 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -12723,6 +12775,19 @@
 	{
 		"data": {
 			"level": "2",
+			"versions": "31"
+		},
+		"folderID": "F8121a7d8a56e9c0e599af7dbed57c370b8ada2221830861f0694d3411c346ce1",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 2 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "2",
 			"versions": "14-cs"
 		},
 		"folderID": "F093a9944c0cf2948f5c8a6a51867c991415866778e168c8d18803f3ef747c148",
@@ -13147,6 +13212,19 @@
 		"playtype": "DP",
 		"searchTerms": [],
 		"title": "Level 3 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "3",
+			"versions": "31"
+		},
+		"folderID": "Fc80b3b1dfa2b007e4f23cd2c60f28a8d45485f95ba879eda08d858de574321bf",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 3 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -13581,6 +13659,19 @@
 	{
 		"data": {
 			"level": "4",
+			"versions": "31"
+		},
+		"folderID": "F35ed77db0f54982b25fef631bddfe278eaaa84b372edbfc2d4c5660804e77f11",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 4 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "4",
 			"versions": "14-cs"
 		},
 		"folderID": "F0dfcc2374852d80e32e784e802ecc61b8f28b2e1dae481e240defab9a0128525",
@@ -14005,6 +14096,19 @@
 		"playtype": "DP",
 		"searchTerms": [],
 		"title": "Level 5 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "5",
+			"versions": "31"
+		},
+		"folderID": "Fba8ebce8e849a290a5e50457761661a6def785120125ec77a821bc9d516f7e76",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 5 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -14439,6 +14543,19 @@
 	{
 		"data": {
 			"level": "6",
+			"versions": "31"
+		},
+		"folderID": "Fcfef278758f7e22d1670c1c9e57a9bc7de1b1b533b135eeeb541513d6502a7cc",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 6 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "6",
 			"versions": "14-cs"
 		},
 		"folderID": "Fb46e5e2a42df20ac3ef5ce7279d5345ec63dc5cd9f67a744c16ebf421d0f5f59",
@@ -14863,6 +14980,19 @@
 		"playtype": "DP",
 		"searchTerms": [],
 		"title": "Level 7 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "7",
+			"versions": "31"
+		},
+		"folderID": "F958bb839b8b6d7af5a3dd3628c8f1852b906e9cc308fd51abfa394ea8dd768a2",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 7 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -15297,6 +15427,19 @@
 	{
 		"data": {
 			"level": "8",
+			"versions": "31"
+		},
+		"folderID": "F4abbb092a1e14c1d26c31049d8344cb99f163e3bf170fb26f3f0671d86e82b4c",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 8 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "8",
 			"versions": "14-cs"
 		},
 		"folderID": "Fdfd8d33d6ae81702e2323b29a697cf4e06f4205534cea8d4a197b3a2db6f4b3b",
@@ -15721,6 +15864,19 @@
 		"playtype": "DP",
 		"searchTerms": [],
 		"title": "Level 9 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "9",
+			"versions": "31"
+		},
+		"folderID": "F93c7ad860631314b85e54be7ba4cd1fb5fc7279d94583182806e872303cbacf7",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"searchTerms": [],
+		"title": "Level 9 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -16155,6 +16311,19 @@
 	{
 		"data": {
 			"level": "1",
+			"versions": "31"
+		},
+		"folderID": "Feb083d47b06dd6752591125bf41299e35596c168fb4946ba731ad9123b646aac",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 1 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "1",
 			"versions": "14-cs"
 		},
 		"folderID": "Fcafbdbef61a09b59b6174ff09a7c948b3f30c688cee1db7e74262613a40ac3c7",
@@ -16579,6 +16748,19 @@
 		"playtype": "SP",
 		"searchTerms": [],
 		"title": "Level 10 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "10",
+			"versions": "31"
+		},
+		"folderID": "F35c24c57f47fc0e1e6de909b284129527caba84848dc55e221ebca64febce978",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 10 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -17013,6 +17195,19 @@
 	{
 		"data": {
 			"level": "11",
+			"versions": "31"
+		},
+		"folderID": "F29c545c484d4079de3b40cfcb1e7cca18361a50d158d83dfdff1a14c12efeeae",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 11 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "11",
 			"versions": "14-cs"
 		},
 		"folderID": "F5a10427a8b6505ec0e1889926eb831099b39af164f3c0c2ea993b0cd853902fb",
@@ -17437,6 +17632,19 @@
 		"playtype": "SP",
 		"searchTerms": [],
 		"title": "Level 12 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "12",
+			"versions": "31"
+		},
+		"folderID": "F2b0542125b7def38e87972d7016c11d8751f51671be778669769417cd4c74204",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 12 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -17871,6 +18079,19 @@
 	{
 		"data": {
 			"level": "2",
+			"versions": "31"
+		},
+		"folderID": "Fec975ebc2bd28de6cc6d12174e8825963f52596534d72a5eed73ca5283622439",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 2 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "2",
 			"versions": "14-cs"
 		},
 		"folderID": "Fb80de22bbd3ae7602c516b0e50595bba7f5a837eb1eb4cb4e67506b70f9d4f0a",
@@ -18295,6 +18516,19 @@
 		"playtype": "SP",
 		"searchTerms": [],
 		"title": "Level 3 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "3",
+			"versions": "31"
+		},
+		"folderID": "F705f2fcc57ea4844e5698ae520cd5dc5ceb1e6fee24592e03dbead7560372f45",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 3 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -18729,6 +18963,19 @@
 	{
 		"data": {
 			"level": "4",
+			"versions": "31"
+		},
+		"folderID": "F6f44d23e0b72a4fec04d8cb2c7e7b059459e84d589e43675eb9e84607c63572b",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 4 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "4",
 			"versions": "14-cs"
 		},
 		"folderID": "F05c9c8393a3849cebe513254724485f9810439ea4fc071125fce35aca8410813",
@@ -19153,6 +19400,19 @@
 		"playtype": "SP",
 		"searchTerms": [],
 		"title": "Level 5 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "5",
+			"versions": "31"
+		},
+		"folderID": "F732113e45ebdede9bbd785aec4f602f529e8685ebcd7e6fa6f7e082967e47646",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 5 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -19587,6 +19847,19 @@
 	{
 		"data": {
 			"level": "6",
+			"versions": "31"
+		},
+		"folderID": "F51160a77a38a043628b0ad132429c465a0fd1eccefa1758deed23f02f844842f",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 6 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "6",
 			"versions": "14-cs"
 		},
 		"folderID": "F4b76ea4509bd723ea4b5a23ee84fc84e6d042a0d7342b89f6efefefbc19fdcfb",
@@ -20011,6 +20284,19 @@
 		"playtype": "SP",
 		"searchTerms": [],
 		"title": "Level 7 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "7",
+			"versions": "31"
+		},
+		"folderID": "Fc9269ab7a3b52690208795fb203a91bbfc79e969006adad4f5d3d0fdb1c606fc",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 7 (EPOLIS)",
 		"type": "charts"
 	},
 	{
@@ -20445,6 +20731,19 @@
 	{
 		"data": {
 			"level": "8",
+			"versions": "31"
+		},
+		"folderID": "Fcdc6aa3dd48511a6b7c219a3cbcadfad6f1a03583ea530023235a3cc52353e39",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 8 (EPOLIS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "8",
 			"versions": "14-cs"
 		},
 		"folderID": "Fa4780b10565d604921017cd42c624d67f5f9619cd688f858de59ce24a505edb5",
@@ -20869,6 +21168,19 @@
 		"playtype": "SP",
 		"searchTerms": [],
 		"title": "Level 9 (EMPRESS CS)",
+		"type": "charts"
+	},
+	{
+		"data": {
+			"level": "9",
+			"versions": "31"
+		},
+		"folderID": "F437949ea3ab0e2996a999ce3ae5b825f08d2fee6bc14e160402130cc02ce968e",
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"searchTerms": [],
+		"title": "Level 9 (EPOLIS)",
 		"type": "charts"
 	},
 	{

--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -25344,5 +25344,810 @@
 			"Exponentiated Karma"
 		],
 		"title": "累乗のカルマ"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"L.E.D.\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "ROCKIN' DRUM & BASS"
+		},
+		"id": 2273,
+		"searchTerms": [],
+		"title": "JUSTICE/GUILTY feat. Nana Takahashi & 709sec."
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"HuΣeR\" feat.紫村 花澄",
+		"data": {
+			"displayVersion": "31",
+			"genre": "EMOTIONAL J-POP"
+		},
+		"id": 2274,
+		"searchTerms": [],
+		"title": "Iris"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"HuΣeR\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HYBRID DANCE MUSIC"
+		},
+		"id": 2275,
+		"searchTerms": [
+			"DENSHI NI NARITAI"
+		],
+		"title": "電子になりたい"
+	},
+	{
+		"altTitles": [],
+		"artist": "kors k vs BEMANI Sound Team \"setup\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "PSYCHEDELIC TECHNO"
+		},
+		"id": 2276,
+		"searchTerms": [],
+		"title": "Time Distortion pt.2(IIDX Edit)"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"dj TAKA\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "MUSIC GAME TRADITIONAL"
+		},
+		"id": 2277,
+		"searchTerms": [],
+		"title": "frequent"
+	},
+	{
+		"altTitles": [],
+		"artist": "Blacklolita x BEMANI Sound Team \"Expander\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "COLOUR TECHCORE"
+		},
+		"id": 2278,
+		"searchTerms": [],
+		"title": "Chemical Colours"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"ZAQUVA\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARDCORE TECHNO"
+		},
+		"id": 2279,
+		"searchTerms": [],
+		"title": "Speculation"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by BEMANI Sound Team \"ZAQUVA\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HYPERACTIVE HELLCORE"
+		},
+		"id": 2280,
+		"searchTerms": [
+			"Meumeupettantan!! (ZAQUVA Remix)"
+		],
+		"title": "めうめうぺったんたん！！ (ZAQUVA Remix)"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Sota Fujimori\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "PSYCHEDELIC"
+		},
+		"id": 2281,
+		"searchTerms": [],
+		"title": "Psychedelic Intelligence"
+	},
+	{
+		"altTitles": [],
+		"artist": "ここなつ2.0",
+		"data": {
+			"displayVersion": "31",
+			"genre": "FUTUREBASS"
+		},
+		"id": 2282,
+		"searchTerms": [
+			"Polaris no Uta"
+		],
+		"title": "ポラリスノウタ"
+	},
+	{
+		"altTitles": [],
+		"artist": "二代目朱雀",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARD RENAISSANCE"
+		},
+		"id": 2283,
+		"searchTerms": [
+			"Shuen no Claudia"
+		],
+		"title": "終焔のClaudia"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"劇団レコード\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "ADVENTURE TRIP"
+		},
+		"id": 2284,
+		"searchTerms": [],
+		"title": "Get Higher"
+	},
+	{
+		"altTitles": [],
+		"artist": "Covered by BEMANI Sound Team \"HuΣeR × wac\" feat. 佐伯伊織",
+		"data": {
+			"displayVersion": "31",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2285,
+		"searchTerms": [
+			"IDOL"
+		],
+		"title": "アイドル"
+	},
+	{
+		"altTitles": [],
+		"artist": "ツユ",
+		"data": {
+			"displayVersion": "31",
+			"genre": "J-POP"
+		},
+		"id": 2286,
+		"searchTerms": [
+			"Kizutsukedo Aishiteru"
+		],
+		"title": "傷つけど、愛してる。"
+	},
+	{
+		"altTitles": [],
+		"artist": "ano",
+		"data": {
+			"displayVersion": "31",
+			"genre": "J-POP"
+		},
+		"id": 2287,
+		"searchTerms": [
+			"Chu, tayousei"
+		],
+		"title": "ちゅ、多様性。"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by uno(IOSYS) feat. Chiyoko",
+		"data": {
+			"displayVersion": "31",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2288,
+		"searchTerms": [
+			"Neoki Yashinoki"
+		],
+		"title": "寝起きヤシの木"
+	},
+	{
+		"altTitles": [],
+		"artist": "kors k",
+		"data": {
+			"displayVersion": "31",
+			"genre": "SCHRANZ"
+		},
+		"id": 2289,
+		"searchTerms": [],
+		"title": "Mukade"
+	},
+	{
+		"altTitles": [],
+		"artist": "Eagle",
+		"data": {
+			"displayVersion": "31",
+			"genre": "COLOUR BASS"
+		},
+		"id": 2290,
+		"searchTerms": [],
+		"title": "Glitch N Ride"
+	},
+	{
+		"altTitles": [],
+		"artist": "Ryu☆ ft.NU-KO",
+		"data": {
+			"displayVersion": "31",
+			"genre": "EURODANCE SPEED"
+		},
+		"id": 2291,
+		"searchTerms": [],
+		"title": "winkle 2 winkle"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by かめりあ",
+		"data": {
+			"displayVersion": "31",
+			"genre": "BROKEN SAMBA DRUM'N'BASS"
+		},
+		"id": 2292,
+		"searchTerms": ["SHAKUNETSU Beach Side Bunny Camellia Remix"],
+		"title": "灼熱Beach Side Bunny (かめりあ's \"Summertime D'n'B\" Remix)"
+	},
+	{
+		"altTitles": [],
+		"artist": "Xceon",
+		"data": {
+			"displayVersion": "31",
+			"genre": "CHINA SQUARE DANCEPOP"
+		},
+		"id": 2293,
+		"searchTerms": [
+			"hatasenuyakusoku ft. kobayashi mana"
+		],
+		"title": "果たせぬ約束 ft. 小林マナ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Aikapin Prod. by uno & NiActivity",
+		"data": {
+			"displayVersion": "31",
+			"genre": "FUNKY BREAKS"
+		},
+		"id": 2294,
+		"searchTerms": [],
+		"title": "Tripping Jumping"
+	},
+	{
+		"altTitles": [],
+		"artist": "CANVAS feat. Quimär",
+		"data": {
+			"displayVersion": "31",
+			"genre": "FREEFORM ARTCORE"
+		},
+		"id": 2295,
+		"searchTerms": [],
+		"title": "Out of Control"
+	},
+	{
+		"altTitles": [],
+		"artist": "nora2r",
+		"data": {
+			"displayVersion": "31",
+			"genre": "ETHNIC HARDSOUND"
+		},
+		"id": 2296,
+		"searchTerms": [],
+		"title": "Echoes of Sunfall"
+	},
+	{
+		"altTitles": [],
+		"artist": "DÉ DÉ MOUSE",
+		"data": {
+			"displayVersion": "31",
+			"genre": "NU SYNTH BASS"
+		},
+		"id": 2297,
+		"searchTerms": [],
+		"title": "Bitter & Lucky"
+	},
+	{
+		"altTitles": [],
+		"artist": "BlackY",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARD RENAISSANCE"
+		},
+		"id": 2298,
+		"searchTerms": [],
+		"title": "Dahlia"
+	},
+	{
+		"altTitles": [],
+		"artist": "Masayoshi Iimori",
+		"data": {
+			"displayVersion": "31",
+			"genre": "DRUM'N'BASS"
+		},
+		"id": 2299,
+		"searchTerms": [],
+		"title": "Jumper"
+	},
+	{
+		"altTitles": [],
+		"artist": "Pizuya's Cell",
+		"data": {
+			"displayVersion": "31",
+			"genre": "ROCK"
+		},
+		"id": 2300,
+		"searchTerms": [
+			"I AM Perfect Absolute Justice-chan!"
+		],
+		"title": "アタシ完全絶対正義ちゃん！"
+	},
+	{
+		"altTitles": [],
+		"artist": "Maozon feat. Nadia",
+		"data": {
+			"displayVersion": "31",
+			"genre": "DRUM & BASS"
+		},
+		"id": 2301,
+		"searchTerms": [
+			"Cinderella"
+		],
+		"title": "シンデレラ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Julianne",
+		"data": {
+			"displayVersion": "31",
+			"genre": "VALHALLASTEP"
+		},
+		"id": 2302,
+		"searchTerms": [
+			"MATENRO"
+		],
+		"title": "摩天楼"
+	},
+	{
+		"altTitles": [],
+		"artist": "Nhato feat. Kanae Asaba & はるまき (from ボタニカルな暮らし。)",
+		"data": {
+			"displayVersion": "31",
+			"genre": "CITY DANCE POP"
+		},
+		"id": 2303,
+		"searchTerms": [
+			"Sentimental Summer"
+		],
+		"title": "センチメンタル・サマー"
+	},
+	{
+		"altTitles": [],
+		"artist": "satella feat. Risa Yuzuki",
+		"data": {
+			"displayVersion": "31",
+			"genre": "UNSUNG FANTASIA"
+		},
+		"id": 2304,
+		"searchTerms": [],
+		"title": "Aeterna"
+	},
+	{
+		"altTitles": [],
+		"artist": "Dirty Androids",
+		"data": {
+			"displayVersion": "31",
+			"genre": "NEO 90's AMBIENT JUNGLE"
+		},
+		"id": 2305,
+		"searchTerms": [],
+		"title": "Deep Sea Mystery"
+	},
+	{
+		"altTitles": [],
+		"artist": "lapix",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARDTECHNO"
+		},
+		"id": 2306,
+		"searchTerms": [],
+		"title": "Submerge Serenade"
+	},
+	{
+		"altTitles": [],
+		"artist": "Zekk",
+		"data": {
+			"displayVersion": "31",
+			"genre": "TRANCE CORE"
+		},
+		"id": 2307,
+		"searchTerms": [],
+		"title": "INHERITANCE"
+	},
+	{
+		"altTitles": [],
+		"artist": "かめりあ feat. ななひら",
+		"data": {
+			"displayVersion": "31",
+			"genre": "MAXIMUM GAME-BREAKING HARDCORE"
+		},
+		"id": 2308,
+		"searchTerms": [],
+		"title": "MAXIMUM CHEAT GIRL"
+	},
+	{
+		"altTitles": [],
+		"artist": "OSTER project feat. 月ノ輪乃愛",
+		"data": {
+			"displayVersion": "31",
+			"genre": "KAWAII DOGGO POPS"
+		},
+		"id": 2309,
+		"searchTerms": [
+			"retriever!"
+		],
+		"title": "れとりば！"
+	},
+	{
+		"altTitles": [],
+		"artist": "OSTER project",
+		"data": {
+			"displayVersion": "31",
+			"genre": "GOTHIC PIANO TRANCE"
+		},
+		"id": 2310,
+		"searchTerms": [],
+		"title": "Vermilion Carol"
+	},
+	{
+		"altTitles": [],
+		"artist": "REMO-CON",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARD HOUSE"
+		},
+		"id": 2311,
+		"searchTerms": [],
+		"title": "This Is Club Musik feat. 大久保紅葉"
+	},
+	{
+		"altTitles": [],
+		"artist": "AJURIKA",
+		"data": {
+			"displayVersion": "31",
+			"genre": "DUBSTEP"
+		},
+		"id": 2312,
+		"searchTerms": [],
+		"title": "GLORIOUS HAMMER"
+	},
+	{
+		"altTitles": [],
+		"artist": "SOUND HOLIC Vs. ZYTOKINE feat. Nana Takahashi",
+		"data": {
+			"displayVersion": "31",
+			"genre": "COLD BEAT"
+		},
+		"id": 2313,
+		"searchTerms": [],
+		"title": "ZEROIN ON THE LIGHT"
+	},
+	{
+		"altTitles": [],
+		"artist": "xi feat. Risa Yuzuki",
+		"data": {
+			"displayVersion": "31",
+			"genre": "JUVENILE PIANO ROCK"
+		},
+		"id": 2314,
+		"searchTerms": [
+			"Yume Enishi"
+		],
+		"title": "夢縁"
+	},
+	{
+		"altTitles": [],
+		"artist": "Avans",
+		"data": {
+			"displayVersion": "31",
+			"genre": "TECHNICAL ELECTRO"
+		},
+		"id": 2315,
+		"searchTerms": [],
+		"title": "Shapeshifter"
+	},
+	{
+		"altTitles": [],
+		"artist": "crayvxn",
+		"data": {
+			"displayVersion": "31",
+			"genre": "NEOTRANCE"
+		},
+		"id": 2316,
+		"searchTerms": [],
+		"title": "Ghost Pulse"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ Mass MAD Izm* feat.H14 of LEONAIR",
+		"data": {
+			"displayVersion": "31",
+			"genre": "MIXTURE"
+		},
+		"id": 2317,
+		"searchTerms": [],
+		"title": "GAME ON"
+	},
+	{
+		"altTitles": [],
+		"artist": "Yuta Imai",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HAPPY HARDCORE TAKEOVER"
+		},
+		"id": 2318,
+		"searchTerms": [],
+		"title": "DAZZLE ATTACK"
+	},
+	{
+		"altTitles": [],
+		"artist": "Yuta Imai Vs. BEMANI Sound Team \"Yvya\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "CROSSOVER"
+		},
+		"id": 2319,
+		"searchTerms": [],
+		"title": "SOLAR ECLIPSE"
+	},
+	{
+		"altTitles": [],
+		"artist": "TORIENA",
+		"data": {
+			"displayVersion": "31",
+			"genre": "SUMMER POP"
+		},
+		"id": 2320,
+		"searchTerms": [
+			"natsukaze disco"
+		],
+		"title": "夏風邪デスコ"
+	},
+	{
+		"altTitles": [],
+		"artist": "TORIENA",
+		"data": {
+			"displayVersion": "31",
+			"genre": "CHARGE CORE"
+		},
+		"id": 2321,
+		"searchTerms": [],
+		"title": "out of disk space"
+	},
+	{
+		"altTitles": [],
+		"artist": "Len",
+		"data": {
+			"displayVersion": "31",
+			"genre": "SPEED HOUSE"
+		},
+		"id": 2322,
+		"searchTerms": [
+			"Nainairoutine"
+		],
+		"title": "ないないルーティン"
+	},
+	{
+		"altTitles": [],
+		"artist": "アオワイファイ feat.秋山雫",
+		"data": {
+			"displayVersion": "31",
+			"genre": "J-POP"
+		},
+		"id": 2323,
+		"searchTerms": [],
+		"title": "My Sweet Bird?"
+	},
+	{
+		"altTitles": [],
+		"artist": "KARUT",
+		"data": {
+			"displayVersion": "31",
+			"genre": "XYMPHONIC TECHCORE"
+		},
+		"id": 2324,
+		"searchTerms": [],
+		"title": "GloriosA"
+	},
+	{
+		"altTitles": [],
+		"artist": "tokiwa",
+		"data": {
+			"displayVersion": "31",
+			"genre": "SCI-FI CHRONICLE"
+		},
+		"id": 2325,
+		"searchTerms": [
+			"Ruou no Mon"
+		],
+		"title": "流桜ノ門"
+	},
+	{
+		"altTitles": [],
+		"artist": "COR!S",
+		"data": {
+			"displayVersion": "31",
+			"genre": "CYBER BREAKCORE"
+		},
+		"id": 2326,
+		"searchTerms": [],
+		"title": "20XX"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ Shimamura",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARDCORE RAVE"
+		},
+		"id": 2327,
+		"searchTerms": [],
+		"title": "TITANIUM RIDERS"
+	},
+	{
+		"altTitles": [],
+		"artist": "隣の庭は青い(庭師+Aoi)",
+		"data": {
+			"displayVersion": "31",
+			"genre": "VOLTENIZED CORE"
+		},
+		"id": 2328,
+		"searchTerms": [],
+		"title": "Xb10r"
+	},
+	{
+		"altTitles": [],
+		"artist": "kors k",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARD DANCE"
+		},
+		"id": 2329,
+		"searchTerms": [],
+		"title": "Monkey Business"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"二代目朱雀 feat.朱雀\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARD RENAISSANCE"
+		},
+		"id": 2330,
+		"searchTerms": [],
+		"title": "Ambivalent Vermilia"
+	},
+	{
+		"altTitles": [],
+		"artist": "Blacklolita",
+		"data": {
+			"displayVersion": "31",
+			"genre": "ASCENDING TOGETHER"
+		},
+		"id": 2331,
+		"searchTerms": [
+			"PLRAYER"
+		],
+		"title": "《PL|RAYER》"
+	},
+	{
+		"altTitles": [],
+		"artist": "Yuta Imai",
+		"data": {
+			"displayVersion": "31",
+			"genre": "BUCHIAGE TRANCE"
+		},
+		"id": 2332,
+		"searchTerms": [
+			"DENKO"
+		],
+		"title": "電光"
+	},
+	{
+		"altTitles": [],
+		"artist": "Hommarju",
+		"data": {
+			"displayVersion": "31",
+			"genre": "UK HARDCORE"
+		},
+		"id": 2333,
+		"searchTerms": [],
+		"title": "Hat Surprise (Season 3)"
+	},
+	{
+		"altTitles": [],
+		"artist": "かめりあ",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HITECH NHI FULLON"
+		},
+		"id": 2334,
+		"searchTerms": [],
+		"title": "i-ii"
+	},
+	{
+		"altTitles": [],
+		"artist": "RoughSketch",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARDCORE"
+		},
+		"id": 2335,
+		"searchTerms": [],
+		"title": "Red Determination"
+	},
+	{
+		"altTitles": [],
+		"artist": "MK",
+		"data": {
+			"displayVersion": "31",
+			"genre": "COLOUR BASS"
+		},
+		"id": 2336,
+		"searchTerms": [],
+		"title": "Sirius"
+	},
+	{
+		"altTitles": [],
+		"artist": "Nhato",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARD TRANCE"
+		},
+		"id": 2337,
+		"searchTerms": [],
+		"title": "Hard Breaker"
+	},
+	{
+		"altTitles": [],
+		"artist": "Maozon",
+		"data": {
+			"displayVersion": "31",
+			"genre": "BIG BEAT"
+		},
+		"id": 2338,
+		"searchTerms": [],
+		"title": "Get Wicked"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by BlackY feat. Risa Yuzuki",
+		"data": {
+			"displayVersion": "31",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2339,
+		"searchTerms": [
+			"(Not) A Devil"
+		],
+		"title": "デビルじゃないもん"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by MK feat. 紫咲ほたる",
+		"data": {
+			"displayVersion": "31",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2340,
+		"searchTerms": [
+			"KAWAIKUTE GOMEN"
+		],
+		"title": "可愛くてごめん"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by Pizuya's Cell",
+		"data": {
+			"displayVersion": "31",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2341,
+		"searchTerms": [
+			"Phony"
+		],
+		"title": "フォニイ"
 	}
 ]

--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -25578,7 +25578,9 @@
 			"genre": "BROKEN SAMBA DRUM'N'BASS"
 		},
 		"id": 2292,
-		"searchTerms": ["SHAKUNETSU Beach Side Bunny Camellia Remix"],
+		"searchTerms": [
+			"SHAKUNETSU Beach Side Bunny Camellia's Summertime DnB Remix"
+		],
 		"title": "灼熱Beach Side Bunny (かめりあ's \"Summertime D'n'B\" Remix)"
 	},
 	{

--- a/database-seeds/collections/tables.json
+++ b/database-seeds/collections/tables.json
@@ -1492,6 +1492,29 @@
 	},
 	{
 		"default": false,
+		"description": "Levels for beatmania IIDX (DP) in Epolis.",
+		"folders": [
+			"F433523a3d513a07b3e1e4e4b9441eec2337f748bd6e8a249ea49dd4bcae92d7b",
+			"F8121a7d8a56e9c0e599af7dbed57c370b8ada2221830861f0694d3411c346ce1",
+			"Fc80b3b1dfa2b007e4f23cd2c60f28a8d45485f95ba879eda08d858de574321bf",
+			"F35ed77db0f54982b25fef631bddfe278eaaa84b372edbfc2d4c5660804e77f11",
+			"Fba8ebce8e849a290a5e50457761661a6def785120125ec77a821bc9d516f7e76",
+			"Fcfef278758f7e22d1670c1c9e57a9bc7de1b1b533b135eeeb541513d6502a7cc",
+			"F958bb839b8b6d7af5a3dd3628c8f1852b906e9cc308fd51abfa394ea8dd768a2",
+			"F4abbb092a1e14c1d26c31049d8344cb99f163e3bf170fb26f3f0671d86e82b4c",
+			"F93c7ad860631314b85e54be7ba4cd1fb5fc7279d94583182806e872303cbacf7",
+			"Fbe4f47c37dd0902394f94049e63c95e1da77686f6b71e38782adb3985d0264b1",
+			"F9c0a1ec60283b225f62eb8cd5ad240651fad00c1cbdfc2b1ca3fe3cb0e0689a4",
+			"F534cb868ae0066629b76a5e92d4c21fbb86d6ff1b8ede167a1a46c4dd8a0fb6f"
+		],
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "DP",
+		"tableID": "iidx-DP-31-levels",
+		"title": "beatmania IIDX (DP) (EPOLIS)"
+	},
+	{
+		"default": false,
 		"description": "Levels for beatmania IIDX (DP) in GOLD CS.",
 		"folders": [
 			"F14159009731b0ab1fca61d9f61a51aafb9c014ef6a5aa814db697ffefc79cfc1",
@@ -2248,6 +2271,29 @@
 		"playtype": "SP",
 		"tableID": "iidx-SP-16-cs-levels",
 		"title": "beatmania IIDX (SP) (EMPRESS CS)"
+	},
+	{
+		"default": false,
+		"description": "Levels for beatmania IIDX (SP) in Epolis.",
+		"folders": [
+			"Feb083d47b06dd6752591125bf41299e35596c168fb4946ba731ad9123b646aac",
+			"Fec975ebc2bd28de6cc6d12174e8825963f52596534d72a5eed73ca5283622439",
+			"F705f2fcc57ea4844e5698ae520cd5dc5ceb1e6fee24592e03dbead7560372f45",
+			"F6f44d23e0b72a4fec04d8cb2c7e7b059459e84d589e43675eb9e84607c63572b",
+			"F732113e45ebdede9bbd785aec4f602f529e8685ebcd7e6fa6f7e082967e47646",
+			"F51160a77a38a043628b0ad132429c465a0fd1eccefa1758deed23f02f844842f",
+			"Fc9269ab7a3b52690208795fb203a91bbfc79e969006adad4f5d3d0fdb1c606fc",
+			"Fcdc6aa3dd48511a6b7c219a3cbcadfad6f1a03583ea530023235a3cc52353e39",
+			"F437949ea3ab0e2996a999ce3ae5b825f08d2fee6bc14e160402130cc02ce968e",
+			"F35c24c57f47fc0e1e6de909b284129527caba84848dc55e221ebca64febce978",
+			"F29c545c484d4079de3b40cfcb1e7cca18361a50d158d83dfdff1a14c12efeeae",
+			"F2b0542125b7def38e87972d7016c11d8751f51671be778669769417cd4c74204"
+		],
+		"game": "iidx",
+		"inactive": false,
+		"playtype": "SP",
+		"tableID": "iidx-SP-31-levels",
+		"title": "beatmania IIDX (SP) (EPOLIS)"
 	},
 	{
 		"default": false,

--- a/database-seeds/scripts/rerunners/iidx/iidx-mdb-parse/convert.ts
+++ b/database-seeds/scripts/rerunners/iidx/iidx-mdb-parse/convert.ts
@@ -59,6 +59,7 @@ export async function ParseIIDXData(
 		case 28:
 		case 29:
 		case 30:
+		case 31:
 			structSize = 0x52c;
 			break;
 		default:

--- a/database-seeds/scripts/rerunners/iidx/iidx-mdb-parse/merge-mdb.ts
+++ b/database-seeds/scripts/rerunners/iidx/iidx-mdb-parse/merge-mdb.ts
@@ -86,7 +86,7 @@ async function ParseIIDXMDB() {
 	// omni XOR -omni in version name
 	// either both are true, or both are false
 	// if they don't match, that's probably a mistake
-	if (options.omni !== options.version.endsWith("-omni")) {
+	if (Boolean(options.omni) !== options.version.endsWith("-omni")) {
 		throw new Error(
 			`Using --omni flag, but the version you provided was ${options.version}, which doesn't look like an omnimix version.`
 		);

--- a/docs/docs/game-support/games/iidx-DP.md
+++ b/docs/docs/game-support/games/iidx-DP.md
@@ -118,6 +118,7 @@ The default rating algorithm is `ktLampRating`.
 | `28` | BISTROVER |
 | `29` | CastHour |
 | `30` | Resident |
+| `31` | EPOLIS |
 | `3-cs` | 3rd Style CS |
 | `4-cs` | 4th Style CS |
 | `5-cs` | 5th Style CS |

--- a/docs/docs/game-support/games/iidx-SP.md
+++ b/docs/docs/game-support/games/iidx-SP.md
@@ -118,6 +118,7 @@ The default rating algorithm is `ktLampRating`.
 | `28` | BISTROVER |
 | `29` | CastHour |
 | `30` | Resident |
+| `31` | EPOLIS |
 | `3-cs` | 3rd Style CS |
 | `4-cs` | 4th Style CS |
 | `5-cs` | 5th Style CS |

--- a/server/src/lib/score-import/import-types/common/eamusement-iidx-csv/parser.ts
+++ b/server/src/lib/score-import/import-types/common/eamusement-iidx-csv/parser.ts
@@ -38,6 +38,7 @@ export enum EAM_VERSION_NAMES {
 	"BISTROVER" = 28,
 	"CastHour" = 29,
 	"RESIDENT" = 30,
+	"EPOLIS" = 31,
 }
 
 const PRE_HV_HEADER_COUNT = 27;


### PR DESCRIPTION
Update for IIDX 31 eamuse csv support.

Like I tried to explain in discord, this also hopefully fixes hitch hiker2 dpa.

In IIDX 4 and 5 AC and CS, this song had a DPA chart which was just a dupe of the DPH (880 notes).  It was removed in IIDX 6.  Omnimix versions prior to 28-omni restore it.

IIDX 28 added a new DPA chart (864 notes).

It seems that there was one chart DB entry for both charts, with the old notecount.

The existing entry has been updated to have the correct notecount.  A new entry has been added with the old notecount to support 27-omni, 26-omni, 5-cs, and 4-cs.