### PR TITLE
[chunithm] Mark songs as available in international version

### DIFF
--- a/database-seeds/collections/charts-chunithm.json
+++ b/database-seeds/collections/charts-chunithm.json
@@ -23609,7 +23609,8 @@
 		"playtype": "Single",
 		"songID": 331,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -100580,7 +100581,8 @@
 		"playtype": "Single",
 		"songID": 2309,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -100595,7 +100597,8 @@
 		"playtype": "Single",
 		"songID": 2309,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -100610,7 +100613,8 @@
 		"playtype": "Single",
 		"songID": 2309,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -100625,7 +100629,8 @@
 		"playtype": "Single",
 		"songID": 2309,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110009,7 +110014,8 @@
 		"playtype": "Single",
 		"songID": 2457,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110024,7 +110030,8 @@
 		"playtype": "Single",
 		"songID": 2457,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110039,7 +110046,8 @@
 		"playtype": "Single",
 		"songID": 2457,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110054,7 +110062,8 @@
 		"playtype": "Single",
 		"songID": 2457,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110069,7 +110078,8 @@
 		"playtype": "Single",
 		"songID": 2458,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110084,7 +110094,8 @@
 		"playtype": "Single",
 		"songID": 2458,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110099,7 +110110,8 @@
 		"playtype": "Single",
 		"songID": 2458,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110114,7 +110126,8 @@
 		"playtype": "Single",
 		"songID": 2458,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110129,7 +110142,8 @@
 		"playtype": "Single",
 		"songID": 2459,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110144,7 +110158,8 @@
 		"playtype": "Single",
 		"songID": 2459,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110159,7 +110174,8 @@
 		"playtype": "Single",
 		"songID": 2459,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110174,7 +110190,8 @@
 		"playtype": "Single",
 		"songID": 2459,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110189,7 +110206,8 @@
 		"playtype": "Single",
 		"songID": 2460,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110204,7 +110222,8 @@
 		"playtype": "Single",
 		"songID": 2460,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110219,7 +110238,8 @@
 		"playtype": "Single",
 		"songID": 2460,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110234,7 +110254,8 @@
 		"playtype": "Single",
 		"songID": 2460,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110249,7 +110270,8 @@
 		"playtype": "Single",
 		"songID": 2461,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110264,7 +110286,8 @@
 		"playtype": "Single",
 		"songID": 2461,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110279,7 +110302,8 @@
 		"playtype": "Single",
 		"songID": 2461,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110294,7 +110318,8 @@
 		"playtype": "Single",
 		"songID": 2461,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110309,7 +110334,8 @@
 		"playtype": "Single",
 		"songID": 2463,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110324,7 +110350,8 @@
 		"playtype": "Single",
 		"songID": 2463,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110339,7 +110366,8 @@
 		"playtype": "Single",
 		"songID": 2463,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110354,7 +110382,8 @@
 		"playtype": "Single",
 		"songID": 2463,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110505,7 +110534,8 @@
 		"playtype": "Single",
 		"songID": 2466,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110520,7 +110550,8 @@
 		"playtype": "Single",
 		"songID": 2466,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110535,7 +110566,8 @@
 		"playtype": "Single",
 		"songID": 2466,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110550,7 +110582,8 @@
 		"playtype": "Single",
 		"songID": 2466,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110565,7 +110598,8 @@
 		"playtype": "Single",
 		"songID": 2467,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110580,7 +110614,8 @@
 		"playtype": "Single",
 		"songID": 2467,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110595,7 +110630,8 @@
 		"playtype": "Single",
 		"songID": 2467,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110610,7 +110646,8 @@
 		"playtype": "Single",
 		"songID": 2467,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110625,7 +110662,8 @@
 		"playtype": "Single",
 		"songID": 2468,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110640,7 +110678,8 @@
 		"playtype": "Single",
 		"songID": 2468,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110655,7 +110694,8 @@
 		"playtype": "Single",
 		"songID": 2468,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110670,7 +110710,8 @@
 		"playtype": "Single",
 		"songID": 2468,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110685,7 +110726,8 @@
 		"playtype": "Single",
 		"songID": 2469,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110700,7 +110742,8 @@
 		"playtype": "Single",
 		"songID": 2469,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110715,7 +110758,8 @@
 		"playtype": "Single",
 		"songID": 2469,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110730,7 +110774,8 @@
 		"playtype": "Single",
 		"songID": 2469,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110745,7 +110790,8 @@
 		"playtype": "Single",
 		"songID": 2475,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110760,7 +110806,8 @@
 		"playtype": "Single",
 		"songID": 2475,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110775,7 +110822,8 @@
 		"playtype": "Single",
 		"songID": 2475,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110790,7 +110838,8 @@
 		"playtype": "Single",
 		"songID": 2475,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110805,7 +110854,8 @@
 		"playtype": "Single",
 		"songID": 2476,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110820,7 +110870,8 @@
 		"playtype": "Single",
 		"songID": 2476,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110835,7 +110886,8 @@
 		"playtype": "Single",
 		"songID": 2476,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -110850,7 +110902,8 @@
 		"playtype": "Single",
 		"songID": 2476,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111301,7 +111354,8 @@
 		"playtype": "Single",
 		"songID": 2485,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111316,7 +111370,8 @@
 		"playtype": "Single",
 		"songID": 2485,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111331,7 +111386,8 @@
 		"playtype": "Single",
 		"songID": 2485,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111346,7 +111402,8 @@
 		"playtype": "Single",
 		"songID": 2485,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111361,7 +111418,8 @@
 		"playtype": "Single",
 		"songID": 2486,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111376,7 +111434,8 @@
 		"playtype": "Single",
 		"songID": 2486,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111391,7 +111450,8 @@
 		"playtype": "Single",
 		"songID": 2486,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111406,7 +111466,8 @@
 		"playtype": "Single",
 		"songID": 2486,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111421,7 +111482,8 @@
 		"playtype": "Single",
 		"songID": 2487,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111436,7 +111498,8 @@
 		"playtype": "Single",
 		"songID": 2487,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111451,7 +111514,8 @@
 		"playtype": "Single",
 		"songID": 2487,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111466,7 +111530,8 @@
 		"playtype": "Single",
 		"songID": 2487,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111481,7 +111546,8 @@
 		"playtype": "Single",
 		"songID": 2488,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111496,7 +111562,8 @@
 		"playtype": "Single",
 		"songID": 2488,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111507,11 +111574,12 @@
 		"difficulty": "EXPERT",
 		"isPrimary": true,
 		"level": "12",
-		"levelNum": 12,
+		"levelNum": 12.3,
 		"playtype": "Single",
 		"songID": 2488,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{
@@ -111526,7 +111594,8 @@
 		"playtype": "Single",
 		"songID": 2488,
 		"versions": [
-			"sunplus"
+			"sunplus",
+			"sunplus-intl"
 		]
 	},
 	{


### PR DESCRIPTION
https://info-chunithm.sega.com/2448/

Songs added to SUN PLUS (International):
- 小仏 凪(CV:佐倉 薫)＆月鈴 白奈(CV:高野 麻里佳)＆御形 アリシアナ(CV:福原 綾香)＆桔梗 小夜曲(CV:原田 彩楓) - Λlteration
- 森羅万象 - カリスマ煉獄天神
- ビートまりお＋あまね（COOL&CREATE）- シアワセうさぎ
- 曲：橘亮祐、篠崎あやと／歌：三角 葵(CV：春野 杏)、逢坂 茜(CV：大空 直美)、日向 千夏(CV：岡咲 美保) - ぽかぽか温泉音頭
- 曲：原田篤（Arte Refact）／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)] - Let's Starry Party！
- technoplanet - Singularity
- 月鈴 那知(CV:今村 彩夏) - 猛進ソリストライフ！ (ULTIMA chart added).